### PR TITLE
Fixed FrameBufferAllocatorTest.

### DIFF
--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -25,8 +25,7 @@ namespace lithium {
 namespace reactivesocket {
 
 std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocate(size_t size) {
-  return folly::Singleton<FrameBufferAllocator>::get()->allocateBuffer(
-      size);
+  return folly::Singleton<FrameBufferAllocator>::get()->allocateBuffer(size);
 }
 
 std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocateBuffer(

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -101,8 +101,9 @@ std::ostream& operator<<(std::ostream&, const FrameHeader&);
 
 class FrameBufferAllocator {
  public:
-  virtual ~FrameBufferAllocator() = default;
   static std::unique_ptr<folly::IOBuf> allocate(size_t size);
+
+  virtual ~FrameBufferAllocator() = default;
 
  private:
   virtual std::unique_ptr<folly::IOBuf> allocateBuffer(size_t size);


### PR DESCRIPTION
Singleton factory passed in make_mock referred to an object which was destroyed after every frame serialisation test. The last test that run, left the factory instead of resetting it to a default one (which provides an instance of FrameBufferAllocator). Consequently, the next test that used allocator (RequestChannel) was using a dangling pointer for frame allocations. Fixes #2 .