### PR TITLE
rename Producer to Publisher to match java Spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${CMAKE_SOURCE_DIR})
 add_library(
   ReactiveSocket
   reactive-streams-cpp/Mocks.h
-  reactive-streams-cpp/Producer.h
+  reactive-streams-cpp/Publisher.h
   reactive-streams-cpp/README.md
   reactive-streams-cpp/Subscriber.h
   reactive-streams-cpp/Subscription.h
@@ -47,7 +47,7 @@ add_library(
   reactivesocket-cpp/src/mixins/LoggingMixin.h
   reactivesocket-cpp/src/mixins/MemoryMixin.h
   reactivesocket-cpp/src/mixins/MixinTerminator.h
-  reactivesocket-cpp/src/mixins/ProducerMixin.h
+  reactivesocket-cpp/src/mixins/PublisherMixin.h
   reactivesocket-cpp/src/mixins/README.md
   reactivesocket-cpp/src/mixins/SinkIfMixin.h
   reactivesocket-cpp/src/mixins/SourceIfMixin.h

--- a/reactive-streams-cpp/Mocks.h
+++ b/reactive-streams-cpp/Mocks.h
@@ -8,7 +8,7 @@
 
 #include <gmock/gmock.h>
 
-#include "reactive-streams-cpp/Producer.h"
+#include "reactive-streams-cpp/Publisher.h"
 #include "reactive-streams-cpp/Subscriber.h"
 #include "reactive-streams-cpp/Subscription.h"
 #include "reactive-streams-cpp/utilities/Ownership.h"
@@ -16,10 +16,10 @@
 namespace lithium {
 namespace reactivestreams {
 
-/// GoogleMock-compatible Producer implementation for fast prototyping.
-/// UnmanagedMockProducer's lifetime MUST be managed externally.
+/// GoogleMock-compatible Publisher implementation for fast prototyping.
+/// UnmanagedMockPublisher's lifetime MUST be managed externally.
 template <typename T, typename E = std::exception_ptr>
-class UnmanagedMockProducer : public Producer<T, E> {
+class UnmanagedMockPublisher : public Publisher<T, E> {
  public:
   MOCK_METHOD1_T(subscribe_, void(Subscriber<T, E>* subscriber));
 
@@ -93,7 +93,7 @@ class MockSubscriber : public Subscriber<T, E> {
 
   void onSubscribe(Subscription& subscription) override {
     subscription_ = &subscription;
-    // We allow registering the same subscriber with multiple Producers.
+    // We allow registering the same subscriber with multiple Publishers.
     // Otherwise, we could get rid of reference counting.
     refCount_.increment();
     onSubscribe_(&subscription);

--- a/reactive-streams-cpp/Publisher.h
+++ b/reactive-streams-cpp/Publisher.h
@@ -18,24 +18,24 @@ class Subscriber;
 ///   * copy from specification for JVM,
 ///
 /// Life cycle considerations:
-/// 1. The Producer is not owned by Subscriber or Subscription.
-/// 2. The Producer can be a temporary object, as it is only used to capture the
-///   indirection in creation of the Subscription instance. Producer's lifetime
+/// 1. The Publisher is not owned by Subscriber or Subscription.
+/// 2. The Publisher can be a temporary object, as it is only used to capture the
+///   indirection in creation of the Subscription instance. Publisher's lifetime
 ///   does not need to extend beyond a lifetime of any of the Subscribers.
 template <typename T, typename E = std::exception_ptr>
-class Producer {
+class Publisher {
  public:
-  virtual ~Producer() = default;
+  virtual ~Publisher() = default;
 
-  /// Establishes an abstract subscription between Subscriber and Producer, by
+  /// Establishes an abstract subscription between Subscriber and Publisher, by
   /// providing the former with an instance of Subscription.
   ///
   /// Must call Subscriber::onSubscribe synchronously to provide a valid
   /// Subscription.
   ///
   /// Life cycle considerations:
-  /// 1. No ownership of the Subscriber is assumed by the Producer.
-  /// 2. The Subsciber pointer MUST remain valid until the Producer calls
+  /// 1. No ownership of the Subscriber is assumed by the Publisher.
+  /// 2. The Subsciber pointer MUST remain valid until the Publisher calls
   ///   Subscriber::{onComplete,onError}. See "unsubscribe handshake" for more
   ///   details.
   virtual void subscribe(Subscriber<T, E>& subscriber) = 0;

--- a/reactive-streams-cpp/Subscriber.h
+++ b/reactive-streams-cpp/Subscriber.h
@@ -21,15 +21,15 @@ class Subscription;
 ///   * add a rule to ensure single terminal signal,
 ///
 /// Life cycle considerations:
-/// 1. The Subscriber is not owned by any Producer, nor it owns a Subscription.
-/// 2. Per "unsubscribe handshake", the Producer MUST always send either
+/// 1. The Subscriber is not owned by any Publisher, nor it owns a Subscription.
+/// 2. Per "unsubscribe handshake", the Publisher MUST always send either
 ///   ::{onComplete,onError} as the last signal to the Subscriber.
 ///   This holds even if an unsubscribe sequence is initiated by the Subscriber
 ///   calling Subscription::cancel. Therefore, it is perfectly possible for a
 ///   Subscriber to deallocate any resources it holds in ::{onComplete,onError}.
 /// 3. Note that no part of ReactiveStreams specification requires the
 ///   Subscriber to be heap-allocated. However, if it is the case, from the
-///   perspective of Producer-Subscriber interaction, it is valid for the
+///   perspective of Publisher-Subscriber interaction, it is valid for the
 ///   Subscriber to `delete this;` as the last statement in
 ///   ::{onComplete,onError}.
 template <typename T, typename E = std::exception_ptr>
@@ -40,7 +40,7 @@ class Subscriber {
 
   virtual ~Subscriber() = default;
 
-  /// Called synchronously from Producer::subscribe to finish the initial
+  /// Called synchronously from Publisher::subscribe to finish the initial
   /// handshake.
   ///
   /// Life cycle considerations:
@@ -49,30 +49,30 @@ class Subscriber {
   ///   Subscription::cancel. See "unsubscribe handshake" for more details.
   virtual void onSubscribe(Subscription& subscription) = 0;
 
-  /// Called by or on behalf of Producer when it wishes to deliver the next
+  /// Called by or on behalf of Publisher when it wishes to deliver the next
   /// element on a subscription.
   ///
   /// If a Subscriber calls `Subscription::request(1); Subscription::cancel()`,
   /// ::onNext might be invoked after or during the call to
-  /// Subscription::cancel. In this case, however, the Producer MUST eventually
+  /// Subscription::cancel. In this case, however, the Publisher MUST eventually
   /// call one of ::{onComplete,onError} to finish the "unsubscribe handshake".
   ///
   /// The method MUST NOT be called after or during an invocation of
   /// ::{onComplete,onError}.
   virtual void onNext(T element) = 0;
 
-  /// Called by or on behalf of Producer when it wishes to terminate the
+  /// Called by or on behalf of Publisher when it wishes to terminate the
   /// abstract subscription gracefully.
   ///
-  /// Subscriber pointer passed to the Producer::subscribe may become invalid as
+  /// Subscriber pointer passed to the Publisher::subscribe may become invalid as
   /// a result of this call. No other method of the Subscriber can be called
   /// after or during an invocation of ::onComplete.
   virtual void onComplete() = 0;
 
-  /// Called by or on behalf of Producer when it wishes to terminate the
+  /// Called by or on behalf of Publisher when it wishes to terminate the
   /// abstract subscription with an error.
   ///
-  /// Subscriber pointer passed to the Producer::subscribe may become invalid as
+  /// Subscriber pointer passed to the Publisher::subscribe may become invalid as
   /// a result of this call. No other method of the Subscriber can be called
   /// after or during an invocation of ::onError.
   virtual void onError(E ex) = 0;

--- a/reactive-streams-cpp/Subscription.h
+++ b/reactive-streams-cpp/Subscription.h
@@ -8,8 +8,8 @@
 namespace lithium {
 namespace reactivestreams {
 
-/// Represents a connection between Producer and Subscriber established by an
-/// invocation of Subscriber::onSubscribe performed by the Producer.
+/// Represents a connection between Publisher and Subscriber established by an
+/// invocation of Subscriber::onSubscribe performed by the Publisher.
 ///
 /// Rules:
 /// TODO(stupaq):
@@ -20,8 +20,8 @@ namespace reactivestreams {
 /// Life cycle considerations:
 /// 1. Subscription is borrowed to the Subscriber in Subscriber::onSubscribe.
 /// 2. Per "unsubscribe handshake", the Subscriber MUST invoke ::cancel as the
-///   last signal to the Producer. This holds even if an unsubscribe sequence
-///   is initiated by the Producer calling Subscriber::{onComplete, onError}.
+///   last signal to the Publisher. This holds even if an unsubscribe sequence
+///   is initiated by the Publisher calling Subscriber::{onComplete, onError}.
 ///   Therefore, it is valid for the Subscription to free any resources it holds
 ///   in ::cancel.
 /// 3. Note that no part of ReactiveStreams specification requires the
@@ -30,8 +30,8 @@ namespace reactivestreams {
 ///   `delete this;` as the last statement in ::cancel.
 ///
 /// Note that it is valid, from the perspective of the ReactiveStreams
-/// specification, for a Subscription and a Producer to be the same object,
-/// as long as the Producer has only one Subscriber.
+/// specification, for a Subscription and a Publisher to be the same object,
+/// as long as the Publisher has only one Subscriber.
 class Subscription {
  public:
   virtual ~Subscription() = default;
@@ -39,7 +39,7 @@ class Subscription {
   /// Called by the Subscriber to communicate readiness to accept `n` more
   /// elements of the stream.
   ///
-  /// It is legal for Producer to call Subscriber::onNext synchronously from
+  /// It is legal for Publisher to call Subscriber::onNext synchronously from
   /// ::request. Similarily, it is possible for Subscriber to invoke
   /// ::request from Subscriber::onNext. To break the symmetry and prevent
   /// unbounded stack growth, implementation of ::request is required to place
@@ -58,7 +58,7 @@ class Subscription {
   ///     }
   ///     // Attempt to push (via Subscriber::onNext) any pending elements that
   ///     // were queued up due to null allowance. This could involve a call to
-  ///     // ::request of a subscription that feeds this Producer with data.
+  ///     // ::request of a subscription that feeds this Publisher with data.
   ///   }
   ///
   virtual void request(size_t n) = 0;

--- a/reactive-streams-cpp/TARGETS
+++ b/reactive-streams-cpp/TARGETS
@@ -1,7 +1,7 @@
 cpp_library(
     name = 'api',
     headers = [
-        'Producer.h',
+        'Publisher.h',
         'Subscriber.h',
         'Subscription.h',
     ],

--- a/reactive-streams-cpp/examples/Examples.cpp
+++ b/reactive-streams-cpp/examples/Examples.cpp
@@ -14,7 +14,7 @@ TEST(Examples, SelfManagedMocks) {
   // double-free bugs.
   int value = 42;
 
-  UnmanagedMockProducer<int> producer;
+  UnmanagedMockPublisher<int> producer;
   auto* subscription = &makeMockSubscription();
   auto* subscriber = &makeMockSubscriber<int>();
   {
@@ -31,7 +31,7 @@ TEST(Examples, SelfManagedMocks) {
           // deliver one element, despite Subscription::cancel() has been
           // called.
           subscriber->onNext(value);
-          // This Producer never spontaneously terminates the subscription,
+          // This Publisher never spontaneously terminates the subscription,
           // hence we can respond with onComplete unconditionally.
           subscriber->onComplete();
           subscriber = nullptr;
@@ -50,7 +50,7 @@ TEST(Examples, UnmanagedMocks) {
   // double-free bugs.
   int value = 42;
 
-  UnmanagedMockProducer<int> producer;
+  UnmanagedMockPublisher<int> producer;
   UnmanagedMockSubscription subscription;
   UnmanagedMockSubscriber<int> subscriber;
   {
@@ -67,7 +67,7 @@ TEST(Examples, UnmanagedMocks) {
           // deliver one element, despite Subscription::cancel() has been
           // called.
           subscriber.onNext(value);
-          // This Producer never spontaneously terminates the subscription,
+          // This Publisher never spontaneously terminates the subscription,
           // hence we can respond with onComplete unconditionally.
           subscriber.onComplete();
         }));

--- a/reactivesocket-cpp/TARGETS
+++ b/reactivesocket-cpp/TARGETS
@@ -29,7 +29,7 @@ cpp_library(
         'src/mixins/MemoryMixin.h',
         'src/mixins/MixinTerminator.h',
         'src/mixins/LoggingMixin.h',
-        'src/mixins/ProducerMixin.h',
+        'src/mixins/PublisherMixin.h',
         'src/mixins/StreamIfMixin.h',
         'src/mixins/SinkIfMixin.h',
         'src/mixins/SourceIfMixin.h',

--- a/reactivesocket-cpp/src/ReactiveStreamsCompat.h
+++ b/reactivesocket-cpp/src/ReactiveStreamsCompat.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "reactive-streams-cpp/Producer.h"
+#include "reactive-streams-cpp/Publisher.h"
 #include "reactive-streams-cpp/Subscriber.h"
 #include "reactive-streams-cpp/Subscription.h"
 
@@ -28,7 +28,7 @@ class SubscriptionPtr;
 namespace reactivesocket {
 
 template <typename T>
-using Producer = reactivestreams::Producer<T, folly::exception_wrapper>;
+using Publisher = reactivestreams::Publisher<T, folly::exception_wrapper>;
 template <typename T>
 using Subscriber = reactivestreams::Subscriber<T, folly::exception_wrapper>;
 using Subscription = reactivestreams::Subscription;

--- a/reactivesocket-cpp/src/RequestHandler.h
+++ b/reactivesocket-cpp/src/RequestHandler.h
@@ -15,7 +15,7 @@ class RequestHandler {
 
   /// Handles a new Channel requested by the other end.
   ///
-  /// Modelled after Producer::subscribe, hence must synchronously call
+  /// Modelled after Publisher::subscribe, hence must synchronously call
   /// Subscriber::onSubscribe, and provide a valid Subscription.
   virtual Subscriber<Payload>& handleRequestChannel(
       Payload request,

--- a/reactivesocket-cpp/src/automata/ChannelRequester.h
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.h
@@ -16,7 +16,7 @@
 #include "reactivesocket-cpp/src/mixins/LoggingMixin.h"
 #include "reactivesocket-cpp/src/mixins/MemoryMixin.h"
 #include "reactivesocket-cpp/src/mixins/MixinTerminator.h"
-#include "reactivesocket-cpp/src/mixins/ProducerMixin.h"
+#include "reactivesocket-cpp/src/mixins/PublisherMixin.h"
 #include "reactivesocket-cpp/src/mixins/SinkIfMixin.h"
 #include "reactivesocket-cpp/src/mixins/SourceIfMixin.h"
 #include "reactivesocket-cpp/src/mixins/StreamIfMixin.h"
@@ -32,10 +32,10 @@ enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Channel requester.
 class ChannelRequesterBase
-    : public LoggingMixin<ProducerMixin<
+    : public LoggingMixin<PublisherMixin<
           Frame_REQUEST_CHANNEL,
           LoggingMixin<ConsumerMixin<Frame_RESPONSE, MixinTerminator>>>> {
-  using Base = LoggingMixin<ProducerMixin<
+  using Base = LoggingMixin<PublisherMixin<
       Frame_REQUEST_CHANNEL,
       LoggingMixin<ConsumerMixin<Frame_RESPONSE, MixinTerminator>>>>;
 

--- a/reactivesocket-cpp/src/automata/ChannelResponder.h
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.h
@@ -16,7 +16,7 @@
 #include "reactivesocket-cpp/src/mixins/LoggingMixin.h"
 #include "reactivesocket-cpp/src/mixins/MemoryMixin.h"
 #include "reactivesocket-cpp/src/mixins/MixinTerminator.h"
-#include "reactivesocket-cpp/src/mixins/ProducerMixin.h"
+#include "reactivesocket-cpp/src/mixins/PublisherMixin.h"
 #include "reactivesocket-cpp/src/mixins/SinkIfMixin.h"
 #include "reactivesocket-cpp/src/mixins/SourceIfMixin.h"
 #include "reactivesocket-cpp/src/mixins/StreamIfMixin.h"
@@ -32,11 +32,11 @@ enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Channel responder.
 class ChannelResponderBase
-    : public LoggingMixin<ProducerMixin<
+    : public LoggingMixin<PublisherMixin<
           Frame_RESPONSE,
           LoggingMixin<
               ConsumerMixin<Frame_REQUEST_CHANNEL, MixinTerminator>>>> {
-  using Base = LoggingMixin<ProducerMixin<
+  using Base = LoggingMixin<PublisherMixin<
       Frame_RESPONSE,
       LoggingMixin<ConsumerMixin<Frame_REQUEST_CHANNEL, MixinTerminator>>>>;
 

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.h
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.h
@@ -15,7 +15,7 @@
 #include "reactivesocket-cpp/src/mixins/LoggingMixin.h"
 #include "reactivesocket-cpp/src/mixins/MemoryMixin.h"
 #include "reactivesocket-cpp/src/mixins/MixinTerminator.h"
-#include "reactivesocket-cpp/src/mixins/ProducerMixin.h"
+#include "reactivesocket-cpp/src/mixins/PublisherMixin.h"
 #include "reactivesocket-cpp/src/mixins/SinkIfMixin.h"
 #include "reactivesocket-cpp/src/mixins/StreamIfMixin.h"
 
@@ -30,8 +30,8 @@ enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Subscription responder.
 class SubscriptionResponderBase
-    : public LoggingMixin<ProducerMixin<Frame_RESPONSE, MixinTerminator>> {
-  using Base = LoggingMixin<ProducerMixin<Frame_RESPONSE, MixinTerminator>>;
+    : public LoggingMixin<PublisherMixin<Frame_RESPONSE, MixinTerminator>> {
+  using Base = LoggingMixin<PublisherMixin<Frame_RESPONSE, MixinTerminator>>;
 
  public:
   using Base::Base;

--- a/reactivesocket-cpp/src/mixins/ConsumerMixin.h
+++ b/reactivesocket-cpp/src/mixins/ConsumerMixin.h
@@ -25,7 +25,7 @@ class ConsumerMixin : public Base {
   /// Adds implicit allowance.
   ///
   /// This portion of allowance will not be synced to the remote end, but will
-  /// count towards the limit of allowance the remote ProducerMixin may use.
+  /// count towards the limit of allowance the remote PublisherMixin may use.
   void addImplicitAllowance(size_t n) {
     allowance_.release(n);
   }

--- a/reactivesocket-cpp/src/mixins/ExecutorMixin.h
+++ b/reactivesocket-cpp/src/mixins/ExecutorMixin.h
@@ -48,7 +48,7 @@ class ExecutorMixin : public Base {
   }
 
   /// @{
-  /// Producer<Payload>
+  /// Publisher<Payload>
   void subscribe(Subscriber<Payload>& subscriber) {
     // This call punches through the executor-enforced ordering, to ensure that
     // the Subscriber pointer is set as soon as possible.

--- a/reactivesocket-cpp/src/mixins/LoggingMixin.h
+++ b/reactivesocket-cpp/src/mixins/LoggingMixin.h
@@ -39,7 +39,7 @@ class LoggingMixin : public Base {
   }
 
   /// @{
-  /// Producer<Payload>
+  /// Publisher<Payload>
   void subscribe(Subscriber<Payload>& subscriber) {
     Base::logPrefix(LOG(INFO)) << "subscribe(" << &subscriber << ")";
     Base::subscribe(subscriber);

--- a/reactivesocket-cpp/src/mixins/MemoryMixin.h
+++ b/reactivesocket-cpp/src/mixins/MemoryMixin.h
@@ -41,7 +41,7 @@ class MemoryMixin : public Base {
   ~MemoryMixin() {}
 
   /// @{
-  /// Producer<Payload>
+  /// Publisher<Payload>
   void subscribe(Subscriber<Payload>& subscriber) {
     Base::incrementRefCount();
     Base::subscribe(subscriber);

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -21,7 +21,7 @@ enum class StreamCompletionSignal;
 
 /// A mixin that represents a flow-control-aware producer of data.
 template <typename ProducedFrame, typename Base>
-class ProducerMixin : public Base {
+class PublisherMixin : public Base {
  public:
   using Base::Base;
 
@@ -64,7 +64,7 @@ class ProducerMixin : public Base {
   /// @}
 
   std::ostream& logPrefix(std::ostream& os) {
-    return os << "ProducerMixin(" << &this->connection_ << ", "
+    return os << "PublisherMixin(" << &this->connection_ << ", "
               << this->streamId_ << "): ";
   }
 

--- a/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
+++ b/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
@@ -16,8 +16,8 @@ namespace lithium {
 namespace reactivesocket {
 
 template <typename T>
-using UnmanagedMockProducer =
-    reactivestreams::UnmanagedMockProducer<T, folly::exception_wrapper>;
+using UnmanagedMockPublisher =
+    reactivestreams::UnmanagedMockPublisher<T, folly::exception_wrapper>;
 template <typename T>
 using UnmanagedMockSubscriber =
     reactivestreams::UnmanagedMockSubscriber<T, folly::exception_wrapper>;


### PR DESCRIPTION
Match the Java spec. It doesn't seem like there is any pushback against renaming this, and it becomes increasingly difficult over time.

https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md#specification

```
  $ cmake ../
  $ make
  $ ./ReactiveSocketTest

[  PASSED  ] 21 tests.
```