### PR TITLE
Exclude googletest from CMake Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ target_link_libraries(
 
 enable_testing()
 
-add_subdirectory(external/googletest)
+add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+# EXCLUDE_FROM_ALL so 'make install' doesn't attempt installation of googletest
 
 add_executable(
   ReactiveSocketTest


### PR DESCRIPTION
In preparation of support for "make install" for ReactiveSocket library.
This prevents the gtest and gmock libs from being installed when "make install" is called.