### PR TITLE
fixing lifetime of the ConnectionAutomaton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # reactivesocket-cpp
+
 C++ implementation of ReactiveSocket
+
+NOTE: This is a work in progress. It is not feature complete, and does not yet comply with the protocol, so can not yet interop with any other implementation. 
 
 # Build Status
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,29 @@ C++ implementation of ReactiveSocket
 
 <a href='https://travis-ci.org/ReactiveSocket/reactivesocket-cpp/builds'><img src='https://travis-ci.org/ReactiveSocket/reactivesocket-cpp.svg?branch=master'></a>
 
-# Building and running tests
+# Dependencies
 
-After installing latest folly release with `brew install folly` and making sure that you've checked out external dependencies via `git submodule update --recursive`, you can build and run tests with:
+Install `folly`:
 
 ```
-  mkdir -p build
-  cd build
-  cmake ../
-  make
-  ./ReactiveSocketTest
+brew install folly
+```
+
+After first checkout, initialize and update submodules:
+
+```
+git submodule init
+git submodule update --recursive
+```
+
+# Building and running tests
+
+After installing dependencies as above, you can build and run tests with:
+
+```
+mkdir -p build
+cd build
+cmake ../
+make
+./ReactiveSocketTest
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ C++ implementation of ReactiveSocket
 
 After installing latest folly release with `brew install folly` and making sure that you've checked out external dependencies via `git submodule update --recursive`, you can build and run tests with:
 
+```
   mkdir -p build
   cd build
   cmake ../
   make
   ./ReactiveSocketTest
-
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ brew install folly
 After first checkout, initialize and update submodules:
 
 ```
+# inside root ./reactivesocket-cpp
 git submodule init
 git submodule update --recursive
 ```
@@ -25,6 +26,7 @@ git submodule update --recursive
 After installing dependencies as above, you can build and run tests with:
 
 ```
+# inside root ./reactivesocket-cpp
 mkdir -p build
 cd build
 cmake ../

--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 
-#include "lithium/reactivesocket-cpp/src/ConnectionAutomaton.h"
+#include "reactivesocket-cpp/src/ConnectionAutomaton.h"
 
 #include <limits>
 

--- a/reactivesocket-cpp/src/ConnectionAutomaton.h
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.h
@@ -7,10 +7,11 @@
 #include <memory>
 #include <unordered_map>
 
-#include "reactive-streams-cpp/utilities/AllowanceSemaphore.h"
-#include "reactive-streams-cpp/utilities/SmartPointers.h"
-#include "reactivesocket-cpp/src/Payload.h"
-#include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
+#include "lithium/reactive-streams-cpp/utilities/AllowanceSemaphore.h"
+#include "lithium/reactive-streams-cpp/utilities/SmartPointers.h"
+#include "lithium/reactivesocket-cpp/src/Payload.h"
+#include "lithium/reactivesocket-cpp/src/ReactiveStreamsCompat.h"
+#include "lithium/reactivesocket-cpp/src/mixins/IntrusiveDeleter.h"
 
 namespace lithium {
 namespace reactivesocket {
@@ -36,7 +37,10 @@ class ConnectionAutomaton :
     /// Registered as an input in the DuplexConnection.
     public Subscriber<Payload>,
     /// Receives signals about connection writability.
-    public Subscription {
+    public Subscription,
+    /// The ConnectionAutomaton instance is shared between streams and also
+    /// ReactiveSocket class, using refcounting for lifetime management
+    public IntrusiveDeleter {
  public:
   ConnectionAutomaton(
       std::unique_ptr<DuplexConnection> connection,
@@ -48,8 +52,6 @@ class ConnectionAutomaton :
   /// May result, depending on the implementation of the DuplexConnection, in
   /// processing of one or more frames.
   void connect();
-
-  ~ConnectionAutomaton();
 
   /// @{
   /// A contract exposed to AbstractStreamAutomaton, modelled after Subscriber
@@ -91,7 +93,11 @@ class ConnectionAutomaton :
   void endStream(StreamId streamId, StreamCompletionSignal signal);
   /// @}
 
+  void close();
+
  private:
+  ~ConnectionAutomaton();
+
   /// Performs the same actions as ::endStream without propagating closure
   /// signal to the underlying connection.
   ///

--- a/reactivesocket-cpp/src/ReactiveSocket.cpp
+++ b/reactivesocket-cpp/src/ReactiveSocket.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 
-#include "reactivesocket-cpp/src/ReactiveSocket.h"
+#include "lithium/reactivesocket-cpp/src/ReactiveSocket.h"
 
 #include <cassert>
 #include <functional>
@@ -11,26 +11,29 @@
 #include <folly/Memory.h>
 #include <folly/MoveWrapper.h>
 
-#include "reactivesocket-cpp/src/DuplexConnection.h"
-#include "reactivesocket-cpp/src/Frame.h"
-#include "reactivesocket-cpp/src/Payload.h"
-#include "reactivesocket-cpp/src/RequestHandler.h"
-#include "reactivesocket-cpp/src/automata/ChannelRequester.h"
-#include "reactivesocket-cpp/src/automata/ChannelResponder.h"
-#include "reactivesocket-cpp/src/automata/SubscriptionRequester.h"
-#include "reactivesocket-cpp/src/automata/SubscriptionResponder.h"
+#include "lithium/reactivesocket-cpp/src/DuplexConnection.h"
+#include "lithium/reactivesocket-cpp/src/Frame.h"
+#include "lithium/reactivesocket-cpp/src/Payload.h"
+#include "lithium/reactivesocket-cpp/src/RequestHandler.h"
+#include "lithium/reactivesocket-cpp/src/automata/ChannelRequester.h"
+#include "lithium/reactivesocket-cpp/src/automata/ChannelResponder.h"
+#include "lithium/reactivesocket-cpp/src/automata/SubscriptionRequester.h"
+#include "lithium/reactivesocket-cpp/src/automata/SubscriptionResponder.h"
 
 namespace lithium {
 namespace reactivesocket {
 
-ReactiveSocket::~ReactiveSocket() {}
+ReactiveSocket::~ReactiveSocket() {
+  connection_->close();
+  connection_->decrementRefCount();
+}
 
 std::unique_ptr<ReactiveSocket> ReactiveSocket::fromClientConnection(
     std::unique_ptr<DuplexConnection> connection,
     std::unique_ptr<RequestHandler> handler) {
   std::unique_ptr<ReactiveSocket> socket(
       new ReactiveSocket(false, std::move(connection), std::move(handler)));
-  socket->connection_.connect();
+  socket->connection_->connect();
   return socket;
 }
 
@@ -39,7 +42,7 @@ std::unique_ptr<ReactiveSocket> ReactiveSocket::fromServerConnection(
     std::unique_ptr<RequestHandler> handler) {
   std::unique_ptr<ReactiveSocket> socket(
       new ReactiveSocket(true, std::move(connection), std::move(handler)));
-  socket->connection_.connect();
+  socket->connection_->connect();
   return socket;
 }
 
@@ -48,9 +51,9 @@ Subscriber<Payload>& ReactiveSocket::requestChannel(
   // TODO(stupaq): handle any exceptions
   StreamId streamId = nextStreamId_;
   nextStreamId_ += 2;
-  ChannelResponder::Parameters params = {&connection_, streamId};
+  ChannelResponder::Parameters params = {connection_, streamId};
   auto automaton = new ChannelRequester(params);
-  connection_.addStream(streamId, *automaton);
+  connection_->addStream(streamId, *automaton);
   automaton->subscribe(responseSink);
   responseSink.onSubscribe(*automaton);
   automaton->start();
@@ -63,9 +66,9 @@ void ReactiveSocket::requestSubscription(
   // TODO(stupaq): handle any exceptions
   StreamId streamId = nextStreamId_;
   nextStreamId_ += 2;
-  SubscriptionRequester::Parameters params = {&connection_, streamId};
+  SubscriptionRequester::Parameters params = {connection_, streamId};
   auto automaton = new SubscriptionRequester(params);
-  connection_.addStream(streamId, *automaton);
+  connection_->addStream(streamId, *automaton);
   automaton->subscribe(responseSink);
   responseSink.onSubscribe(*automaton);
   automaton->onNext(std::move(request));
@@ -78,13 +81,13 @@ ReactiveSocket::ReactiveSocket(
     std::unique_ptr<RequestHandler> handler)
     : handler_(std::move(handler)),
       nextStreamId_(isServer ? 1 : 2),
-      connection_(
+      connection_(new ConnectionAutomaton(
           std::move(connection),
           std::bind(
               &ReactiveSocket::createResponder,
               this,
               std::placeholders::_1,
-              std::placeholders::_2)) {}
+              std::placeholders::_2))) {}
 
 bool ReactiveSocket::createResponder(
     StreamId streamId,
@@ -96,14 +99,15 @@ bool ReactiveSocket::createResponder(
       if (!frame.deserializeFrom(std::move(serializedFrame))) {
         return false;
       }
-      ChannelResponder::Parameters params = {&connection_, streamId};
+      ChannelResponder::Parameters params = {connection_, streamId};
       auto automaton = new ChannelResponder(params);
-      connection_.addStream(streamId, *automaton);
+      connection_->addStream(streamId, *automaton);
       auto& requestSink =
           handler_->handleRequestChannel(std::move(frame.data_), *automaton);
+      // TODO: validate that the callback subscribed to the automaton (output)
       automaton->subscribe(requestSink);
-      automaton->onNextFrame(frame);
       requestSink.onSubscribe(*automaton);
+      automaton->onNextFrame(frame);
       automaton->start();
       break;
     }
@@ -112,9 +116,9 @@ bool ReactiveSocket::createResponder(
       if (!frame.deserializeFrom(std::move(serializedFrame))) {
         return false;
       }
-      SubscriptionResponder::Parameters params = {&connection_, streamId};
+      SubscriptionResponder::Parameters params = {connection_, streamId};
       auto automaton = new SubscriptionResponder(params);
-      connection_.addStream(streamId, *automaton);
+      connection_->addStream(streamId, *automaton);
       handler_->handleRequestSubscription(std::move(frame.data_), *automaton);
       automaton->onNextFrame(frame);
       automaton->start();

--- a/reactivesocket-cpp/src/ReactiveSocket.cpp
+++ b/reactivesocket-cpp/src/ReactiveSocket.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 
-#include "lithium/reactivesocket-cpp/src/ReactiveSocket.h"
+#include "reactivesocket-cpp/src/ReactiveSocket.h"
 
 #include <cassert>
 #include <functional>

--- a/reactivesocket-cpp/src/ReactiveSocket.h
+++ b/reactivesocket-cpp/src/ReactiveSocket.h
@@ -7,9 +7,9 @@
 #include <functional>
 #include <memory>
 
-#include "reactivesocket-cpp/src/ConnectionAutomaton.h"
-#include "reactivesocket-cpp/src/Payload.h"
-#include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
+#include "lithium/reactivesocket-cpp/src/ConnectionAutomaton.h"
+#include "lithium/reactivesocket-cpp/src/Payload.h"
+#include "lithium/reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
 namespace lithium {
 namespace reactivesocket {
@@ -61,7 +61,7 @@ class ReactiveSocket {
 
   std::unique_ptr<RequestHandler> handler_;
   StreamId nextStreamId_;
-  ConnectionAutomaton connection_;
+  ConnectionAutomaton* connection_;
 };
 }
 }


### PR DESCRIPTION
It is possible that ReactiveSocket class instance is destroyed by a user client call back. Eq. onComplete will tare down everything. In that case ReactiveSocket destructor was also taking down the ConnectionAutomaton instance which was executing the callback and had some more business to do. In order to stop this premature destruction of ConnectionAutomaton, it has to have independent lifetime from ReactiveSocket class. Also we need to make sure that all streams will be properly cleaned up when the ReactiveSocket instance is going away.