### PR TITLE
Travis Cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
 	path = external/googletest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.2)
 project(ReactiveSocket)
 
 # Generate compilation database for use by YouCompleteMe.

--- a/cmake/FindFolly.cmake
+++ b/cmake/FindFolly.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.2)
 
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
CMake to 3.2 and using https instead of git url. Small cleanups for Travis CI before bigger ones are added.