### PR TITLE
Remove lithium namespace

### DIFF
--- a/reactive-streams-cpp/Mocks.h
+++ b/reactive-streams-cpp/Mocks.h
@@ -157,4 +157,3 @@ inline MockSubscription& makeMockSubscription() {
   return *(new MockSubscription());
 }
 }
-}

--- a/reactive-streams-cpp/Mocks.h
+++ b/reactive-streams-cpp/Mocks.h
@@ -12,7 +12,6 @@
 #include "reactive-streams-cpp/Subscription.h"
 #include "reactive-streams-cpp/utilities/Ownership.h"
 
-namespace lithium {
 namespace reactivestreams {
 
 /// GoogleMock-compatible Publisher implementation for fast prototyping.

--- a/reactive-streams-cpp/Publisher.h
+++ b/reactive-streams-cpp/Publisher.h
@@ -40,4 +40,3 @@ class Publisher {
   virtual void subscribe(Subscriber<T, E>& subscriber) = 0;
 };
 }
-}

--- a/reactive-streams-cpp/Publisher.h
+++ b/reactive-streams-cpp/Publisher.h
@@ -4,7 +4,6 @@
 
 #include <exception>
 
-namespace lithium {
 namespace reactivestreams {
 
 template <typename T, typename E>

--- a/reactive-streams-cpp/Subscriber.h
+++ b/reactive-streams-cpp/Subscriber.h
@@ -4,7 +4,6 @@
 
 #include <exception>
 
-namespace lithium {
 namespace reactivestreams {
 
 class Subscription;

--- a/reactive-streams-cpp/Subscriber.h
+++ b/reactive-streams-cpp/Subscriber.h
@@ -76,4 +76,3 @@ class Subscriber {
   virtual void onError(E ex) = 0;
 };
 }
-}

--- a/reactive-streams-cpp/Subscription.h
+++ b/reactive-streams-cpp/Subscription.h
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 
-namespace lithium {
 namespace reactivestreams {
 
 /// Represents a connection between Publisher and Subscriber established by an

--- a/reactive-streams-cpp/Subscription.h
+++ b/reactive-streams-cpp/Subscription.h
@@ -74,4 +74,3 @@ class Subscription {
   virtual void cancel() = 0;
 };
 }
-}

--- a/reactive-streams-cpp/examples/Examples.cpp
+++ b/reactive-streams-cpp/examples/Examples.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
-using namespace lithium::reactivestreams;
+using namespace reactivestreams;
 
 TEST(Examples, SelfManagedMocks) {
   // Best run with ASAN, to detect potential leaks, use-after-free or

--- a/reactive-streams-cpp/test/AllowanceSemaphoreTest.cpp
+++ b/reactive-streams-cpp/test/AllowanceSemaphoreTest.cpp
@@ -8,7 +8,7 @@
 #include "reactive-streams-cpp/utilities/AllowanceSemaphore.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivestreams;
+using namespace ::reactivestreams;
 
 TEST(AllowanceSemaphoreTest, Finite) {
   AllowanceSemaphore sem;

--- a/reactive-streams-cpp/test/OwnershipTest.cpp
+++ b/reactive-streams-cpp/test/OwnershipTest.cpp
@@ -7,7 +7,7 @@
 #include "reactive-streams-cpp/utilities/Ownership.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivestreams;
+using namespace ::reactivestreams;
 
 class TestObject {
  public:

--- a/reactive-streams-cpp/test/SmartPointersTest.cpp
+++ b/reactive-streams-cpp/test/SmartPointersTest.cpp
@@ -11,7 +11,7 @@
 #include "reactive-streams-cpp/utilities/SmartPointers.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivestreams;
+using namespace ::reactivestreams;
 
 TEST(SubscriberPtrTest, ResetDtorRelease) {
   StrictMock<UnmanagedMockSubscriber<int>> subscriber0, subscriber1,

--- a/reactive-streams-cpp/utilities/AllowanceSemaphore.h
+++ b/reactive-streams-cpp/utilities/AllowanceSemaphore.h
@@ -69,4 +69,3 @@ class AllowanceSemaphore {
   ValueType value_{0};
 };
 }
-}

--- a/reactive-streams-cpp/utilities/AllowanceSemaphore.h
+++ b/reactive-streams-cpp/utilities/AllowanceSemaphore.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <limits>
 
-namespace lithium {
 namespace reactivestreams {
 
 class AllowanceSemaphore {

--- a/reactive-streams-cpp/utilities/Ownership.h
+++ b/reactive-streams-cpp/utilities/Ownership.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <memory>
 
-namespace lithium {
 namespace reactivestreams {
 
 /// Deletes specified object using std::default_delete<T> the first time

--- a/reactive-streams-cpp/utilities/Ownership.h
+++ b/reactive-streams-cpp/utilities/Ownership.h
@@ -93,4 +93,3 @@ RefCountedDeleter<T>::decrementDeferred() {
   return Handle(*this);
 }
 }
-}

--- a/reactive-streams-cpp/utilities/SmartPointers.h
+++ b/reactive-streams-cpp/utilities/SmartPointers.h
@@ -161,4 +161,3 @@ SubscriptionPtr<S> makeSubscriptionPtr(S* subscription) {
   return SubscriptionPtr<S>(subscription);
 }
 }
-}

--- a/reactive-streams-cpp/utilities/SmartPointers.h
+++ b/reactive-streams-cpp/utilities/SmartPointers.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <utility>
 
-namespace lithium {
 namespace reactivestreams {
 
 /// A "smart pointer" to an arbitrary Subscriber.

--- a/reactivesocket-cpp/src/AbstractStreamAutomaton.cpp
+++ b/reactivesocket-cpp/src/AbstractStreamAutomaton.cpp
@@ -9,7 +9,6 @@
 #include "reactivesocket-cpp/src/Frame.h"
 #include "reactivesocket-cpp/src/Payload.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 std::ostream& operator<<(std::ostream& os, StreamCompletionSignal signal) {

--- a/reactivesocket-cpp/src/AbstractStreamAutomaton.cpp
+++ b/reactivesocket-cpp/src/AbstractStreamAutomaton.cpp
@@ -70,4 +70,3 @@ void AbstractStreamAutomaton::deserializeAndDispatch(Payload& payload) {
   }
 }
 }
-}

--- a/reactivesocket-cpp/src/AbstractStreamAutomaton.h
+++ b/reactivesocket-cpp/src/AbstractStreamAutomaton.h
@@ -11,7 +11,6 @@ namespace folly {
 class exception_wrapper;
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 class ConnectionAutomaton;

--- a/reactivesocket-cpp/src/AbstractStreamAutomaton.h
+++ b/reactivesocket-cpp/src/AbstractStreamAutomaton.h
@@ -109,4 +109,3 @@ class AbstractStreamAutomaton {
   void deserializeAndDispatch(Payload& paylaod);
 };
 }
-}

--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -200,4 +200,3 @@ void ConnectionAutomaton::handleUnknownStream(
 }
 /// @}
 }
-}

--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -13,7 +13,6 @@
 #include "reactivesocket-cpp/src/Frame.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 ConnectionAutomaton::ConnectionAutomaton(

--- a/reactivesocket-cpp/src/ConnectionAutomaton.h
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.h
@@ -146,4 +146,3 @@ class ConnectionAutomaton :
   std::deque<Payload> pendingWrites_; // TODO(stupaq): two vectors?
 };
 }
-}

--- a/reactivesocket-cpp/src/ConnectionAutomaton.h
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.h
@@ -11,7 +11,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class AbstractStreamAutomaton;

--- a/reactivesocket-cpp/src/DuplexConnection.h
+++ b/reactivesocket-cpp/src/DuplexConnection.h
@@ -41,4 +41,3 @@ class DuplexConnection {
   virtual Subscriber<Payload>& getOutput() = 0;
 };
 }
-}

--- a/reactivesocket-cpp/src/DuplexConnection.h
+++ b/reactivesocket-cpp/src/DuplexConnection.h
@@ -5,7 +5,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// Represents a connection of the underlying protocol, on top of which

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -20,7 +20,6 @@ folly::Singleton<lithium::reactivesocket::FrameBufferAllocator>
 // TODO(stupaq): strict enum validation
 // TODO(stupaq): verify whether frames contain extra data
 // TODO(stupaq): get rid of these try-catch blocks
-namespace lithium {
 namespace reactivesocket {
 
 std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocate(size_t size) {

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -13,8 +13,7 @@
 #include <folly/io/IOBuf.h>
 
 namespace {
-folly::Singleton<reactivesocket::FrameBufferAllocator>
-    bufferAllocatorSingleton;
+folly::Singleton<reactivesocket::FrameBufferAllocator> bufferAllocatorSingleton;
 }
 
 // TODO(stupaq): strict enum validation

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -13,7 +13,7 @@
 #include <folly/io/IOBuf.h>
 
 namespace {
-folly::Singleton<lithium::reactivesocket::FrameBufferAllocator>
+folly::Singleton<reactivesocket::FrameBufferAllocator>
     bufferAllocatorSingleton;
 }
 

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -300,4 +300,3 @@ std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
 }
 /// @}
 }
-}

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -20,7 +20,6 @@ class Cursor;
 }
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 /// A unique identifier of a stream.

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -234,4 +234,3 @@ class Frame_ERROR {
 std::ostream& operator<<(std::ostream&, const Frame_ERROR&);
 /// @}
 }
-}

--- a/reactivesocket-cpp/src/Payload.h
+++ b/reactivesocket-cpp/src/Payload.h
@@ -13,4 +13,3 @@ namespace reactivesocket {
 /// MUST manage the lifetime of the underlying buffer.
 using Payload = std::unique_ptr<folly::IOBuf>;
 }
-}

--- a/reactivesocket-cpp/src/Payload.h
+++ b/reactivesocket-cpp/src/Payload.h
@@ -8,7 +8,6 @@ namespace folly {
 class IOBuf;
 }
 
-namespace lithium {
 namespace reactivesocket {
 /// The type of a read-only view on a binary buffer.
 /// MUST manage the lifetime of the underlying buffer.

--- a/reactivesocket-cpp/src/ReactiveSocket.cpp
+++ b/reactivesocket-cpp/src/ReactiveSocket.cpp
@@ -130,4 +130,3 @@ bool ReactiveSocket::createResponder(
   return true;
 }
 }
-}

--- a/reactivesocket-cpp/src/ReactiveSocket.cpp
+++ b/reactivesocket-cpp/src/ReactiveSocket.cpp
@@ -20,7 +20,6 @@
 #include "reactivesocket-cpp/src/automata/SubscriptionRequester.h"
 #include "reactivesocket-cpp/src/automata/SubscriptionResponder.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 ReactiveSocket::~ReactiveSocket() {

--- a/reactivesocket-cpp/src/ReactiveSocket.h
+++ b/reactivesocket-cpp/src/ReactiveSocket.h
@@ -9,7 +9,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class ConnectionAutomaton;

--- a/reactivesocket-cpp/src/ReactiveSocket.h
+++ b/reactivesocket-cpp/src/ReactiveSocket.h
@@ -62,4 +62,3 @@ class ReactiveSocket {
   StreamId nextStreamId_;
 };
 }
-}

--- a/reactivesocket-cpp/src/ReactiveStreamsCompat.h
+++ b/reactivesocket-cpp/src/ReactiveStreamsCompat.h
@@ -38,4 +38,3 @@ template <typename S>
 using SubscriptionPtr = reactivestreams::SubscriptionPtr<S>;
 
 } // namespace reactivesocket
-} // namespace lithium

--- a/reactivesocket-cpp/src/ReactiveStreamsCompat.h
+++ b/reactivesocket-cpp/src/ReactiveStreamsCompat.h
@@ -13,7 +13,6 @@ class exception_wrapper;
 /// This header defines aliases to the interfaces defined in the ReactiveStream
 /// specification, which replace std::exception_ptr with more efficient
 /// folly::exception_wrapper.
-namespace lithium {
 namespace reactivestreams {
 
 template <typename S>

--- a/reactivesocket-cpp/src/RequestHandler.h
+++ b/reactivesocket-cpp/src/RequestHandler.h
@@ -25,4 +25,3 @@ class RequestHandler {
       Subscriber<Payload>& response) = 0;
 };
 }
-}

--- a/reactivesocket-cpp/src/RequestHandler.h
+++ b/reactivesocket-cpp/src/RequestHandler.h
@@ -5,7 +5,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class RequestHandler {

--- a/reactivesocket-cpp/src/automata/ChannelRequester.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.cpp
@@ -183,4 +183,3 @@ std::ostream& ChannelRequesterBase::logPrefix(std::ostream& os) {
             << "): ";
 }
 }
-}

--- a/reactivesocket-cpp/src/automata/ChannelRequester.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.cpp
@@ -14,7 +14,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 void ChannelRequesterBase::onSubscribe(Subscription& subscription) {

--- a/reactivesocket-cpp/src/automata/ChannelRequester.h
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.h
@@ -24,7 +24,6 @@ namespace folly {
 class exception_wrapper;
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/automata/ChannelRequester.h
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.h
@@ -88,4 +88,3 @@ using ChannelRequester =
     SourceIfMixin<SinkIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<
         LoggingMixin<MemoryMixin<LoggingMixin<ChannelRequesterBase>>>>>>>>;
 }
-}

--- a/reactivesocket-cpp/src/automata/ChannelResponder.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.cpp
@@ -118,4 +118,3 @@ std::ostream& ChannelResponderBase::logPrefix(std::ostream& os) {
             << "): ";
 }
 }
-}

--- a/reactivesocket-cpp/src/automata/ChannelResponder.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.cpp
@@ -11,7 +11,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 void ChannelResponderBase::onNext(Payload response) {

--- a/reactivesocket-cpp/src/automata/ChannelResponder.h
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.h
@@ -24,7 +24,6 @@ namespace folly {
 class exception_wrapper;
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/automata/ChannelResponder.h
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.h
@@ -83,4 +83,3 @@ using ChannelResponder =
     SourceIfMixin<SinkIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<
         LoggingMixin<MemoryMixin<LoggingMixin<ChannelResponderBase>>>>>>>>;
 }
-}

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
@@ -14,7 +14,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 void SubscriptionRequesterBase::onNext(Payload request) {

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
@@ -141,4 +141,3 @@ std::ostream& SubscriptionRequesterBase::logPrefix(std::ostream& os) {
             << "): ";
 }
 }
-}

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.h
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.h
@@ -75,4 +75,3 @@ using SubscriptionRequester =
     SourceIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<
         LoggingMixin<MemoryMixin<LoggingMixin<SubscriptionRequesterBase>>>>>>>;
 }
-}

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.h
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.h
@@ -22,7 +22,6 @@ namespace folly {
 class exception_wrapper;
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
@@ -96,4 +96,3 @@ std::ostream& SubscriptionResponderBase::logPrefix(std::ostream& os) {
             << "): ";
 }
 }
-}

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
@@ -11,7 +11,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 void SubscriptionResponderBase::onNext(Payload response) {

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.h
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.h
@@ -70,4 +70,3 @@ using SubscriptionResponder =
     SinkIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<
         LoggingMixin<MemoryMixin<LoggingMixin<SubscriptionResponderBase>>>>>>>;
 }
-}

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.h
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.h
@@ -22,7 +22,6 @@ namespace folly {
 class exception_wrapper;
 }
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/mixins/ConsumerMixin-inl.h
+++ b/reactivesocket-cpp/src/mixins/ConsumerMixin-inl.h
@@ -12,7 +12,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 template <typename Frame, typename Base>

--- a/reactivesocket-cpp/src/mixins/ConsumerMixin-inl.h
+++ b/reactivesocket-cpp/src/mixins/ConsumerMixin-inl.h
@@ -50,4 +50,3 @@ void ConsumerMixin<Frame, Base>::handleFlowControlError() {
   CHECK(false);
 }
 }
-}

--- a/reactivesocket-cpp/src/mixins/ConsumerMixin.h
+++ b/reactivesocket-cpp/src/mixins/ConsumerMixin.h
@@ -10,7 +10,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/mixins/ConsumerMixin.h
+++ b/reactivesocket-cpp/src/mixins/ConsumerMixin.h
@@ -80,6 +80,5 @@ class ConsumerMixin : public Base {
   reactivestreams::AllowanceSemaphore pendingAllowance_;
 };
 }
-}
 
 #include "ConsumerMixin-inl.h"

--- a/reactivesocket-cpp/src/mixins/ExecutorMixin.h
+++ b/reactivesocket-cpp/src/mixins/ExecutorMixin.h
@@ -17,7 +17,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// Instead of calling into the respective Base methods, schedules signals

--- a/reactivesocket-cpp/src/mixins/ExecutorMixin.h
+++ b/reactivesocket-cpp/src/mixins/ExecutorMixin.h
@@ -129,4 +129,3 @@ class ExecutorMixin : public Base {
       folly::make_unique<PendingSignals>()};
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/IntrusiveDeleter.h
+++ b/reactivesocket-cpp/src/mixins/IntrusiveDeleter.h
@@ -32,4 +32,3 @@ class IntrusiveDeleter {
 
 inline IntrusiveDeleter::~IntrusiveDeleter() = default;
 }
-}

--- a/reactivesocket-cpp/src/mixins/IntrusiveDeleter.h
+++ b/reactivesocket-cpp/src/mixins/IntrusiveDeleter.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <memory>
 
-namespace lithium {
 namespace reactivesocket {
 
 /// Deletes itself using the first time the reference count, initially one,

--- a/reactivesocket-cpp/src/mixins/LoggingMixin.h
+++ b/reactivesocket-cpp/src/mixins/LoggingMixin.h
@@ -103,4 +103,3 @@ class LoggingMixin : public Base {
   /// @}
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/LoggingMixin.h
+++ b/reactivesocket-cpp/src/mixins/LoggingMixin.h
@@ -12,7 +12,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// Logs every frame or signal received by the Base.

--- a/reactivesocket-cpp/src/mixins/MemoryMixin.h
+++ b/reactivesocket-cpp/src/mixins/MemoryMixin.h
@@ -12,7 +12,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class IntrusiveDeleter;

--- a/reactivesocket-cpp/src/mixins/MemoryMixin.h
+++ b/reactivesocket-cpp/src/mixins/MemoryMixin.h
@@ -105,4 +105,3 @@ class MemoryMixin : public Base {
   }
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/MixinTerminator.h
+++ b/reactivesocket-cpp/src/mixins/MixinTerminator.h
@@ -78,4 +78,3 @@ class MixinTerminator
   const StreamId streamId_;
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/MixinTerminator.h
+++ b/reactivesocket-cpp/src/mixins/MixinTerminator.h
@@ -8,7 +8,6 @@
 
 #include "reactivesocket-cpp/src/mixins/IntrusiveDeleter.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class ConnectionAutomaton;

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -73,4 +73,3 @@ class PublisherMixin : public Base {
   reactivestreams::SubscriptionPtr<Subscription> producingSubscription_;
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -13,7 +13,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 enum class StreamCompletionSignal;

--- a/reactivesocket-cpp/src/mixins/SinkIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/SinkIfMixin.h
@@ -39,4 +39,3 @@ class SinkIfMixin : public Base, public Subscriber<Payload> {
   }
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/SinkIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/SinkIfMixin.h
@@ -8,7 +8,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// A mixin which provides dynamic dispatch for a chain of mixins and

--- a/reactivesocket-cpp/src/mixins/SourceIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/SourceIfMixin.h
@@ -5,7 +5,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// A mixin which provides dynamic dispatch for a chain of mixins and

--- a/reactivesocket-cpp/src/mixins/SourceIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/SourceIfMixin.h
@@ -28,4 +28,3 @@ class SourceIfMixin : public Base, public Subscription {
   }
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/StreamIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/StreamIfMixin.h
@@ -47,4 +47,3 @@ class StreamIfMixin : public Base, public AbstractStreamAutomaton {
   }
 };
 }
-}

--- a/reactivesocket-cpp/src/mixins/StreamIfMixin.h
+++ b/reactivesocket-cpp/src/mixins/StreamIfMixin.h
@@ -5,7 +5,6 @@
 #include "reactivesocket-cpp/src/AbstractStreamAutomaton.h"
 #include "reactivesocket-cpp/src/Payload.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// A mixin which provides dynamic dispatch for a chain of mixins and

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -11,7 +11,7 @@
 #include "reactivesocket-cpp/src/Payload.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivesocket;
+using namespace ::reactivesocket;
 
 class FrameTest : public ::testing::Test {
   void SetUp() override {
@@ -23,14 +23,14 @@ class FrameTest : public ::testing::Test {
           return buf.release();
         }));
 
-    folly::Singleton<lithium::reactivesocket::FrameBufferAllocator>::make_mock(
+    folly::Singleton<reactivesocket::FrameBufferAllocator>::make_mock(
         [&] { return &allocator; }, /* no tear down */ [](void*) {});
   }
 
   void TearDown() override {
     folly::SingletonVault::singleton()->destroyInstances();
     // Bring the default allocator.
-    folly::Singleton<lithium::reactivesocket::FrameBufferAllocator>::make_mock(
+    folly::Singleton<reactivesocket::FrameBufferAllocator>::make_mock(
         nullptr);
     folly::SingletonVault::singleton()->reenableInstances();
   }

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -30,8 +30,7 @@ class FrameTest : public ::testing::Test {
   void TearDown() override {
     folly::SingletonVault::singleton()->destroyInstances();
     // Bring the default allocator.
-    folly::Singleton<reactivesocket::FrameBufferAllocator>::make_mock(
-        nullptr);
+    folly::Singleton<reactivesocket::FrameBufferAllocator>::make_mock(nullptr);
     folly::SingletonVault::singleton()->reenableInstances();
   }
 

--- a/reactivesocket-cpp/test/InlineConnection.cpp
+++ b/reactivesocket-cpp/test/InlineConnection.cpp
@@ -136,4 +136,3 @@ Subscriber<Payload>& InlineConnection::getOutput() {
   return outputSink;
 }
 }
-}

--- a/reactivesocket-cpp/test/InlineConnection.cpp
+++ b/reactivesocket-cpp/test/InlineConnection.cpp
@@ -10,7 +10,6 @@
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 #include "reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 InlineConnection::InlineConnection()

--- a/reactivesocket-cpp/test/InlineConnection.h
+++ b/reactivesocket-cpp/test/InlineConnection.h
@@ -54,4 +54,3 @@ class InlineConnection : public DuplexConnection {
   Subscription* outputSubscription_;
 };
 }
-}

--- a/reactivesocket-cpp/test/InlineConnection.h
+++ b/reactivesocket-cpp/test/InlineConnection.h
@@ -7,7 +7,6 @@
 #include "reactivesocket-cpp/src/DuplexConnection.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 /// An intra-thread implementation of DuplexConnection that synchronously passes

--- a/reactivesocket-cpp/test/InlineConnectionTest.cpp
+++ b/reactivesocket-cpp/test/InlineConnectionTest.cpp
@@ -12,7 +12,7 @@
 #include "reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivesocket;
+using namespace ::reactivesocket;
 
 TEST(InlineConnectionTest, PingPong) {
   // InlineConnection forward appropriate calls in-line, hence the order of mock

--- a/reactivesocket-cpp/test/MockDuplexConnection.h
+++ b/reactivesocket-cpp/test/MockDuplexConnection.h
@@ -8,7 +8,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/ReactiveStreamsCompat.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class MockDuplexConnection : public DuplexConnection {

--- a/reactivesocket-cpp/test/MockDuplexConnection.h
+++ b/reactivesocket-cpp/test/MockDuplexConnection.h
@@ -24,4 +24,3 @@ class MockDuplexConnection : public DuplexConnection {
   }
 };
 }
-}

--- a/reactivesocket-cpp/test/MockRequestHandler.h
+++ b/reactivesocket-cpp/test/MockRequestHandler.h
@@ -32,4 +32,3 @@ class MockRequestHandler : public RequestHandler {
   }
 };
 }
-}

--- a/reactivesocket-cpp/test/MockRequestHandler.h
+++ b/reactivesocket-cpp/test/MockRequestHandler.h
@@ -9,7 +9,6 @@
 #include "reactivesocket-cpp/src/Payload.h"
 #include "reactivesocket-cpp/src/RequestHandler.h"
 
-namespace lithium {
 namespace reactivesocket {
 
 class MockRequestHandler : public RequestHandler {

--- a/reactivesocket-cpp/test/ReactiveSocketTest.cpp
+++ b/reactivesocket-cpp/test/ReactiveSocketTest.cpp
@@ -17,7 +17,7 @@
 #include "reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h"
 
 using namespace ::testing;
-using namespace ::lithium::reactivesocket;
+using namespace ::reactivesocket;
 
 MATCHER_P(
     Equals,

--- a/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
+++ b/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
@@ -11,7 +11,6 @@ class exception_wrapper;
 /// This header defines aliases to the mocks provided by the ReactiveStream
 /// specification, which replace std::exception_ptr with more efficient
 /// folly::exception_wrapper.
-namespace lithium {
 namespace reactivesocket {
 
 template <typename T>

--- a/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
+++ b/reactivesocket-cpp/test/ReactiveStreamsMocksCompat.h
@@ -35,4 +35,3 @@ inline MockSubscription& makeMockSubscription() {
   return reactivestreams::makeMockSubscription();
 }
 }
-}


### PR DESCRIPTION
After this, the only lithium references are in TARGET files

https://github.com/ReactiveSocket/reactivesocket-cpp/issues/38