### PR TITLE
[reactivesockets-cpp] add metadata to frames

### DIFF
--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -35,9 +35,9 @@ void ConnectionAutomaton::connect(bool client) {
 
   if (client) {
     // TODO set correct version
-    auto data = folly::IOBuf::create(0);
+    auto metadata = folly::IOBuf::create(0);
     Frame_SETUP frame(0, 0, 0, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(),
-                      std::move(data));
+                      FrameMetadata(std::move(metadata)));
     onNext(frame.serializeOut());
   }
 }

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -8,6 +8,9 @@
 
 /// Needed for inline d'tors of frames.
 #include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
+#include <folly/Memory.h>
+#include <folly/Optional.h>
 
 #include "reactivesocket-cpp/src/Payload.h"
 
@@ -16,6 +19,7 @@ template <typename V>
 class Optional;
 namespace io {
 class Appender;
+class QueueAppender;
 class Cursor;
 }
 }
@@ -89,6 +93,7 @@ class FrameHeader {
       : type_(type), flags_(flags), streamId_(streamId) {}
 
   void serializeInto(folly::io::Appender& app);
+  void serializeInto(folly::io::QueueAppender& app);
   bool deserializeFrom(folly::io::Cursor& cur);
 
   FrameType type_;
@@ -100,12 +105,35 @@ std::ostream& operator<<(std::ostream&, const FrameHeader&);
 class FrameBufferAllocator {
  public:
   static std::unique_ptr<folly::IOBuf> allocate(size_t size);
+  static std::unique_ptr<folly::IOBufQueue> allocateQueue();
 
   virtual ~FrameBufferAllocator() = default;
 
  private:
   virtual std::unique_ptr<folly::IOBuf> allocateBuffer(size_t size);
 };
+
+class FrameMetadata {
+ public:
+  explicit FrameMetadata(std::unique_ptr<folly::IOBuf> metadataPayload)
+  : metadataPayload_(std::move(metadataPayload)) {}
+  /// Empty metadata
+  explicit FrameMetadata()
+  : metadataPayload_(folly::make_unique<folly::IOBuf>()) {}
+
+  std::unique_ptr<folly::IOBuf> serialize();
+
+  /// if metadata is present, deserializes it into metadata
+  static bool deserializeFrom(folly::io::Cursor& cur,
+                              const FrameFlags& flags,
+                              folly::Optional<FrameMetadata>& metadata);
+  bool deserializeFrom(folly::io::Cursor& cur);
+
+  std::unique_ptr<folly::IOBuf> metadataPayload_;
+};
+std::ostream& operator<<(std::ostream&, const folly::Optional<FrameMetadata>&);
+
+static const folly::Optional<FrameMetadata> FrameMetadata_EMPTY { folly::none };
 
 /// @{
 /// Frames do not form hierarchy, as we never perform type erasure on a frame.
@@ -122,20 +150,23 @@ class Frame_REQUEST_SUB {
       StreamId streamId,
       FrameFlags flags,
       uint32_t requestN,
+      folly::Optional<FrameMetadata> metadata,
       Payload data)
       : header_(FrameType::REQUEST_SUB, flags, streamId),
         requestN_(requestN),
+        metadata_(std::move(metadata)),
         data_(std::move(data)) {}
 
   /// For compatibility with other data-carrying frames.
-  Frame_REQUEST_SUB(StreamId streamId, FrameFlags flags, Payload data)
-      : Frame_REQUEST_SUB(streamId, flags, 0, std::move(data)) {}
+  Frame_REQUEST_SUB(StreamId streamId, FrameFlags flags, folly::Optional<FrameMetadata> metadata, Payload data)
+      : Frame_REQUEST_SUB(streamId, flags, 0, std::move(metadata), std::move(data)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
 
   FrameHeader header_;
   uint32_t requestN_;
+  folly::Optional<FrameMetadata> metadata_;
   Payload data_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_REQUEST_SUB&);
@@ -149,20 +180,23 @@ class Frame_REQUEST_CHANNEL {
       StreamId streamId,
       FrameFlags flags,
       uint32_t requestN,
+      folly::Optional<FrameMetadata> metadata,
       Payload data)
       : header_(FrameType::REQUEST_CHANNEL, flags, streamId),
         requestN_(requestN),
+        metadata_(std::move(metadata)),
         data_(std::move(data)) {}
 
   /// For compatibility with other data-carrying frames.
-  Frame_REQUEST_CHANNEL(StreamId streamId, FrameFlags flags, Payload data)
-      : Frame_REQUEST_CHANNEL(streamId, flags, 0, std::move(data)) {}
+  Frame_REQUEST_CHANNEL(StreamId streamId, FrameFlags flags, folly::Optional<FrameMetadata> metadata, Payload data)
+      : Frame_REQUEST_CHANNEL(streamId, flags, 0, std::move(metadata), std::move(data)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
 
   FrameHeader header_;
   uint32_t requestN_;
+  folly::Optional<FrameMetadata> metadata_;
   Payload data_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_REQUEST_CHANNEL&);
@@ -191,12 +225,15 @@ class Frame_CANCEL {
 
   Frame_CANCEL() {}
   explicit Frame_CANCEL(StreamId streamId)
-      : header_(FrameType::CANCEL, FrameFlags_EMPTY, streamId) {}
+      : Frame_CANCEL(streamId, FrameFlags_EMPTY, folly::none) {}
+  Frame_CANCEL(StreamId streamId, FrameFlags flags, folly::Optional<FrameMetadata> metadata)
+      : header_(FrameType::CANCEL, flags, streamId), metadata_(std::move(metadata)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
 
   FrameHeader header_;
+  folly::Optional<FrameMetadata> metadata_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_CANCEL&);
 
@@ -205,13 +242,14 @@ class Frame_RESPONSE {
   static constexpr bool Trait_CarriesAllowance = false;
 
   Frame_RESPONSE() {}
-  Frame_RESPONSE(StreamId streamId, FrameFlags flags, Payload data)
-      : header_(FrameType::RESPONSE, flags, streamId), data_(std::move(data)) {}
+  Frame_RESPONSE(StreamId streamId, FrameFlags flags, folly::Optional<FrameMetadata> metadata, Payload data)
+      : header_(FrameType::RESPONSE, flags, streamId), metadata_(std::move(metadata)), data_(std::move(data)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
 
   FrameHeader header_;
+  folly::Optional<FrameMetadata> metadata_;
   Payload data_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_RESPONSE&);
@@ -222,14 +260,18 @@ class Frame_ERROR {
 
   Frame_ERROR() {}
   Frame_ERROR(StreamId streamId, ErrorCode errorCode)
-      : header_(FrameType::ERROR, FrameFlags_EMPTY, streamId),
-        errorCode_(errorCode) {}
+      : Frame_ERROR(streamId, FrameFlags_EMPTY, errorCode, folly::none) {}
+  Frame_ERROR(StreamId streamId, FrameFlags flags, ErrorCode errorCode, folly::Optional<FrameMetadata> metadata)
+      : header_(FrameType::ERROR, flags, streamId),
+        errorCode_(errorCode),
+        metadata_(std::move(metadata)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
 
   FrameHeader header_;
   ErrorCode errorCode_;
+  folly::Optional<FrameMetadata> metadata_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_ERROR&);
 
@@ -261,12 +303,12 @@ class Frame_SETUP {
       uint32_t version,
       uint32_t keepaliveTime,
       uint32_t maxLifetime,
-      Payload data)
+      folly::Optional<FrameMetadata> metadata)
       : header_(FrameType::SETUP, flags, streamId),
         version_(version),
         keepaliveTime_(keepaliveTime),
         maxLifetime_(maxLifetime),
-        data_(std::move(data)) {}
+        metadata_(std::move(metadata)) {}
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
@@ -275,7 +317,7 @@ class Frame_SETUP {
   uint32_t version_;
   uint32_t keepaliveTime_;
   uint32_t maxLifetime_;
-  Payload data_;
+  folly::Optional<FrameMetadata> metadata_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_SETUP&);
 /// @}

--- a/reactivesocket-cpp/src/automata/ChannelRequester.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.cpp
@@ -40,6 +40,7 @@ void ChannelRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
+          FrameMetadata(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.
@@ -67,7 +68,7 @@ void ChannelRequesterBase::onComplete() {
       break;
     case State::REQUESTED: {
       state_ = State::CLOSED;
-      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, nullptr);
+      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/ChannelResponder.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.cpp
@@ -27,7 +27,7 @@ void ChannelResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;
@@ -62,7 +62,7 @@ void ChannelResponderBase::cancel() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
@@ -33,6 +33,7 @@ void SubscriptionRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
+          FrameMetadata(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
@@ -27,7 +27,7 @@ void SubscriptionResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -30,7 +30,7 @@ class PublisherMixin : public Base {
   }
 
   void onNext(Payload payload) {
-    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, std::move(payload));
+    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, FrameMetadata(), std::move(payload));
     Base::connection_->onNextFrame(frame);
   }
   /// @}

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -5,10 +5,8 @@
 #include <folly/Singleton.h>
 #include <folly/io/IOBuf.h>
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include "reactivesocket-cpp/src/Frame.h"
-#include "reactivesocket-cpp/src/Payload.h"
 
 using namespace ::testing;
 using namespace ::reactivesocket;
@@ -16,7 +14,7 @@ using namespace ::reactivesocket;
 class FrameTest : public ::testing::Test {
   void SetUp() override {
     EXPECT_CALL(allocator, allocateBuffer_(_))
-        .WillOnce(Invoke([](size_t size) {
+        .WillRepeatedly(Invoke([](size_t size) {
           auto buf = folly::IOBuf::createCombined(size + sizeof(int32_t));
           // create some wasted headroom
           buf->advance(sizeof(int32_t));
@@ -67,14 +65,16 @@ void expectHeader(
 
 TEST_F(FrameTest, Frame_REQUEST_CHANNEL) {
   uint32_t streamId = 42;
-  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_REQN_PRESENT;
+  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_REQN_PRESENT | FrameFlags_METADATA;
   uint32_t requestN = 3;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
   auto frame = reserialize<Frame_REQUEST_CHANNEL>(
-      streamId, flags, requestN, data->clone());
+      streamId, flags, requestN, FrameMetadata(metadata->clone()), data->clone());
 
   expectHeader(FrameType::REQUEST_CHANNEL, flags, streamId, frame);
   EXPECT_EQ(requestN, frame.requestN_);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
@@ -89,28 +89,52 @@ TEST_F(FrameTest, Frame_REQUEST_N) {
 
 TEST_F(FrameTest, Frame_CANCEL) {
   uint32_t streamId = 42;
-  auto frame = reserialize<Frame_CANCEL>(streamId);
+  FrameFlags flags = FrameFlags_METADATA;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
+  auto frame = reserialize<Frame_CANCEL>(streamId, flags, FrameMetadata(metadata->clone()));
 
-  expectHeader(FrameType::CANCEL, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::CANCEL, flags, streamId, frame);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
 }
 
-TEST_F(FrameTest, Frame_RESPONE) {
+TEST_F(FrameTest, Frame_RESPONSE) {
   uint32_t streamId = 42;
-  FrameFlags flags = FrameFlags_COMPLETE;
+  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_METADATA;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, data->clone());
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata(metadata->clone()), data->clone());
 
   expectHeader(FrameType::RESPONSE, flags, streamId, frame);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
+TEST_F(FrameTest, Frame_RESPONSE_NoMeta) {
+  uint32_t streamId = 42;
+  FrameFlags flags = FrameFlags_COMPLETE;
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, folly::none, data->clone());
+
+  expectHeader(FrameType::RESPONSE, flags, streamId, frame);
+  EXPECT_FALSE(frame.metadata_.hasValue());
+  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
+}
+
+
+
 TEST_F(FrameTest, Frame_ERROR) {
   uint32_t streamId = 42;
+  FrameFlags flags = FrameFlags_METADATA;
   auto errorCode = ErrorCode::REJECTED;
-  auto frame = reserialize<Frame_ERROR>(streamId, errorCode);
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
+  auto frame = reserialize<Frame_ERROR>(streamId,
+                                        flags,
+                                        errorCode,
+                                        FrameMetadata(metadata->clone()));
 
-  expectHeader(FrameType::ERROR, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::ERROR, flags, streamId, frame);
   EXPECT_EQ(errorCode, frame.errorCode_);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
 }
 
 TEST_F(FrameTest, Frame_KEEPALIVE) {
@@ -125,16 +149,22 @@ TEST_F(FrameTest, Frame_KEEPALIVE) {
 
 TEST_F(FrameTest, Frame_SETUP) {
   uint32_t streamId = 0;
-  FrameFlags flags = 0;
+  FrameFlags flags = FrameFlags_METADATA;
   uint32_t version = 0;
   uint32_t keepaliveTime = std::numeric_limits<uint32_t>::max();
   uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_SETUP>(streamId, flags, version, keepaliveTime, maxLifetime, data->clone());
+  auto frame = reserialize<Frame_SETUP>(streamId,
+                                        flags,
+                                        version,
+                                        keepaliveTime,
+                                        maxLifetime,
+                                        FrameMetadata(metadata->clone()));
 
-  expectHeader(FrameType::SETUP, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::SETUP, flags, streamId, frame);
   EXPECT_EQ(version, frame.version_);
   EXPECT_EQ(keepaliveTime, frame.keepaliveTime_);
   EXPECT_EQ(maxLifetime, frame.maxLifetime_);
-  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
 }


### PR DESCRIPTION
- Add metadata to all currently supported messages

Note: started using IOBufQueue as it's a better abstraction for chaining together many IOBuf's than just doing it on top of IOBuf.

- Correction: Setup frame doesn't have 'data', only mime types for data/metadata and then the metadata