### PR TITLE
[reactivesockets-cpp] add metadata to frames

### DIFF
--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -37,7 +37,8 @@ void ConnectionAutomaton::connect(bool client) {
     // TODO set correct version
     auto metadata = folly::IOBuf::create(0);
     auto data = folly::IOBuf::create(0);
-    Frame_SETUP frame(0, 0, 0, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(),
+    auto flags = FrameFlags_METADATA;
+    Frame_SETUP frame(0, flags, 0, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(),
                       FrameMetadata(std::move(metadata)), std::move(data));
     onNext(frame.serializeOut());
   }

--- a/reactivesocket-cpp/src/ConnectionAutomaton.cpp
+++ b/reactivesocket-cpp/src/ConnectionAutomaton.cpp
@@ -35,9 +35,10 @@ void ConnectionAutomaton::connect(bool client) {
 
   if (client) {
     // TODO set correct version
+    auto metadata = folly::IOBuf::create(0);
     auto data = folly::IOBuf::create(0);
     Frame_SETUP frame(0, 0, 0, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max(),
-                      std::move(data));
+                      FrameMetadata(std::move(metadata)), std::move(data));
     onNext(frame.serializeOut());
   }
 }

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -2,6 +2,12 @@
 
 #include "reactivesocket-cpp/src/Frame.h"
 
+#include <bitset>
+#include <memory>
+#include <ostream>
+
+#include <folly/Memory.h>
+#include <folly/Optional.h>
 #include <folly/Singleton.h>
 #include <folly/io/Cursor.h>
 

--- a/reactivesocket-cpp/src/Frame.cpp
+++ b/reactivesocket-cpp/src/Frame.cpp
@@ -2,15 +2,8 @@
 
 #include "reactivesocket-cpp/src/Frame.h"
 
-#include <bitset>
-#include <memory>
-#include <ostream>
-
-#include <folly/Memory.h>
-#include <folly/Optional.h>
 #include <folly/Singleton.h>
 #include <folly/io/Cursor.h>
-#include <folly/io/IOBuf.h>
 
 namespace {
 folly::Singleton<reactivesocket::FrameBufferAllocator> bufferAllocatorSingleton;
@@ -28,6 +21,10 @@ std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocate(size_t size) {
 std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocateBuffer(
     size_t size) {
   return folly::IOBuf::createCombined(size);
+}
+
+std::unique_ptr<folly::IOBufQueue> FrameBufferAllocator::allocateQueue() {
+  return folly::make_unique<folly::IOBufQueue>(folly::IOBufQueue(folly::IOBufQueue::cacheChainLength()));
 }
 
 std::ostream& operator<<(std::ostream& os, FrameType type) {
@@ -99,6 +96,12 @@ void FrameHeader::serializeInto(folly::io::Appender& app) {
   app.writeBE<uint32_t>(streamId_);
 }
 
+void FrameHeader::serializeInto(folly::io::QueueAppender& app) {
+  app.writeBE(static_cast<uint16_t>(type_));
+  app.writeBE<uint16_t>(flags_);
+  app.writeBE<uint32_t>(streamId_);
+}
+
 bool FrameHeader::deserializeFrom(folly::io::Cursor& cur) {
   try {
     type_ = static_cast<FrameType>(cur.readBE<uint16_t>());
@@ -114,20 +117,68 @@ std::ostream& operator<<(std::ostream& os, const FrameHeader& header) {
   std::bitset<16> flags(header.flags_);
   return os << header.type_ << "[" << flags << ", " << header.streamId_ << "]";
 }
+
+std::unique_ptr<folly::IOBuf> FrameMetadata::serialize() {
+  auto buf = FrameBufferAllocator::allocate(sizeof(uint32_t));
+  folly::io::Appender app(buf.get(), /* do not grow */ 0);
+  app.writeBE<uint32_t>(static_cast<uint32_t>(metadataPayload_->length()) + sizeof(uint32_t));
+  buf->appendChain(std::move(metadataPayload_));
+  return buf;
+}
+
+bool FrameMetadata::deserializeFrom(folly::io::Cursor& cur,
+                                    const FrameFlags& flags,
+                                    folly::Optional<FrameMetadata>& metadata) {
+  if (flags & FrameFlags_METADATA) {
+    FrameMetadata m;
+    if (! m.deserializeFrom(cur)) {
+      return false;
+    } else {
+      metadata.assign(std::move(m));
+      return true;
+    }
+  } else { // no metadata was set
+    return true;
+  }
+}
+
+bool FrameMetadata::deserializeFrom(folly::io::Cursor& cur) {
+  try {
+    auto length = cur.readBE<uint32_t>() - sizeof(uint32_t);
+    if (length > 0) {
+      cur.clone(metadataPayload_, length);
+    } else {
+      metadataPayload_.reset();
+    }
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const folly::Optional<FrameMetadata>& metadata) {
+  return os << "[meta: " << (metadata.hasValue() ?
+                              folly::to<std::string>(metadata->metadataPayload_->computeChainDataLength())
+                              : "empty") << "]";
+}
 /// @}
 
 /// @{
 Payload Frame_REQUEST_SUB::serializeOut() {
+  auto queue = FrameBufferAllocator::allocateQueue();
   auto buf =
-      FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
-
-  folly::io::Appender app(buf.get(), /* do not grow */ 0);
+    FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
   header_.serializeInto(app);
   app.writeBE<uint32_t>(requestN_);
-  if (data_) {
-    buf->appendChain(std::move(data_));
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
   }
-  return buf;
+  if (data_) {
+    app.insert(std::move(data_));
+  }
+  return queue->move();
 }
 
 bool Frame_REQUEST_SUB::deserializeFrom(Payload in) {
@@ -135,11 +186,12 @@ bool Frame_REQUEST_SUB::deserializeFrom(Payload in) {
   if (!header_.deserializeFrom(cur)) {
     return false;
   }
-  // TODO support metadata
-  assert((header_.flags_ & FrameFlags_METADATA) == 0);
   try {
     requestN_ = cur.readBE<uint32_t>();
   } catch (...) {
+    return false;
+  }
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
     return false;
   }
   auto totalLength = cur.totalLength();
@@ -152,24 +204,29 @@ bool Frame_REQUEST_SUB::deserializeFrom(Payload in) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_SUB& frame) {
-  return os << frame.header_ << "(" << frame.requestN_ << ", <"
-            << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
-            << ">)";
+  return os << frame.header_ << "(" << frame.requestN_ << ", " << frame.metadata_ << ", <" <<
+            (frame.data_ ? frame.data_->computeChainDataLength() : 0) << ">)";
 }
 /// @}
 
 /// @{
 Payload Frame_REQUEST_CHANNEL::serializeOut() {
+  auto queue = FrameBufferAllocator::allocateQueue();
   auto buf =
-      FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
+    FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
 
-  folly::io::Appender app(buf.get(), /* do not grow */ 0);
   header_.serializeInto(app);
   app.writeBE<uint32_t>(requestN_);
-  if (data_) {
-    buf->appendChain(std::move(data_));
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
   }
-  return buf;
+  if (data_) {
+    app.insert(std::move(data_));
+  }
+
+  return queue->move();
 }
 
 bool Frame_REQUEST_CHANNEL::deserializeFrom(Payload in) {
@@ -177,11 +234,12 @@ bool Frame_REQUEST_CHANNEL::deserializeFrom(Payload in) {
   if (!header_.deserializeFrom(cur)) {
     return false;
   }
-  // TODO support metadata
-  assert((header_.flags_ & FrameFlags_METADATA) == 0);
   try {
     requestN_ = cur.readBE<uint32_t>();
   } catch (...) {
+    return false;
+  }
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
     return false;
   }
   auto totalLength = cur.totalLength();
@@ -194,9 +252,8 @@ bool Frame_REQUEST_CHANNEL::deserializeFrom(Payload in) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
-  return os << frame.header_ << "(" << frame.requestN_ << ", <"
-            << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
-            << ">)";
+  return os << frame.header_ << "(" << frame.requestN_ << ", " << frame.metadata_ << ", <"
+            << (frame.data_ ? frame.data_->computeChainDataLength() : 0) << ">)";
 }
 /// @}
 
@@ -230,10 +287,15 @@ std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_N& frame) {
 
 /// @{
 Payload Frame_CANCEL::serializeOut() {
+  auto queue = FrameBufferAllocator::allocateQueue();
   auto buf = FrameBufferAllocator::allocate(FrameHeader::kSize);
-  folly::io::Appender app(buf.get(), /* do not grow */ 0);
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
   header_.serializeInto(app);
-  return buf;
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
+  }
+  return queue->move();
 }
 
 bool Frame_CANCEL::deserializeFrom(Payload in) {
@@ -241,26 +303,31 @@ bool Frame_CANCEL::deserializeFrom(Payload in) {
   if (!header_.deserializeFrom(cur)) {
     return false;
   }
-  // TODO support metadata
-  assert((header_.flags_ & FrameFlags_METADATA) == 0);
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
+    return false;
+  }
   return true;
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_CANCEL& frame) {
-  return os << frame.header_;
+  return os << frame.header_ << ", " << frame.metadata_;
 }
 /// @}
 
 /// @{
 Payload Frame_RESPONSE::serializeOut() {
+  auto queue = FrameBufferAllocator::allocateQueue();
   auto buf = FrameBufferAllocator::allocate(FrameHeader::kSize);
-
-  folly::io::Appender app(buf.get(), /* do not grow */ 0);
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
   header_.serializeInto(app);
-  if (data_) {
-    buf->appendChain(std::move(data_));
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
   }
-  return buf;
+  if (data_) {
+    app.insert(std::move(data_));
+  }
+  return queue->move();
 }
 
 bool Frame_RESPONSE::deserializeFrom(Payload in) {
@@ -268,8 +335,9 @@ bool Frame_RESPONSE::deserializeFrom(Payload in) {
   if (!header_.deserializeFrom(cur)) {
     return false;
   }
-  // TODO support metadata
-  assert((header_.flags_ & FrameFlags_METADATA) == 0);
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
+    return false;
+  }
   auto totalLength = cur.totalLength();
   if (totalLength > 0) {
     cur.clone(data_, totalLength);
@@ -280,7 +348,7 @@ bool Frame_RESPONSE::deserializeFrom(Payload in) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_RESPONSE& frame) {
-  return os << frame.header_ << "(<"
+  return os << frame.header_ << ", (" << frame.metadata_ << " <"
             << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
             << ">)";
 }
@@ -288,12 +356,16 @@ std::ostream& operator<<(std::ostream& os, const Frame_RESPONSE& frame) {
 
 /// @{
 Payload Frame_ERROR::serializeOut() {
-  auto buf =
-      FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
-  folly::io::Appender app(buf.get(), /* do not grow */ 0);
+  auto queue = FrameBufferAllocator::allocateQueue();
+  auto buf = FrameBufferAllocator::allocate(FrameHeader::kSize + sizeof(uint32_t));
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
   header_.serializeInto(app);
   app.writeBE(static_cast<uint32_t>(errorCode_));
-  return buf;
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
+  }
+  return queue->move();
 }
 
 bool Frame_ERROR::deserializeFrom(Payload in) {
@@ -301,18 +373,19 @@ bool Frame_ERROR::deserializeFrom(Payload in) {
   if (!header_.deserializeFrom(cur)) {
     return false;
   }
-  // TODO support metadata
-  assert((header_.flags_ & FrameFlags_METADATA) == 0);
   try {
     errorCode_ = static_cast<ErrorCode>(cur.readBE<uint32_t>());
-    return true;
   } catch (...) {
     return false;
   }
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
+    return false;
+  }
+  return true;
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
-  return os << frame.header_ << "(" << frame.errorCode_ << ")";
+  return os << frame.header_ << ", " << frame.metadata_ << ", (" << frame.errorCode_ << ")";
 }
 /// @}
 
@@ -351,49 +424,55 @@ std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
 /// @}
 
 /// @{
-    Payload Frame_SETUP::serializeOut() {
-      auto buf = FrameBufferAllocator::allocate(FrameHeader::kSize + 3 * sizeof(uint32_t));
+Payload Frame_SETUP::serializeOut() {
+  auto queue = FrameBufferAllocator::allocateQueue();
+  auto buf = FrameBufferAllocator::allocate(FrameHeader::kSize + 3 * sizeof(uint32_t));
+  queue->append(std::move(buf));
+  folly::io::QueueAppender app(queue.get(), /* do not grow */ 0);
 
-      folly::io::Appender app(buf.get(), /* do not grow */ 0);
-      header_.serializeInto(app);
-      app.writeBE(static_cast<uint32_t>(version_));
-      app.writeBE(static_cast<uint32_t>(keepaliveTime_));
-      app.writeBE(static_cast<uint32_t>(maxLifetime_));
-      // TODO encode mime types
-      if (data_) {
-        buf->appendChain(std::move(data_));
-      }
-      return buf;
-    }
+  header_.serializeInto(app);
+  app.writeBE(static_cast<uint32_t>(version_));
+  app.writeBE(static_cast<uint32_t>(keepaliveTime_));
+  app.writeBE(static_cast<uint32_t>(maxLifetime_));
+  // TODO encode mime types
+  if (header_.flags_ & FrameFlags_METADATA) {
+    app.insert(metadata_->serialize());
+  }
+  if (data_) {
+    app.insert(std::move(data_));
+  }
+  return queue->move();
+}
 
-    bool Frame_SETUP::deserializeFrom(Payload in) {
-      folly::io::Cursor cur(in.get());
-      if (!header_.deserializeFrom(cur)) {
-        return false;
-      }
-      // TODO support metadata
-      assert((header_.flags_ & FrameFlags_METADATA) == 0);
-      try {
-        version_ = cur.readBE<uint32_t>();
-        keepaliveTime_ = cur.readBE<uint32_t>();
-        maxLifetime_ = cur.readBE<uint32_t>();
-      } catch (...) {
-        return false;
-      }
-      // TODO decode mime types
-      auto totalLength = cur.totalLength();
-      if (totalLength > 0) {
-        cur.clone(data_, totalLength);
-      } else {
-        data_.reset();
-      }
-      return true;
-    }
+bool Frame_SETUP::deserializeFrom(Payload in) {
+  folly::io::Cursor cur(in.get());
+  if (!header_.deserializeFrom(cur)) {
+    return false;
+  }
+  try {
+    version_ = cur.readBE<uint32_t>();
+    keepaliveTime_ = cur.readBE<uint32_t>();
+    maxLifetime_ = cur.readBE<uint32_t>();
+  } catch (...) {
+    return false;
+  }
+  // TODO decode mime types
+  if (!FrameMetadata::deserializeFrom(cur, header_.flags_, metadata_)) {
+    return false;
+  }
+  auto totalLength = cur.totalLength();
+  if (totalLength > 0) {
+    cur.clone(data_, totalLength);
+  } else {
+    data_.reset();
+  }
+  return true;
+}
 
-    std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
-      return os << frame.header_ << "(<"
-             << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
-             << ">)";
-    }
+std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
+  return os << frame.header_ << ", (" << frame.metadata_ << ", <"
+            << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
+            << ">)";;
+}
 /// @}
 }

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -20,11 +20,7 @@ template <typename V>
 class Optional;
 namespace io {
 class Cursor;
-
-namespace detail {
-  template <typename Derived>
-  class Writable;
-}
+class QueueAppender;
 }
 }
 
@@ -96,8 +92,7 @@ class FrameHeader {
   FrameHeader(FrameType type, FrameFlags flags, StreamId streamId)
       : type_(type), flags_(flags), streamId_(streamId) {}
 
-  template<typename T>
-  void serializeInto(folly::io::detail::Writable<T>& app);
+  void serializeInto(folly::io::QueueAppender& app);
   bool deserializeFrom(folly::io::Cursor& cur);
 
   FrameType type_;

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -100,7 +100,6 @@ std::ostream& operator<<(std::ostream&, const FrameHeader&);
 class FrameBufferAllocator {
  public:
   static std::unique_ptr<folly::IOBuf> allocate(size_t size);
-  static std::unique_ptr<folly::IOBufQueue> allocateQueue();
 
   virtual ~FrameBufferAllocator() = default;
 

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -115,6 +115,9 @@ class FrameMetadata {
   explicit FrameMetadata()
   : metadataPayload_(nullptr) {}
 
+  static FrameMetadata empty();
+  void checkFlags(FrameFlags flags);
+
   void serializeInto(folly::io::QueueAppender& appender);
 
   /// if metadata is present, deserializes it into metadata
@@ -122,8 +125,6 @@ class FrameMetadata {
                               const FrameFlags& flags,
                               FrameMetadata& metadata);
   bool deserializeFrom(folly::io::Cursor& cur);
-
-  uint32_t size();
 
   std::unique_ptr<folly::IOBuf> metadataPayload_;
 };
@@ -150,7 +151,9 @@ class Frame_REQUEST_SUB {
       : header_(FrameType::REQUEST_SUB, flags, streamId),
         requestN_(requestN),
         metadata_(std::move(metadata)),
-        data_(std::move(data)) {}
+        data_(std::move(data)) {
+    metadata_.checkFlags(flags);
+  }
 
   /// For compatibility with other data-carrying frames.
   Frame_REQUEST_SUB(StreamId streamId, FrameFlags flags, FrameMetadata metadata, Payload data)
@@ -180,7 +183,9 @@ class Frame_REQUEST_CHANNEL {
       : header_(FrameType::REQUEST_CHANNEL, flags, streamId),
         requestN_(requestN),
         metadata_(std::move(metadata)),
-        data_(std::move(data)) {}
+        data_(std::move(data)) {
+    metadata_.checkFlags(flags);
+  }
 
   /// For compatibility with other data-carrying frames.
   Frame_REQUEST_CHANNEL(StreamId streamId, FrameFlags flags, FrameMetadata metadata, Payload data)
@@ -220,9 +225,11 @@ class Frame_CANCEL {
 
   Frame_CANCEL() {}
   explicit Frame_CANCEL(StreamId streamId)
-      : Frame_CANCEL(streamId, FrameFlags_EMPTY, FrameMetadata()) {}
+      : Frame_CANCEL(streamId, FrameFlags_EMPTY, FrameMetadata::empty()) {}
   Frame_CANCEL(StreamId streamId, FrameFlags flags, FrameMetadata metadata)
-      : header_(FrameType::CANCEL, flags, streamId), metadata_(std::move(metadata)) {}
+      : header_(FrameType::CANCEL, flags, streamId), metadata_(std::move(metadata)) {
+    metadata_.checkFlags(flags);
+  }
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
@@ -238,7 +245,9 @@ class Frame_RESPONSE {
 
   Frame_RESPONSE() {}
   Frame_RESPONSE(StreamId streamId, FrameFlags flags, FrameMetadata metadata, Payload data)
-      : header_(FrameType::RESPONSE, flags, streamId), metadata_(std::move(metadata)), data_(std::move(data)) {}
+      : header_(FrameType::RESPONSE, flags, streamId), metadata_(std::move(metadata)), data_(std::move(data)) {
+    metadata_.checkFlags(flags);
+  }
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
@@ -255,11 +264,13 @@ class Frame_ERROR {
 
   Frame_ERROR() {}
   Frame_ERROR(StreamId streamId, ErrorCode errorCode)
-      : Frame_ERROR(streamId, FrameFlags_EMPTY, errorCode, FrameMetadata()) {}
+      : Frame_ERROR(streamId, FrameFlags_EMPTY, errorCode, FrameMetadata::empty()) {}
   Frame_ERROR(StreamId streamId, FrameFlags flags, ErrorCode errorCode, FrameMetadata metadata)
       : header_(FrameType::ERROR, flags, streamId),
         errorCode_(errorCode),
-        metadata_(std::move(metadata)) {}
+        metadata_(std::move(metadata)) {
+    metadata_.checkFlags(flags);
+  }
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);
@@ -305,7 +316,9 @@ class Frame_SETUP {
         keepaliveTime_(keepaliveTime),
         maxLifetime_(maxLifetime),
         metadata_(std::move(metadata)),
-        data_(std::move(data)) {}
+        data_(std::move(data)) {
+    metadata_.checkFlags(flags);
+  }
 
   Payload serializeOut();
   bool deserializeFrom(Payload in);

--- a/reactivesocket-cpp/src/Frame.h
+++ b/reactivesocket-cpp/src/Frame.h
@@ -5,15 +5,15 @@
 #include <iosfwd>
 #include <limits>
 
-#include <folly/Optional.h>
+/// Needed for inline d'tors of frames.
+#include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
 
 #include "reactivesocket-cpp/src/Payload.h"
 
 namespace folly {
 template <typename V>
 class Optional;
-class IOBuf;
-class IOBufQueue;
 namespace io {
 class Cursor;
 class QueueAppender;

--- a/reactivesocket-cpp/src/automata/ChannelRequester.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.cpp
@@ -40,7 +40,7 @@ void ChannelRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
-          FrameMetadata(),
+          FrameMetadata::empty(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.
@@ -68,7 +68,7 @@ void ChannelRequesterBase::onComplete() {
       break;
     case State::REQUESTED: {
       state_ = State::CLOSED;
-      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, FrameMetadata(), nullptr);
+      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, FrameMetadata::empty(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/ChannelRequester.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelRequester.cpp
@@ -40,6 +40,7 @@ void ChannelRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
+          FrameMetadata(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.
@@ -67,7 +68,7 @@ void ChannelRequesterBase::onComplete() {
       break;
     case State::REQUESTED: {
       state_ = State::CLOSED;
-      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, nullptr);
+      Frame_REQUEST_CHANNEL frame(streamId_, FrameFlags_COMPLETE, 0, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/ChannelResponder.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.cpp
@@ -27,7 +27,7 @@ void ChannelResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata::empty(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;
@@ -62,7 +62,7 @@ void ChannelResponderBase::cancel() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata::empty(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/ChannelResponder.cpp
+++ b/reactivesocket-cpp/src/automata/ChannelResponder.cpp
@@ -27,7 +27,7 @@ void ChannelResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;
@@ -62,7 +62,7 @@ void ChannelResponderBase::cancel() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
@@ -33,6 +33,7 @@ void SubscriptionRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
+          FrameMetadata(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.

--- a/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionRequester.cpp
@@ -33,7 +33,7 @@ void SubscriptionRequesterBase::onNext(Payload request) {
           streamId_,
           flags,
           static_cast<uint32_t>(initialN),
-          FrameMetadata(),
+          FrameMetadata::empty(),
           std::move(request));
       // We must inform ConsumerMixin about an implicit allowance we have
       // requested from the remote end.

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
@@ -27,7 +27,7 @@ void SubscriptionResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata::empty(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
+++ b/reactivesocket-cpp/src/automata/SubscriptionResponder.cpp
@@ -27,7 +27,7 @@ void SubscriptionResponderBase::onComplete() {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, nullptr);
+      Frame_RESPONSE frame(streamId_, FrameFlags_COMPLETE, FrameMetadata(), nullptr);
       connection_->onNextFrame(frame);
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
     } break;

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -30,7 +30,7 @@ class PublisherMixin : public Base {
   }
 
   void onNext(Payload payload) {
-    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, FrameMetadata(), std::move(payload));
+    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, FrameMetadata::empty(), std::move(payload));
     Base::connection_->onNextFrame(frame);
   }
   /// @}

--- a/reactivesocket-cpp/src/mixins/PublisherMixin.h
+++ b/reactivesocket-cpp/src/mixins/PublisherMixin.h
@@ -30,7 +30,7 @@ class PublisherMixin : public Base {
   }
 
   void onNext(Payload payload) {
-    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, std::move(payload));
+    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, FrameMetadata(), std::move(payload));
     Base::connection_->onNextFrame(frame);
   }
   /// @}

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -127,7 +127,6 @@ TEST_F(FrameTest, Frame_ERROR) {
   FrameFlags flags = FrameFlags_METADATA;
   auto errorCode = ErrorCode::REJECTED;
   auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
-  auto data = folly::IOBuf::copyBuffer("424242");
   auto frame = reserialize<Frame_ERROR>(streamId,
                                         flags,
                                         errorCode,
@@ -150,24 +149,22 @@ TEST_F(FrameTest, Frame_KEEPALIVE) {
 
 TEST_F(FrameTest, Frame_SETUP) {
   uint32_t streamId = 0;
-  FrameFlags flags = FrameFlags_METADATA;
+  FrameFlags flags = FrameFlags_EMPTY;
   uint32_t version = 0;
   uint32_t keepaliveTime = std::numeric_limits<uint32_t>::max();
   uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
-  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
   auto frame = reserialize<Frame_SETUP>(streamId,
                                         flags,
                                         version,
                                         keepaliveTime,
                                         maxLifetime,
-                                        FrameMetadata(metadata->clone()),
+                                        folly::none,
                                         data->clone());
 
   expectHeader(FrameType::SETUP, flags, streamId, frame);
   EXPECT_EQ(version, frame.version_);
   EXPECT_EQ(keepaliveTime, frame.keepaliveTime_);
   EXPECT_EQ(maxLifetime, frame.maxLifetime_);
-  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -5,10 +5,8 @@
 #include <folly/Singleton.h>
 #include <folly/io/IOBuf.h>
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include "reactivesocket-cpp/src/Frame.h"
-#include "reactivesocket-cpp/src/Payload.h"
 
 using namespace ::testing;
 using namespace ::reactivesocket;
@@ -16,7 +14,7 @@ using namespace ::reactivesocket;
 class FrameTest : public ::testing::Test {
   void SetUp() override {
     EXPECT_CALL(allocator, allocateBuffer_(_))
-        .WillOnce(Invoke([](size_t size) {
+        .WillRepeatedly(Invoke([](size_t size) {
           auto buf = folly::IOBuf::createCombined(size + sizeof(int32_t));
           // create some wasted headroom
           buf->advance(sizeof(int32_t));
@@ -67,14 +65,16 @@ void expectHeader(
 
 TEST_F(FrameTest, Frame_REQUEST_CHANNEL) {
   uint32_t streamId = 42;
-  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_REQN_PRESENT;
+  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_REQN_PRESENT | FrameFlags_METADATA;
   uint32_t requestN = 3;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
   auto frame = reserialize<Frame_REQUEST_CHANNEL>(
-      streamId, flags, requestN, data->clone());
+      streamId, flags, requestN, FrameMetadata(metadata->clone()), data->clone());
 
   expectHeader(FrameType::REQUEST_CHANNEL, flags, streamId, frame);
   EXPECT_EQ(requestN, frame.requestN_);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
@@ -89,28 +89,53 @@ TEST_F(FrameTest, Frame_REQUEST_N) {
 
 TEST_F(FrameTest, Frame_CANCEL) {
   uint32_t streamId = 42;
-  auto frame = reserialize<Frame_CANCEL>(streamId);
+  FrameFlags flags = FrameFlags_METADATA;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
+  auto frame = reserialize<Frame_CANCEL>(streamId, flags, FrameMetadata(metadata->clone()));
 
-  expectHeader(FrameType::CANCEL, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::CANCEL, flags, streamId, frame);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
 }
 
-TEST_F(FrameTest, Frame_RESPONE) {
+TEST_F(FrameTest, Frame_RESPONSE) {
   uint32_t streamId = 42;
-  FrameFlags flags = FrameFlags_COMPLETE;
+  FrameFlags flags = FrameFlags_COMPLETE | FrameFlags_METADATA;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, data->clone());
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata(metadata->clone()), data->clone());
 
   expectHeader(FrameType::RESPONSE, flags, streamId, frame);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
+TEST_F(FrameTest, Frame_RESPONSE_NoMeta) {
+  uint32_t streamId = 42;
+  FrameFlags flags = FrameFlags_COMPLETE;
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, folly::none, data->clone());
+
+  expectHeader(FrameType::RESPONSE, flags, streamId, frame);
+  EXPECT_FALSE(frame.metadata_.hasValue());
+  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
+}
+
+
+
 TEST_F(FrameTest, Frame_ERROR) {
   uint32_t streamId = 42;
+  FrameFlags flags = FrameFlags_METADATA;
   auto errorCode = ErrorCode::REJECTED;
-  auto frame = reserialize<Frame_ERROR>(streamId, errorCode);
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize<Frame_ERROR>(streamId,
+                                        flags,
+                                        errorCode,
+                                        FrameMetadata(metadata->clone()));
 
-  expectHeader(FrameType::ERROR, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::ERROR, flags, streamId, frame);
   EXPECT_EQ(errorCode, frame.errorCode_);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
 }
 
 TEST_F(FrameTest, Frame_KEEPALIVE) {
@@ -125,16 +150,24 @@ TEST_F(FrameTest, Frame_KEEPALIVE) {
 
 TEST_F(FrameTest, Frame_SETUP) {
   uint32_t streamId = 0;
-  FrameFlags flags = 0;
+  FrameFlags flags = FrameFlags_METADATA;
   uint32_t version = 0;
   uint32_t keepaliveTime = std::numeric_limits<uint32_t>::max();
   uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_SETUP>(streamId, flags, version, keepaliveTime, maxLifetime, data->clone());
+  auto frame = reserialize<Frame_SETUP>(streamId,
+                                        flags,
+                                        version,
+                                        keepaliveTime,
+                                        maxLifetime,
+                                        FrameMetadata(metadata->clone()),
+                                        data->clone());
 
-  expectHeader(FrameType::SETUP, FrameFlags_EMPTY, streamId, frame);
+  expectHeader(FrameType::SETUP, flags, streamId, frame);
   EXPECT_EQ(version, frame.version_);
   EXPECT_EQ(keepaliveTime, frame.keepaliveTime_);
   EXPECT_EQ(maxLifetime, frame.maxLifetime_);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -74,7 +74,7 @@ TEST_F(FrameTest, Frame_REQUEST_CHANNEL) {
 
   expectHeader(FrameType::REQUEST_CHANNEL, flags, streamId, frame);
   EXPECT_EQ(requestN, frame.requestN_);
-  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_.metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
@@ -94,7 +94,7 @@ TEST_F(FrameTest, Frame_CANCEL) {
   auto frame = reserialize<Frame_CANCEL>(streamId, flags, FrameMetadata(metadata->clone()));
 
   expectHeader(FrameType::CANCEL, flags, streamId, frame);
-  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_.metadataPayload_));
 }
 
 TEST_F(FrameTest, Frame_RESPONSE) {
@@ -105,7 +105,7 @@ TEST_F(FrameTest, Frame_RESPONSE) {
   auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata(metadata->clone()), data->clone());
 
   expectHeader(FrameType::RESPONSE, flags, streamId, frame);
-  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_.metadataPayload_));
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
@@ -113,10 +113,10 @@ TEST_F(FrameTest, Frame_RESPONSE_NoMeta) {
   uint32_t streamId = 42;
   FrameFlags flags = FrameFlags_COMPLETE;
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, folly::none, data->clone());
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata(), data->clone());
 
   expectHeader(FrameType::RESPONSE, flags, streamId, frame);
-  EXPECT_FALSE(frame.metadata_.hasValue());
+  EXPECT_FALSE(frame.metadata_.metadataPayload_);
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 
@@ -134,7 +134,7 @@ TEST_F(FrameTest, Frame_ERROR) {
 
   expectHeader(FrameType::ERROR, flags, streamId, frame);
   EXPECT_EQ(errorCode, frame.errorCode_);
-  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_->metadataPayload_));
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.metadata_.metadataPayload_));
 }
 
 TEST_F(FrameTest, Frame_KEEPALIVE) {
@@ -159,7 +159,7 @@ TEST_F(FrameTest, Frame_SETUP) {
                                         version,
                                         keepaliveTime,
                                         maxLifetime,
-                                        folly::none,
+                                        FrameMetadata(),
                                         data->clone());
 
   expectHeader(FrameType::SETUP, flags, streamId, frame);

--- a/reactivesocket-cpp/test/FrameTest.cpp
+++ b/reactivesocket-cpp/test/FrameTest.cpp
@@ -113,7 +113,7 @@ TEST_F(FrameTest, Frame_RESPONSE_NoMeta) {
   uint32_t streamId = 42;
   FrameFlags flags = FrameFlags_COMPLETE;
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata(), data->clone());
+  auto frame = reserialize<Frame_RESPONSE>(streamId, flags, FrameMetadata::empty(), data->clone());
 
   expectHeader(FrameType::RESPONSE, flags, streamId, frame);
   EXPECT_FALSE(frame.metadata_.metadataPayload_);
@@ -159,7 +159,7 @@ TEST_F(FrameTest, Frame_SETUP) {
                                         version,
                                         keepaliveTime,
                                         maxLifetime,
-                                        FrameMetadata(),
+                                        FrameMetadata::empty(),
                                         data->clone());
 
   expectHeader(FrameType::SETUP, flags, streamId, frame);


### PR DESCRIPTION
- Add metadata to all currently supported messages
Note: started using IOBufQueue as it's a better abstraction for chaining together many IOBuf's than just doing it on top of IOBuf.