### PR TITLE
Refactor StreamSubscriberRequesterBase to remove template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
   src/automata/ChannelRequester.h
   src/automata/ChannelResponder.cpp
   src/automata/ChannelResponder.h
+  src/automata/StreamSubscriptionRequesterBase.cpp
   src/automata/StreamSubscriptionRequesterBase.h
   src/automata/StreamSubscriptionResponderBase.cpp
   src/automata/StreamSubscriptionResponderBase.h

--- a/TARGETS
+++ b/TARGETS
@@ -35,7 +35,7 @@ cxx_library(
         'src/AbstractStreamAutomaton.cpp',
         'src/automata/ChannelRequester.cpp',
         'src/automata/ChannelResponder.cpp',
-        /src/automata/StreamSubscriptionRequesterBase.cpp',
+        'src/automata/StreamSubscriptionRequesterBase.cpp',
         'src/automata/StreamSubscriptionResponderBase.cpp',
         'src/automata/StreamRequester.cpp',
         'src/automata/StreamResponder.cpp',

--- a/TARGETS
+++ b/TARGETS
@@ -35,6 +35,7 @@ cxx_library(
         'src/AbstractStreamAutomaton.cpp',
         'src/automata/ChannelRequester.cpp',
         'src/automata/ChannelResponder.cpp',
+        /src/automata/StreamSubscriptionRequesterBase.cpp',
         'src/automata/StreamSubscriptionResponderBase.cpp',
         'src/automata/StreamRequester.cpp',
         'src/automata/StreamResponder.cpp',

--- a/src/automata/StreamRequester.cpp
+++ b/src/automata/StreamRequester.cpp
@@ -7,6 +7,42 @@
 
 namespace reactivesocket {
 
+void StreamRequesterBase::onNext(Payload request) {
+  switch (state_) {
+    case State::NEW: {
+      state_ = State::REQUESTED;
+      // FIXME: find a root cause of this assymetry; the problem here is that
+      // the Base::request might be delivered after the whole thing is shut
+      // down, if one uses InlineConnection.
+      size_t initialN = initialResponseAllowance_.drainWithLimit(
+          Frame_REQUEST_N::kMaxRequestN);
+      size_t remainingN = initialResponseAllowance_.drain();
+      // Send as much as possible with the initial request.
+      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
+      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
+      Frame_REQUEST_STREAM frame(
+          streamId_,
+          flags,
+          static_cast<uint32_t>(initialN),
+          FrameMetadata::empty(),
+          std::move(request));
+      // We must inform ConsumerMixin about an implicit allowance we have
+      // requested from the remote end.
+      addImplicitAllowance(initialN);
+      connection_->onNextFrame(frame);
+      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
+      // initial request.
+      if (remainingN) {
+        Base::request(remainingN);
+      }
+    } break;
+    case State::REQUESTED:
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
 std::ostream& StreamRequesterBase::logPrefix(std::ostream& os) {
   return os << "StreamRequester(" << &connection_ << ", " << streamId_ << "): ";
 }

--- a/src/automata/StreamRequester.cpp
+++ b/src/automata/StreamRequester.cpp
@@ -7,40 +7,20 @@
 
 namespace reactivesocket {
 
-void StreamRequesterBase::onNext(Payload request) {
-  switch (state_) {
-    case State::NEW: {
-      state_ = State::REQUESTED;
-      // FIXME: find a root cause of this assymetry; the problem here is that
-      // the Base::request might be delivered after the whole thing is shut
-      // down, if one uses InlineConnection.
-      size_t initialN = initialResponseAllowance_.drainWithLimit(
-          Frame_REQUEST_N::kMaxRequestN);
-      size_t remainingN = initialResponseAllowance_.drain();
-      // Send as much as possible with the initial request.
-      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
-      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
-      Frame_REQUEST_STREAM frame(
-          streamId_,
-          flags,
-          static_cast<uint32_t>(initialN),
-          FrameMetadata::empty(),
-          std::move(request));
-      // We must inform ConsumerMixin about an implicit allowance we have
-      // requested from the remote end.
-      addImplicitAllowance(initialN);
-      connection_->onNextFrame(frame);
-      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
-      // initial request.
-      if (remainingN) {
-        Base::request(remainingN);
-      }
-    } break;
-    case State::REQUESTED:
-      break;
-    case State::CLOSED:
-      break;
-  }
+void StreamRequesterBase::sendRequestFrame(
+    FrameFlags flags,
+    size_t initialN,
+    Payload&& request) {
+  Frame_REQUEST_STREAM frame(
+      streamId_,
+      flags,
+      static_cast<uint32_t>(initialN),
+      FrameMetadata::empty(),
+      std::move(request));
+  // We must inform ConsumerMixin about an implicit allowance we have
+  // requested from the remote end.
+  addImplicitAllowance(initialN);
+  connection_->onNextFrame(frame);
 }
 
 std::ostream& StreamRequesterBase::logPrefix(std::ostream& os) {

--- a/src/automata/StreamRequester.cpp
+++ b/src/automata/StreamRequester.cpp
@@ -17,9 +17,6 @@ void StreamRequesterBase::sendRequestFrame(
       static_cast<uint32_t>(initialN),
       FrameMetadata::empty(),
       std::move(request));
-  // We must inform ConsumerMixin about an implicit allowance we have
-  // requested from the remote end.
-  addImplicitAllowance(initialN);
   connection_->onNextFrame(frame);
 }
 

--- a/src/automata/StreamRequester.h
+++ b/src/automata/StreamRequester.h
@@ -26,12 +26,13 @@ namespace reactivesocket {
 enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Stream requester
-class StreamRequesterBase
-    : public StreamSubscriptionRequesterBase<Frame_REQUEST_STREAM> {
-  using Base = StreamSubscriptionRequesterBase<Frame_REQUEST_STREAM>;
+class StreamRequesterBase : public StreamSubscriptionRequesterBase {
+  using Base = StreamSubscriptionRequesterBase;
 
  public:
   using Base::Base;
+
+  void onNext(Payload request) override;
 
  protected:
   /// @{

--- a/src/automata/StreamRequester.h
+++ b/src/automata/StreamRequester.h
@@ -32,10 +32,9 @@ class StreamRequesterBase : public StreamSubscriptionRequesterBase {
  public:
   using Base::Base;
 
-  void onNext(Payload request) override;
-
  protected:
   /// @{
+  void sendRequestFrame(FrameFlags, size_t, Payload&&) override;
   std::ostream& logPrefix(std::ostream& os);
   /// @}
 };

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -4,6 +4,33 @@
 
 namespace reactivesocket {
 
+void StreamSubscriptionRequesterBase::onNext(Payload request) {
+  switch (state_) {
+    case State::NEW: {
+      state_ = State::REQUESTED;
+      // FIXME: find a root cause of this assymetry; the problem here is that
+      // the Base::request might be delivered after the whole thing is shut
+      // down, if one uses InlineConnection.
+      size_t initialN = initialResponseAllowance_.drainWithLimit(
+          Frame_REQUEST_N::kMaxRequestN);
+      size_t remainingN = initialResponseAllowance_.drain();
+      // Send as much as possible with the initial request.
+      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
+      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
+      sendRequestFrame(flags, initialN, std::move(request));
+      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
+      // initial request.
+      if (remainingN) {
+        Base::request(remainingN);
+      }
+    } break;
+    case State::REQUESTED:
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
 void StreamSubscriptionRequesterBase::request(size_t n) {
   switch (state_) {
     case State::NEW:

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -1,0 +1,93 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "StreamSubscriptionRequesterBase.h"
+
+namespace reactivesocket {
+
+void StreamSubscriptionRequesterBase::request(size_t n) {
+  switch (state_) {
+    case State::NEW:
+      // The initial request has not been sent out yet, hence we must accumulate
+      // the unsynchronised allowance, portion of which will be sent out with
+      // the initial request frame, and the rest will be dispatched via
+      // Base:request (ultimately by sending REQUEST_N frames).
+      initialResponseAllowance_.release(n);
+      break;
+    case State::REQUESTED:
+      Base::request(n);
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void StreamSubscriptionRequesterBase::cancel() {
+  switch (state_) {
+    case State::NEW:
+      state_ = State::CLOSED;
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+      break;
+    case State::REQUESTED: {
+      state_ = State::CLOSED;
+      Frame_CANCEL frame(streamId_);
+      connection_->onNextFrame(frame);
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+    } break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void StreamSubscriptionRequesterBase::endStream(StreamCompletionSignal signal) {
+  switch (state_) {
+    case State::NEW:
+    case State::REQUESTED:
+      // Spontaneous ::endStream signal means an error.
+      DCHECK(StreamCompletionSignal::GRACEFUL != signal);
+      state_ = State::CLOSED;
+      break;
+    case State::CLOSED:
+      break;
+  }
+  Base::endStream(signal);
+}
+
+void StreamSubscriptionRequesterBase::onNextFrame(Frame_RESPONSE& frame) {
+  bool end = false;
+  switch (state_) {
+    case State::NEW:
+      // Cannot receive a frame before sending the initial request.
+      CHECK(false);
+      break;
+    case State::REQUESTED:
+      if (frame.header_.flags_ & FrameFlags_COMPLETE) {
+        state_ = State::CLOSED;
+        end = true;
+      }
+      break;
+    case State::CLOSED:
+      break;
+  }
+  Base::onNextFrame(frame);
+  if (end) {
+    connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+  }
+}
+
+void StreamSubscriptionRequesterBase::onNextFrame(Frame_ERROR& frame) {
+  switch (state_) {
+    case State::NEW:
+      // Cannot receive a frame before sending the initial request.
+      CHECK(false);
+      break;
+    case State::REQUESTED:
+      state_ = State::CLOSED;
+      Base::onError(
+          std::runtime_error(frame.data_->moveToFbString().toStdString()));
+      connection_->endStream(streamId_, StreamCompletionSignal::ERROR);
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+}

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -17,6 +17,10 @@ void StreamSubscriptionRequesterBase::onNext(Payload request) {
       // Send as much as possible with the initial request.
       CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
       auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
+      
+      // We must inform ConsumerMixin about an implicit allowance we have
+      // requested from the remote end.
+      addImplicitAllowance(initialN);
       sendRequestFrame(flags, initialN, std::move(request));
       // Pump the remaining allowance into the ConsumerMixin _after_ sending the
       // initial request.

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -36,7 +36,7 @@ class StreamSubscriptionRequesterBase
 
   /// Degenerate form of the Subscriber interface -- only one request payload
   /// will be sent to the server.
-  virtual void onNext(Payload) = 0;
+  void onNext(Payload);
 
   /// @{
   /// A Subscriber interface to control ingestion of response payloads.
@@ -46,6 +46,9 @@ class StreamSubscriptionRequesterBase
   /// @}
 
  protected:
+  /// Override in subclass to send the correct type of request frame
+  virtual void sendRequestFrame(FrameFlags, size_t, Payload&&) = 0;
+
   /// @{
   void endStream(StreamCompletionSignal);
 

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -27,7 +27,6 @@ namespace reactivesocket {
 enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Subscription requester.
-template <class T>
 class StreamSubscriptionRequesterBase
     : public LoggingMixin<ConsumerMixin<Frame_RESPONSE, MixinTerminator>> {
   using Base = LoggingMixin<ConsumerMixin<Frame_RESPONSE, MixinTerminator>>;
@@ -37,7 +36,7 @@ class StreamSubscriptionRequesterBase
 
   /// Degenerate form of the Subscriber interface -- only one request payload
   /// will be sent to the server.
-  void onNext(Payload);
+  virtual void onNext(Payload) = 0;
 
   /// @{
   /// A Subscriber interface to control ingestion of response payloads.
@@ -67,139 +66,8 @@ class StreamSubscriptionRequesterBase
     CLOSED,
   } state_{State::NEW};
 
- private:
   /// An allowance accumulated before the stream is initialised.
   /// Remaining part of the allowance is forwarded to the ConsumerMixin.
   reactivestreams::AllowanceSemaphore initialResponseAllowance_;
 };
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::onNext(Payload request) {
-  switch (state_) {
-    case State::NEW: {
-      state_ = State::REQUESTED;
-      // FIXME: find a root cause of this assymetry; the problem here is that
-      // the Base::request might be delivered after the whole thing is shut
-      // down, if one uses InlineConnection.
-      size_t initialN = initialResponseAllowance_.drainWithLimit(
-          Frame_REQUEST_N::kMaxRequestN);
-      size_t remainingN = initialResponseAllowance_.drain();
-      // Send as much as possible with the initial request.
-      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
-      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
-      T frame(
-          streamId_,
-          flags,
-          static_cast<uint32_t>(initialN),
-          FrameMetadata::empty(),
-          std::move(request));
-      // We must inform ConsumerMixin about an implicit allowance we have
-      // requested from the remote end.
-      addImplicitAllowance(initialN);
-      connection_->onNextFrame(frame);
-      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
-      // initial request.
-      if (remainingN) {
-        Base::request(remainingN);
-      }
-    } break;
-    case State::REQUESTED:
-      break;
-    case State::CLOSED:
-      break;
-  }
-}
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::request(size_t n) {
-  switch (state_) {
-    case State::NEW:
-      // The initial request has not been sent out yet, hence we must accumulate
-      // the unsynchronised allowance, portion of which will be sent out with
-      // the initial request frame, and the rest will be dispatched via
-      // Base:request (ultimately by sending REQUEST_N frames).
-      initialResponseAllowance_.release(n);
-      break;
-    case State::REQUESTED:
-      Base::request(n);
-      break;
-    case State::CLOSED:
-      break;
-  }
-}
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::cancel() {
-  switch (state_) {
-    case State::NEW:
-      state_ = State::CLOSED;
-      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
-      break;
-    case State::REQUESTED: {
-      state_ = State::CLOSED;
-      Frame_CANCEL frame(streamId_);
-      connection_->onNextFrame(frame);
-      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
-    } break;
-    case State::CLOSED:
-      break;
-  }
-}
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::endStream(
-    StreamCompletionSignal signal) {
-  switch (state_) {
-    case State::NEW:
-    case State::REQUESTED:
-      // Spontaneous ::endStream signal means an error.
-      DCHECK(StreamCompletionSignal::GRACEFUL != signal);
-      state_ = State::CLOSED;
-      break;
-    case State::CLOSED:
-      break;
-  }
-  Base::endStream(signal);
-}
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::onNextFrame(Frame_RESPONSE& frame) {
-  bool end = false;
-  switch (state_) {
-    case State::NEW:
-      // Cannot receive a frame before sending the initial request.
-      CHECK(false);
-      break;
-    case State::REQUESTED:
-      if (frame.header_.flags_ & FrameFlags_COMPLETE) {
-        state_ = State::CLOSED;
-        end = true;
-      }
-      break;
-    case State::CLOSED:
-      break;
-  }
-  Base::onNextFrame(frame);
-  if (end) {
-    connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
-  }
-}
-
-template <class T>
-void StreamSubscriptionRequesterBase<T>::onNextFrame(Frame_ERROR& frame) {
-  switch (state_) {
-    case State::NEW:
-      // Cannot receive a frame before sending the initial request.
-      CHECK(false);
-      break;
-    case State::REQUESTED:
-      state_ = State::CLOSED;
-      Base::onError(
-          std::runtime_error(frame.data_->moveToFbString().toStdString()));
-      connection_->endStream(streamId_, StreamCompletionSignal::ERROR);
-      break;
-    case State::CLOSED:
-      break;
-  }
-}
 }

--- a/src/automata/SubscriptionRequester.cpp
+++ b/src/automata/SubscriptionRequester.cpp
@@ -7,6 +7,42 @@
 
 namespace reactivesocket {
 
+void SubscriptionRequesterBase::onNext(Payload request) {
+  switch (state_) {
+    case State::NEW: {
+      state_ = State::REQUESTED;
+      // FIXME: find a root cause of this assymetry; the problem here is that
+      // the Base::request might be delivered after the whole thing is shut
+      // down, if one uses InlineConnection.
+      size_t initialN = initialResponseAllowance_.drainWithLimit(
+          Frame_REQUEST_N::kMaxRequestN);
+      size_t remainingN = initialResponseAllowance_.drain();
+      // Send as much as possible with the initial request.
+      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
+      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
+      Frame_REQUEST_SUB frame(
+          streamId_,
+          flags,
+          static_cast<uint32_t>(initialN),
+          FrameMetadata::empty(),
+          std::move(request));
+      // We must inform ConsumerMixin about an implicit allowance we have
+      // requested from the remote end.
+      addImplicitAllowance(initialN);
+      connection_->onNextFrame(frame);
+      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
+      // initial request.
+      if (remainingN) {
+        Base::request(remainingN);
+      }
+    } break;
+    case State::REQUESTED:
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
 std::ostream& SubscriptionRequesterBase::logPrefix(std::ostream& os) {
   return os << "SubscriptionRequester(" << &connection_ << ", " << streamId_
             << "): ";

--- a/src/automata/SubscriptionRequester.cpp
+++ b/src/automata/SubscriptionRequester.cpp
@@ -17,9 +17,6 @@ void SubscriptionRequesterBase::sendRequestFrame(
       static_cast<uint32_t>(initialN),
       FrameMetadata::empty(),
       std::move(request));
-  // We must inform ConsumerMixin about an implicit allowance we have
-  // requested from the remote end.
-  addImplicitAllowance(initialN);
   connection_->onNextFrame(frame);
 }
 

--- a/src/automata/SubscriptionRequester.cpp
+++ b/src/automata/SubscriptionRequester.cpp
@@ -7,40 +7,20 @@
 
 namespace reactivesocket {
 
-void SubscriptionRequesterBase::onNext(Payload request) {
-  switch (state_) {
-    case State::NEW: {
-      state_ = State::REQUESTED;
-      // FIXME: find a root cause of this assymetry; the problem here is that
-      // the Base::request might be delivered after the whole thing is shut
-      // down, if one uses InlineConnection.
-      size_t initialN = initialResponseAllowance_.drainWithLimit(
-          Frame_REQUEST_N::kMaxRequestN);
-      size_t remainingN = initialResponseAllowance_.drain();
-      // Send as much as possible with the initial request.
-      CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
-      auto flags = initialN > 0 ? FrameFlags_REQN_PRESENT : FrameFlags_EMPTY;
-      Frame_REQUEST_SUB frame(
-          streamId_,
-          flags,
-          static_cast<uint32_t>(initialN),
-          FrameMetadata::empty(),
-          std::move(request));
-      // We must inform ConsumerMixin about an implicit allowance we have
-      // requested from the remote end.
-      addImplicitAllowance(initialN);
-      connection_->onNextFrame(frame);
-      // Pump the remaining allowance into the ConsumerMixin _after_ sending the
-      // initial request.
-      if (remainingN) {
-        Base::request(remainingN);
-      }
-    } break;
-    case State::REQUESTED:
-      break;
-    case State::CLOSED:
-      break;
-  }
+void SubscriptionRequesterBase::sendRequestFrame(
+    FrameFlags flags,
+    size_t initialN,
+    Payload&& request) {
+  Frame_REQUEST_SUB frame(
+      streamId_,
+      flags,
+      static_cast<uint32_t>(initialN),
+      FrameMetadata::empty(),
+      std::move(request));
+  // We must inform ConsumerMixin about an implicit allowance we have
+  // requested from the remote end.
+  addImplicitAllowance(initialN);
+  connection_->onNextFrame(frame);
 }
 
 std::ostream& SubscriptionRequesterBase::logPrefix(std::ostream& os) {

--- a/src/automata/SubscriptionRequester.h
+++ b/src/automata/SubscriptionRequester.h
@@ -33,10 +33,9 @@ class SubscriptionRequesterBase : public StreamSubscriptionRequesterBase {
  public:
   using Base::Base;
 
-  void onNext(Payload request) override;
-
  protected:
   /// @{
+  void sendRequestFrame(FrameFlags, size_t, Payload&&) override;
   std::ostream& logPrefix(std::ostream& os);
   /// @}
 };

--- a/src/automata/SubscriptionRequester.h
+++ b/src/automata/SubscriptionRequester.h
@@ -27,12 +27,13 @@ namespace reactivesocket {
 enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a Subscription requester.
-class SubscriptionRequesterBase
-    : public StreamSubscriptionRequesterBase<Frame_REQUEST_SUB> {
-  using Base = StreamSubscriptionRequesterBase<Frame_REQUEST_SUB>;
+class SubscriptionRequesterBase : public StreamSubscriptionRequesterBase {
+  using Base = StreamSubscriptionRequesterBase;
 
  public:
   using Base::Base;
+
+  void onNext(Payload request) override;
 
  protected:
   /// @{


### PR DESCRIPTION
Refactor StreamSubscriberRequesterBase to not be a template (reduced code footprint), and instead offer a pure virtual method for onNext() for subclasses to override in order to send the correct frame type.