### PR TITLE
Add support for RequestResponse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
   src/automata/ChannelRequester.h
   src/automata/ChannelResponder.cpp
   src/automata/ChannelResponder.h
+  src/automata/RequestResponseRequester.cpp
   src/automata/StreamSubscriptionRequesterBase.cpp
   src/automata/StreamSubscriptionRequesterBase.h
   src/automata/StreamSubscriptionResponderBase.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ add_library(
   src/automata/ChannelResponder.cpp
   src/automata/ChannelResponder.h
   src/automata/RequestResponseRequester.cpp
+  src/automata/RequestResponseRequester.h
+  src/automata/RequestResponseResponder.cpp
+  src/automata/RequestResponseResponder.h
   src/automata/StreamSubscriptionRequesterBase.cpp
   src/automata/StreamSubscriptionRequesterBase.h
   src/automata/StreamSubscriptionResponderBase.cpp

--- a/TARGETS
+++ b/TARGETS
@@ -39,6 +39,7 @@ cxx_library(
         'src/automata/ChannelRequester.cpp',
         'src/automata/ChannelResponder.cpp',
         'src/automata/RequestResponseRequester.cpp',
+        'src/automata/RequestResponseResponder.cpp',
         'src/automata/StreamSubscriptionRequesterBase.cpp',
         'src/automata/StreamSubscriptionResponderBase.cpp',
         'src/automata/StreamRequester.cpp',

--- a/TARGETS
+++ b/TARGETS
@@ -38,6 +38,7 @@ cxx_library(
         'src/AbstractStreamAutomaton.cpp',
         'src/automata/ChannelRequester.cpp',
         'src/automata/ChannelResponder.cpp',
+        'src/automata/RequestResponseRequester.cpp',
         'src/automata/StreamSubscriptionRequesterBase.cpp',
         'src/automata/StreamSubscriptionResponderBase.cpp',
         'src/automata/StreamRequester.cpp',

--- a/src/AbstractStreamAutomaton.cpp
+++ b/src/AbstractStreamAutomaton.cpp
@@ -47,6 +47,9 @@ void AbstractStreamAutomaton::onNextFrame(
     case FrameType::REQUEST_N:
       deserializeAndDispatch<Frame_REQUEST_N>(std::move(payload));
       return;
+    case FrameType::REQUEST_RESPONSE:
+      deserializeAndDispatch<Frame_REQUEST_RESPONSE>(std::move(payload));
+      return;
     case FrameType::CANCEL:
       deserializeAndDispatch<Frame_CANCEL>(std::move(payload));
       return;

--- a/src/AbstractStreamAutomaton.h
+++ b/src/AbstractStreamAutomaton.h
@@ -17,6 +17,7 @@ class ConnectionAutomaton;
 class Frame_REQUEST_STREAM;
 class Frame_REQUEST_SUB;
 class Frame_REQUEST_CHANNEL;
+class Frame_REQUEST_RESPONSE;
 class Frame_REQUEST_N;
 class Frame_CANCEL;
 class Frame_RESPONSE;
@@ -96,6 +97,7 @@ class AbstractStreamAutomaton {
   virtual void onNextFrame(Frame_REQUEST_SUB&& frame) = 0;
   virtual void onNextFrame(Frame_REQUEST_CHANNEL&& frame) = 0;
   virtual void onNextFrame(Frame_REQUEST_N&& frame) = 0;
+  virtual void onNextFrame(Frame_REQUEST_RESPONSE&& frame) = 0;
   virtual void onNextFrame(Frame_CANCEL&& frame) = 0;
   virtual void onNextFrame(Frame_RESPONSE&& frame) = 0;
   virtual void onNextFrame(Frame_ERROR&& frame) = 0;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -38,7 +38,7 @@ enum class FrameType : uint16_t {
   SETUP = 0x0001,
   LEASE = 0x0002,
   KEEPALIVE = 0x0003,
-  // REQUEST_RESPONSE = 0x0004,
+  REQUEST_RESPONSE = 0x0004,
   REQUEST_FNF = 0x0005,
   REQUEST_STREAM = 0x0006,
   REQUEST_SUB = 0x0007,
@@ -217,6 +217,29 @@ class Frame_REQUEST_CHANNEL : public Frame_REQUEST_Base {
   Frame_REQUEST_CHANNEL(StreamId streamId, FrameFlags flags, Payload payload)
       : Frame_REQUEST_CHANNEL(streamId, flags, 0, std::move(payload)) {}
 };
+
+class Frame_REQUEST_RESPONSE {
+ public:
+  static constexpr bool Trait_CarriesAllowance = false;
+
+  Frame_REQUEST_RESPONSE() = default;
+  Frame_REQUEST_RESPONSE(StreamId streamId, FrameFlags flags, Payload payload)
+      : header_(
+            FrameType::REQUEST_RESPONSE,
+            flags | payload.getFlags(),
+            streamId),
+        payload_(std::move(payload)) {
+    payload_.checkFlags(header_.flags_); // to verify the client didn't set
+    // METADATA and provided none
+  }
+
+  std::unique_ptr<folly::IOBuf> serializeOut();
+  bool deserializeFrom(std::unique_ptr<folly::IOBuf> in);
+
+  FrameHeader header_;
+  Payload payload_;
+};
+std::ostream& operator<<(std::ostream&, const Frame_REQUEST_RESPONSE&);
 
 class Frame_REQUEST_FNF {
  public:

--- a/src/NullRequestHandler.cpp
+++ b/src/NullRequestHandler.cpp
@@ -46,6 +46,13 @@ void NullRequestHandler::handleRequestSubscription(
   response.onError(std::runtime_error("NullRequestHandler"));
 }
 
+void NullRequestHandler::handleRequestResponse(
+    Payload /*request*/,
+    Subscriber<Payload>& response) {
+  response.onSubscribe(createManagedInstance<NullSubscription>());
+  response.onError(std::runtime_error("NullRequestHandler"));
+}
+
 void NullRequestHandler::handleFireAndForgetRequest(Payload /*request*/) {}
 
 void NullRequestHandler::handleMetadataPush(

--- a/src/NullRequestHandler.h
+++ b/src/NullRequestHandler.h
@@ -35,6 +35,9 @@ class NullRequestHandler : public RequestHandler {
   void handleRequestSubscription(Payload request, Subscriber<Payload>& response)
       override;
 
+  void handleRequestResponse(Payload request, Subscriber<Payload>& response)
+      override;
+
   void handleFireAndForgetRequest(Payload request) override;
 
   void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override;

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -78,6 +78,8 @@ class ReactiveSocket {
 
   void requestFireAndForget(Payload request);
 
+  void requestResponse(Payload payload, Subscriber<Payload>& responseSink);
+
   void close();
 
   void onClose(CloseListener listener);

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -30,6 +30,11 @@ class RequestHandler {
       Payload request,
       Subscriber<Payload>& response) = 0;
 
+  /// Handles a new inbound RequestResponse requested by the other end.
+  virtual void handleRequestResponse(
+      Payload request,
+      Subscriber<Payload>& response) = 0;
+
   /// Handles a new fire-and-forget request sent by the other end.
   virtual void handleFireAndForgetRequest(Payload request) = 0;
 

--- a/src/automata/RequestResponseRequester.cpp
+++ b/src/automata/RequestResponseRequester.cpp
@@ -12,8 +12,6 @@ void RequestResponseRequesterBase::subscribe(Subscriber<Payload>& subscriber) {
   // FIXME
   // Subscriber::onSubscribe is delivered externally, as it may attempt to
   // synchronously deliver Subscriber::request.
-  // Q: why do we want to avoid Subscriber::request being delivered
-  // synchronously?
 }
 
 void RequestResponseRequesterBase::onNext(Payload request) {
@@ -26,6 +24,8 @@ void RequestResponseRequesterBase::onNext(Payload request) {
       break;
     }
     case State::REQUESTED:
+      // Cannot receive a request payload twice.
+      CHECK(false);
       break;
     case State::CLOSED:
       break;
@@ -68,8 +68,6 @@ void RequestResponseRequesterBase::endStream(StreamCompletionSignal signal) {
     case State::CLOSED:
       break;
   }
-  // Q: don't really understand what the comment below means or if it applies
-  // in this case as well?
   // FIXME: switch on signal and verify that callsites propagate stream errors
   consumingSubscriber_.onComplete();
 }

--- a/src/automata/RequestResponseRequester.cpp
+++ b/src/automata/RequestResponseRequester.cpp
@@ -1,0 +1,125 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "RequestResponseRequester.h"
+
+#include <iostream>
+
+namespace reactivesocket {
+
+void RequestResponseRequesterBase::subscribe(Subscriber<Payload>& subscriber) {
+  DCHECK(!consumingSubscriber_);
+  consumingSubscriber_.reset(&subscriber);
+  // FIXME
+  // Subscriber::onSubscribe is delivered externally, as it may attempt to
+  // synchronously deliver Subscriber::request.
+  // Q: why do we want to avoid Subscriber::request being delivered
+  // synchronously?
+}
+
+void RequestResponseRequesterBase::onNext(Payload request) {
+  switch (state_) {
+    case State::NEW: {
+      state_ = State::REQUESTED;
+      Frame_REQUEST_RESPONSE frame(
+          streamId_, FrameFlags_EMPTY, std::move(std::move(request)));
+      connection_->outputFrameOrEnqueue(frame.serializeOut());
+      break;
+    }
+    case State::REQUESTED:
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void RequestResponseRequesterBase::request(size_t n) {
+  if (payload_) {
+    consumingSubscriber_.onNext(std::move(payload_.value()));
+    payload_.clear();
+  } else {
+    waitingForPayload_ = true;
+  }
+}
+
+void RequestResponseRequesterBase::cancel() {
+  switch (state_) {
+    case State::NEW:
+      state_ = State::CLOSED;
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+      break;
+    case State::REQUESTED: {
+      state_ = State::CLOSED;
+      connection_->outputFrameOrEnqueue(Frame_CANCEL(streamId_).serializeOut());
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+    } break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void RequestResponseRequesterBase::endStream(StreamCompletionSignal signal) {
+  switch (state_) {
+    case State::NEW:
+    case State::REQUESTED:
+      // Spontaneous ::endStream signal means an error.
+      DCHECK(StreamCompletionSignal::GRACEFUL != signal);
+      state_ = State::CLOSED;
+      break;
+    case State::CLOSED:
+      break;
+  }
+  // Q: don't really understand what the comment below means or if it applies
+  // in this case as well?
+  // FIXME: switch on signal and verify that callsites propagate stream errors
+  consumingSubscriber_.onComplete();
+}
+
+void RequestResponseRequesterBase::onNextFrame(Frame_ERROR&& frame) {
+  switch (state_) {
+    case State::NEW:
+      // Cannot receive a frame before sending the initial request.
+      CHECK(false);
+      break;
+    case State::REQUESTED:
+      state_ = State::CLOSED;
+      consumingSubscriber_.onError(
+          std::runtime_error(frame.payload_.moveDataToString()));
+      connection_->endStream(streamId_, StreamCompletionSignal::ERROR);
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void RequestResponseRequesterBase::onNextFrame(Frame_RESPONSE&& frame) {
+  bool end = false;
+  switch (state_) {
+    case State::NEW:
+      // Cannot receive a frame before sending the initial request.
+      CHECK(false);
+      break;
+    case State::REQUESTED:
+      if (frame.header_.flags_ & FrameFlags_COMPLETE) {
+        state_ = State::CLOSED;
+        end = true;
+      }
+      break;
+    case State::CLOSED:
+      break;
+  }
+  if (waitingForPayload_) {
+    consumingSubscriber_.onNext(std::move(frame.payload_));
+  } else {
+    payload_.assign(std::move(frame.payload_));
+  }
+
+  if (end) {
+    connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+  }
+}
+
+std::ostream& RequestResponseRequesterBase::logPrefix(std::ostream& os) {
+  return os << " RequestResponseRequester(" << &connection_ << ", " << streamId_
+            << "): ";
+}
+}

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -1,0 +1,80 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <iosfwd>
+#include <folly/Optional.h>
+
+#include <reactive-streams/utilities/SmartPointers.h>
+#include "src/Frame.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+#include "src/mixins/ExecutorMixin.h"
+#include "src/mixins/LoggingMixin.h"
+#include "src/mixins/MemoryMixin.h"
+#include "src/mixins/MixinTerminator.h"
+#include "src/mixins/SourceIfMixin.h"
+#include "src/mixins/StreamIfMixin.h"
+
+namespace folly {
+class exception_wrapper;
+}
+
+namespace reactivesocket {
+
+enum class StreamCompletionSignal;
+
+/// Implementation of stream automaton that represents a RequestResponse
+/// requester
+class RequestResponseRequesterBase : public MixinTerminator {
+
+ public:
+  using MixinTerminator::MixinTerminator;
+
+  /// Degenerate form of the Subscriber interface -- only one request payload
+  /// will be sent to the server.
+  void onNext(Payload);
+
+  /// @{
+  void subscribe(Subscriber<Payload>& subscriber);
+  void request(size_t);
+  void cancel();
+  /// @}
+
+ protected:
+  /// @{
+  void endStream(StreamCompletionSignal signal);
+
+  /// Not all frames are intercepted, some just pass through.
+  using MixinTerminator::onNextFrame;
+
+  void onNextFrame(Frame_RESPONSE&&);
+  void onNextFrame(Frame_ERROR&&);
+
+  void onError(folly::exception_wrapper ex);
+
+  std::ostream& logPrefix(std::ostream& os);
+  /// @}
+
+  /// State of the Subscription requester.
+  enum class State : uint8_t {
+    NEW,
+    REQUESTED,
+    CLOSED,
+  } state_{State::NEW};
+
+  // Whether the Subscriber made the request(1) call and thus is
+  // ready to accept the payload.
+  bool waitingForPayload_{false};
+  folly::Optional<Payload> payload_;
+
+  /// A Subscriber that will consume payloads.
+  /// This mixin is responsible for delivering a terminal signal to the
+  /// Subscriber once the stream ends.
+  reactivestreams::SubscriberPtr<Subscriber<Payload>> consumingSubscriber_;
+};
+
+using RequestResponseRequester = SourceIfMixin <
+    StreamIfMixin<LoggingMixin<ExecutorMixin<LoggingMixin<
+        MemoryMixin<LoggingMixin<RequestResponseRequesterBase>>>>>>>;
+}

--- a/src/automata/RequestResponseResponder.cpp
+++ b/src/automata/RequestResponseResponder.cpp
@@ -1,0 +1,82 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "RequestResponseResponder.h"
+
+#include "src/ConnectionAutomaton.h"
+#include "src/Frame.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+
+namespace reactivesocket {
+
+void RequestResponseResponderBase::onNext(Payload response) {
+  switch (state_) {
+    case State::RESPONDING: {
+      state_ = State::CLOSED;
+      Base::onNext(std::move(response), FrameFlags_COMPLETE);
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+      break;
+    }
+    case State::CLOSED:
+      break;
+  }
+}
+
+void RequestResponseResponderBase::onComplete() {
+  switch (state_) {
+    case State::RESPONDING: {
+      state_ = State::CLOSED;
+      connection_->outputFrameOrEnqueue(
+          Frame_RESPONSE::complete(streamId_).serializeOut());
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+    } break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+
+void RequestResponseResponderBase::onError(folly::exception_wrapper ex) {
+  switch (state_) {
+    case State::RESPONDING: {
+      state_ = State::CLOSED;
+      auto msg = ex.what().toStdString();
+      connection_->outputFrameOrEnqueue(
+          Frame_ERROR::applicationError(streamId_, msg).serializeOut());
+      connection_->endStream(streamId_, StreamCompletionSignal::ERROR);
+    } break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+void RequestResponseResponderBase::endStream(StreamCompletionSignal signal) {
+  switch (state_) {
+    case State::RESPONDING:
+      // Spontaneous ::endStream signal means an error.
+      DCHECK(StreamCompletionSignal::GRACEFUL != signal);
+      state_ = State::CLOSED;
+      break;
+    case State::CLOSED:
+      break;
+  }
+  Base::endStream(signal);
+}
+
+void RequestResponseResponderBase::onNextFrame(Frame_CANCEL&& frame) {
+  switch (state_) {
+    case State::RESPONDING:
+      state_ = State::CLOSED;
+      connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
+      break;
+    case State::CLOSED:
+      break;
+  }
+}
+
+std::ostream& RequestResponseResponderBase::logPrefix(std::ostream& os) {
+  return os << "RequestResponseResponder(" << &connection_ << ", "
+            << streamId_ << "): ";
+}
+
+}

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -1,0 +1,50 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <iosfwd>
+
+#include "reactive-streams/utilities/SmartPointers.h"
+#include "src/Frame.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+#include "src/automata/StreamSubscriptionResponderBase.h"
+#include "src/mixins/ExecutorMixin.h"
+#include "src/mixins/LoggingMixin.h"
+#include "src/mixins/MemoryMixin.h"
+#include "src/mixins/SinkIfMixin.h"
+#include "src/mixins/StreamIfMixin.h"
+
+namespace folly {
+class exception_wrapper;
+}
+
+namespace reactivesocket {
+
+enum class StreamCompletionSignal;
+
+/// Implementation of stream automaton that represents a RequestResponse
+/// responder
+class RequestResponseResponderBase : public StreamSubscriptionResponderBase {
+  using Base = StreamSubscriptionResponderBase;
+
+ public:
+  using Base::Base;
+
+ protected:
+  /// @{
+
+  /// Don't need to intercept any frames, let them pass through.
+  using Base::onNextFrame;
+
+  std::ostream& logPrefix(std::ostream& os) {
+    return os << "RequestResponseResponder(" << &connection_ << ", "
+              << streamId_ << "): ";
+  }
+  /// @}
+};
+
+using RequestResponseResponder =
+    SinkIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<LoggingMixin<
+        MemoryMixin<LoggingMixin<RequestResponseResponderBase>>>>>>>;
+}

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -8,10 +8,11 @@
 #include "src/Frame.h"
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
-#include "src/automata/StreamSubscriptionResponderBase.h"
 #include "src/mixins/ExecutorMixin.h"
 #include "src/mixins/LoggingMixin.h"
 #include "src/mixins/MemoryMixin.h"
+#include "src/mixins/MixinTerminator.h"
+#include "src/mixins/PublisherMixin.h"
 #include "src/mixins/SinkIfMixin.h"
 #include "src/mixins/StreamIfMixin.h"
 
@@ -25,24 +26,41 @@ enum class StreamCompletionSignal;
 
 /// Implementation of stream automaton that represents a RequestResponse
 /// responder
-class RequestResponseResponderBase : public StreamSubscriptionResponderBase {
-  using Base = StreamSubscriptionResponderBase;
+class RequestResponseResponderBase
+    : public LoggingMixin<PublisherMixin<Frame_RESPONSE, MixinTerminator>> {
+  using Base =  LoggingMixin<PublisherMixin<Frame_RESPONSE, MixinTerminator>>;
 
  public:
   using Base::Base;
 
+  /// @{
+  /// A Subscriber implementation exposed to the user of ReactiveSocket to
+  /// receive "response" payloads.
+  void onNext(Payload);
+
+  void onComplete();
+
+  void onError(folly::exception_wrapper);
+  /// @}
+
  protected:
   /// @{
+  void endStream(StreamCompletionSignal);
 
-  /// Don't need to intercept any frames, let them pass through.
+  /// Not all frames are intercepted, some just pass through.
   using Base::onNextFrame;
 
-  std::ostream& logPrefix(std::ostream& os) {
-    return os << "RequestResponseResponder(" << &connection_ << ", "
-              << streamId_ << "): ";
-  }
+  void onNextFrame(Frame_CANCEL&&);
+
+  std::ostream& logPrefix(std::ostream& os);
   /// @}
-};
+
+  /// State of the Subscription responder.
+  enum class State : uint8_t {
+    RESPONDING,
+    CLOSED,
+  } state_{State::RESPONDING};
+ };
 
 using RequestResponseResponder =
     SinkIfMixin<StreamIfMixin<LoggingMixin<ExecutorMixin<LoggingMixin<

--- a/src/mixins/LoggingMixin.h
+++ b/src/mixins/LoggingMixin.h
@@ -69,6 +69,11 @@ class LoggingMixin : public Base {
     Base::onNext(std::move(payload));
   }
 
+  void onNext(Payload payload, FrameFlags flags) {
+    Base::logPrefix(LOG(INFO)) << "onNext(" << payload << ", " << flags << ")";
+    Base::onNext(std::move(payload), flags);
+  }
+
   void onComplete() {
     Base::logPrefix(LOG(INFO)) << "onComplete()";
     Base::onComplete();

--- a/src/mixins/MixinTerminator.h
+++ b/src/mixins/MixinTerminator.h
@@ -60,6 +60,8 @@ class MixinTerminator
 
   void onNextFrame(Frame_REQUEST_CHANNEL&&) {}
 
+  void onNextFrame(Frame_REQUEST_RESPONSE&&) {}
+
   void onNextFrame(Frame_REQUEST_N&&) {}
 
   void onNextFrame(Frame_CANCEL&&) {}

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -53,6 +53,11 @@ class PublisherMixin : public Base {
     Base::onNextFrame(std::move(frame));
   }
 
+  void onNextFrame(Frame_REQUEST_RESPONSE&& frame) {
+    producingSubscription_.request(1);
+    Base::onNextFrame(std::move(frame));
+  }
+
   /// Remaining frames just pass through.
   template <typename Frame>
   typename std::enable_if<!Frame::Trait_CarriesAllowance>::type onNextFrame(

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -29,8 +29,8 @@ class PublisherMixin : public Base {
     producingSubscription_.reset(&subscription);
   }
 
-  void onNext(Payload payload) {
-    ProducedFrame frame(Base::streamId_, FrameFlags_EMPTY, std::move(payload));
+  void onNext(Payload payload, FrameFlags flags = FrameFlags_EMPTY) {
+    ProducedFrame frame(Base::streamId_, flags, std::move(payload));
     Base::connection_->outputFrameOrEnqueue(frame.serializeOut());
   }
   /// @}

--- a/src/mixins/StreamIfMixin.h
+++ b/src/mixins/StreamIfMixin.h
@@ -33,6 +33,9 @@ class StreamIfMixin : public Base, public AbstractStreamAutomaton {
   void onNextFrame(Frame_REQUEST_CHANNEL&& frame) override final {
     Base::onNextFrame(std::move(frame));
   }
+  void onNextFrame(Frame_REQUEST_RESPONSE&& frame) override final {
+    Base::onNextFrame(std::move(frame));
+  }
   void onNextFrame(Frame_REQUEST_N&& frame) override final {
     Base::onNextFrame(std::move(frame));
   }

--- a/test/FrameTest.cpp
+++ b/test/FrameTest.cpp
@@ -205,6 +205,19 @@ TEST_F(FrameTest, Frame_LEASE) {
   EXPECT_EQ(numberOfRequests, frame.numberOfRequests_);
 }
 
+TEST_F(FrameTest, Frame_REQUEST_RESPONSE) {
+  uint32_t streamId = 42;
+  FrameFlags flags = FrameFlags_METADATA;
+  auto metadata = folly::IOBuf::copyBuffer("i'm so meta even this acronym");
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize<Frame_REQUEST_RESPONSE>(
+      streamId, flags, Payload(data->clone(), metadata->clone()));
+
+  expectHeader(FrameType::REQUEST_RESPONSE, flags, streamId, frame);
+  EXPECT_TRUE(folly::IOBufEqual()(*metadata, *frame.payload_.metadata));
+  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.payload_.data));
+}
+
 TEST_F(FrameTest, Frame_REQUEST_FNF) {
   uint32_t streamId = 42;
   FrameFlags flags = FrameFlags_METADATA;

--- a/test/MockRequestHandler.h
+++ b/test/MockRequestHandler.h
@@ -22,6 +22,9 @@ class MockRequestHandler : public RequestHandler {
   MOCK_METHOD2(
       handleRequestSubscription_,
       void(Payload& request, Subscriber<Payload>*));
+  MOCK_METHOD2(
+      handleRequestResponse_,
+      void(Payload& request, Subscriber<Payload>*));
   MOCK_METHOD1(handleFireAndForgetRequest_, void(Payload& request));
   MOCK_METHOD1(
       handleMetadataPush_,
@@ -42,6 +45,11 @@ class MockRequestHandler : public RequestHandler {
   void handleRequestSubscription(Payload request, Subscriber<Payload>& response)
       override {
     handleRequestSubscription_(request, &response);
+  }
+
+  void handleRequestResponse(Payload request, Subscriber<Payload>& response)
+      override {
+    handleRequestResponse_(request, &response);
   }
 
   void handleFireAndForgetRequest(Payload request) override {

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -389,6 +389,70 @@ TEST(ReactiveSocketTest, RequestSubscription) {
       Payload(originalPayload->clone()), clientInput);
 }
 
+TEST(ReactiveSocketTest, RequestResponse) {
+  // InlineConnection forwards appropriate calls in-line, hence the order of
+  // mock calls will be deterministic.
+  Sequence s;
+
+  auto clientConn = folly::make_unique<InlineConnection>();
+  auto serverConn = folly::make_unique<InlineConnection>();
+  clientConn->connectTo(*serverConn);
+
+  StrictMock<UnmanagedMockSubscriber<Payload>> clientInput;
+  StrictMock<UnmanagedMockSubscription> serverOutputSub;
+  Subscription* clientInputSub = nullptr;
+  Subscriber<Payload>* serverOutput = nullptr;
+
+  auto clientSock = ReactiveSocket::fromClientConnection(
+      std::move(clientConn),
+      // No interactions on this mock, the client will not accept any requests.
+      folly::make_unique<StrictMock<MockRequestHandler>>());
+
+  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto& serverHandlerRef = *serverHandler;
+  auto serverSock = ReactiveSocket::fromServerConnection(
+      std::move(serverConn), std::move(serverHandler));
+
+  const auto originalPayload = folly::IOBuf::copyBuffer("foo");
+
+  // Client creates a subscription.
+  EXPECT_CALL(clientInput, onSubscribe_(_))
+      .InSequence(s)
+      .WillOnce(Invoke([&](Subscription* sub) {
+        clientInputSub = sub;
+        // Request payload immediately.
+        clientInputSub->request(1);
+      }));
+
+  // The request reaches the other end and triggers new responder to be set up.
+  EXPECT_CALL(
+      serverHandlerRef, handleRequestResponse_(Equals(&originalPayload), _))
+      .InSequence(s)
+      .WillOnce(Invoke([&](Payload& request, Subscriber<Payload>* response) {
+        serverOutput = response;
+        serverOutput->onSubscribe(serverOutputSub);
+      }));
+
+  EXPECT_CALL(serverOutputSub, request_(_))
+      .InSequence(s)
+      // The server deliver the response immediately.
+      .WillOnce(Invoke([&](size_t) {
+        serverOutput->onNext(Payload(originalPayload->clone()));
+      }));
+
+  // Client receives the only payload and closes the subscription in response.
+  EXPECT_CALL(clientInput, onNext_(Equals(&originalPayload)))
+      .InSequence(s)
+      .WillOnce(Invoke([&](Payload&) { clientInputSub->cancel(); }));
+
+  EXPECT_CALL(serverOutputSub, cancel_()).InSequence(s).WillOnce(Invoke([&]() {
+    serverOutput->onComplete();
+  }));
+  EXPECT_CALL(clientInput, onComplete_()).InSequence(s);
+
+  // Kick off the magic.
+  clientSock->requestResponse(Payload(originalPayload->clone()), clientInput);
+}
 TEST(ReactiveSocketTest, RequestFireAndForget) {
   // InlineConnection forwards appropriate calls in-line, hence the order of
   // mock calls will be deterministic.

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -410,6 +410,9 @@ TEST(ReactiveSocketTest, RequestResponse) {
 
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
+
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
 

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -447,11 +447,13 @@ TEST(ReactiveSocketTest, RequestResponse) {
   EXPECT_CALL(clientInput, onNext_(Equals(&originalPayload)))
       .InSequence(s)
       .WillOnce(Invoke([&](Payload&) { clientInputSub->cancel(); }));
+  // Client also receives onComplete() call since the response frame received
+  // had COMPELTE flag set
+  EXPECT_CALL(clientInput, onComplete_()).InSequence(s);
 
   EXPECT_CALL(serverOutputSub, cancel_()).InSequence(s).WillOnce(Invoke([&]() {
     serverOutput->onComplete();
   }));
-  EXPECT_CALL(clientInput, onComplete_()).InSequence(s);
 
   // Kick off the magic.
   clientSock->requestResponse(Payload(originalPayload->clone()), clientInput);


### PR DESCRIPTION
Summary:
A REQUEST_RESPONSE frame is sent when subscriber calls ReactiveSocket::requestResponse(), and the response payload is delivered back to the subscriber only after it requests it with a request() call.
We send back one single frames from the publisher to the subscriber, containing the payload and also the COMPLETE flag;

Test Plan:
Added ReactiveSocket test.

Also tested java subscriber -> C++ publisher with:
publisher: ./tcpServer
subscriber: reactivesocket-cli --rr -i Hello tcp://localhost:9898