### PR TITLE
Get createManagedInstance to work with Subscriber<T> where T != Payload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(Threads)
 
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Werror -Woverloaded-virtual")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -momit-leaf-frame-pointer")
 
 # Configuration for Debug build mode.
@@ -288,5 +288,19 @@ target_link_libraries(
         ${CMAKE_THREAD_LIBS_INIT})
 
 add_dependencies(tcpresumeserver gmock)
+
+add_executable(
+        subscriber_non_payload
+	test/simple/SubscriberNonPayloadTest.cpp
+)
+
+target_link_libraries(
+        subscriber_non_payload
+        ReactiveSocket
+        ${FOLLY_LIBRARIES}
+        ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_dependencies(subscriber_non_payload ReactiveSocket ReactiveStreams)
 
 # EOF

--- a/src/mixins/MemoryMixin.h
+++ b/src/mixins/MemoryMixin.h
@@ -30,7 +30,7 @@ namespace reactivesocket {
 /// implicitly specified as virtual, depending on whether the Base class
 /// is implementing the (virtual) methods of the
 /// Subscription or the Subscriber interface.
-template <typename Base>
+template <typename Base, typename Payload = Payload>
 class MemoryMixin : public Base {
   static_assert(
       std::is_base_of<IntrusiveDeleter, Base>::value,
@@ -126,10 +126,11 @@ class WithIntrusiveDeleter {
 
 } // namespace details
 
-template <typename Base, typename... TArgs>
+template <typename Base, typename Payload = Payload, typename... TArgs>
 Base& createManagedInstance(TArgs&&... args) {
   auto* instance =
-      new MemoryMixin<typename details::WithIntrusiveDeleter<Base>::T>(
+      new MemoryMixin<typename details::WithIntrusiveDeleter<Base>::T,
+                      Payload>(
           std::forward<TArgs>(args)...);
   return *instance;
 }

--- a/src/mixins/MemoryMixin.h
+++ b/src/mixins/MemoryMixin.h
@@ -30,7 +30,7 @@ namespace reactivesocket {
 /// implicitly specified as virtual, depending on whether the Base class
 /// is implementing the (virtual) methods of the
 /// Subscription or the Subscriber interface.
-template <typename Base, typename Payload = Payload>
+template <typename Base, typename T = Payload>
 class MemoryMixin : public Base {
   static_assert(
       std::is_base_of<IntrusiveDeleter, Base>::value,
@@ -42,8 +42,8 @@ class MemoryMixin : public Base {
   ~MemoryMixin() {}
 
   /// @{
-  /// Publisher<Payload>
-  void subscribe(Subscriber<Payload>& subscriber) {
+  /// Publisher<T>
+  void subscribe(Subscriber<T>& subscriber) {
     Base::incrementRefCount();
     Base::subscribe(subscriber);
   }
@@ -62,13 +62,13 @@ class MemoryMixin : public Base {
   /// @}
 
   /// @{
-  /// Subscriber<Payload>
+  /// Subscriber<T>
   void onSubscribe(Subscription& subscription) {
     Base::incrementRefCount();
     Base::onSubscribe(subscription);
   }
 
-  void onNext(Payload payload) {
+  void onNext(T payload) {
     Base::onNext(std::move(payload));
   }
 
@@ -126,11 +126,10 @@ class WithIntrusiveDeleter {
 
 } // namespace details
 
-template <typename Base, typename Payload = Payload, typename... TArgs>
+template <typename Base, typename T = Payload, typename... TArgs>
 Base& createManagedInstance(TArgs&&... args) {
   auto* instance =
-      new MemoryMixin<typename details::WithIntrusiveDeleter<Base>::T,
-                      Payload>(
+      new MemoryMixin<typename details::WithIntrusiveDeleter<Base>::T, T>(
           std::forward<TArgs>(args)...);
   return *instance;
 }

--- a/test/simple/SubscriberNonPayloadTest.cpp
+++ b/test/simple/SubscriberNonPayloadTest.cpp
@@ -24,7 +24,7 @@ class FooSubscriber : public IntrusiveDeleter, public Subscriber<Foo> {
 };
 
 int main(int argc, char** argv) {
-auto& m = createManagedInstance<FooSubscriber, Foo>();
+  auto& m = createManagedInstance<FooSubscriber, Foo>();
   m.onNext(Foo("asdf"));
   return 0;
 }

--- a/test/simple/SubscriberNonPayloadTest.cpp
+++ b/test/simple/SubscriberNonPayloadTest.cpp
@@ -1,0 +1,30 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <stddef.h>
+
+#include "src/ReactiveStreamsCompat.h"
+#include "src/Payload.h"
+#include "src/mixins/IntrusiveDeleter.h"
+#include "src/mixins/MemoryMixin.h"
+
+using namespace reactivesocket;
+
+class Foo {
+ public:
+  explicit Foo(const std::string&) {}
+ };
+
+class FooSubscriber : public IntrusiveDeleter, public Subscriber<Foo> {
+ public:
+  ~FooSubscriber() override = default;
+  void onSubscribe(Subscription&) override {}
+  void onNext(Foo) override {}
+  void onComplete() override {}
+  void onError(folly::exception_wrapper) override {}
+};
+
+int main(int argc, char** argv) {
+auto& m = createManagedInstance<FooSubscriber, Foo>();
+  m.onNext(Foo("asdf"));
+  return 0;
+}


### PR DESCRIPTION
With -Werror and -Woverloaded-virtual, we cannot use `createManagedInstance` with a `Subscriber<T>` where `T != Payload`.

test/simple/SubscriberNonPayloadTest.cpp will fail without the changes to MemoryMixin.h

Other mixins also refer to Payload directly, but I can fix those up in subsequent diffs.