### PR TITLE
createManagedInstance causes Subscriber to be leaked.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,4 +289,18 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
+add_executable(
+  leaked_subscriber
+  test/simple/LeakedSubscriber.cpp
+  )
+
+target_link_libraries(
+  leaked_subscriber
+  ReactiveSocket
+  ${FOLLY_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+  )
+
+add_dependencies(leaked_subscriber ReactiveSocket ReactiveStreams)
+
 # EOF

--- a/test/simple/LeakedSubscriber.cpp
+++ b/test/simple/LeakedSubscriber.cpp
@@ -1,0 +1,23 @@
+#include <stddef.h>
+
+#include "src/ReactiveStreamsCompat.h"
+#include "src/Payload.h"
+#include "src/mixins/IntrusiveDeleter.h"
+#include "src/mixins/MemoryMixin.h"
+
+using namespace reactivesocket;
+
+class FooSubscriber : public IntrusiveDeleter, public Subscriber<Payload> {
+public:
+  ~FooSubscriber() override = default;
+  void onSubscribe(Subscription&) override {}
+  void onNext(Payload) override {}
+  void onComplete() override {}
+  void onError(folly::exception_wrapper) override {}
+};
+
+int main(int argc, char** argv) {
+  auto& m = createManagedInstance<FooSubscriber>();
+  m.onNext(Payload("asdf"));
+  return 0;
+}


### PR DESCRIPTION
This is a very simple test binary.  It just creates a Subscriber using `createManagedInstance`.  This instance appears to be leaked when I build and run it with

> cmake ../ -DCMAKE_BUILD_TYPE=DEBUG && make

```
$ ./leaked_subscriber

=================================================================
==9764==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f37b1362532 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x99532)
        #1 0x40a010 in FooSubscriber& reactivesocket::createManagedInstance<FooSubscriber>() (/home/maxwellsayles/github/reactivesocket-cpp/build/leaked_subscriber+0x40a010)
	    #2 0x409362 in main /home/maxwellsayles/github/reactivesocket-cpp/test/simple/LeakedSubscriber.cpp:20
	        #3 0x7f37b01cd82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

SUMMARY: AddressSanitizer: 24 byte(s) leaked in 1 allocation(s).
```

I'm probably doing it wrong though.