### PR TITLE
Use VLOG in LoggingMixin

### DIFF
--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -58,6 +58,8 @@ class ChannelRequesterBase
   void cancel();
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal);
@@ -68,8 +70,6 @@ class ChannelRequesterBase
   void onNextFrame(Frame_RESPONSE&&);
 
   void onNextFrame(Frame_ERROR&&);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
  private:

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -57,6 +57,8 @@ class ChannelResponderBase
   void cancel();
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal);
@@ -67,8 +69,6 @@ class ChannelResponderBase
   void onNextFrame(Frame_REQUEST_CHANNEL&&);
 
   void onNextFrame(Frame_CANCEL&&);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
  private:

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -40,6 +40,8 @@ class RequestResponseRequesterBase : public MixinTerminator {
   void cancel();
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal signal);
@@ -51,8 +53,6 @@ class RequestResponseRequesterBase : public MixinTerminator {
   void onNextFrame(Frame_ERROR&&);
 
   void onError(folly::exception_wrapper ex);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
   /// State of the Subscription requester.

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -43,6 +43,8 @@ class RequestResponseResponderBase
   void onError(folly::exception_wrapper);
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal);
@@ -51,8 +53,6 @@ class RequestResponseResponderBase
   using Base::onNextFrame;
 
   void onNextFrame(Frame_CANCEL&&);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
   /// State of the Subscription responder.

--- a/src/automata/StreamRequester.h
+++ b/src/automata/StreamRequester.h
@@ -32,10 +32,11 @@ class StreamRequesterBase : public StreamSubscriptionRequesterBase {
  public:
   using Base::Base;
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void sendRequestFrame(FrameFlags, size_t, Payload&&) override;
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 };
 

--- a/src/automata/StreamResponder.h
+++ b/src/automata/StreamResponder.h
@@ -20,7 +20,6 @@ class StreamResponderBase : public StreamSubscriptionResponderBase {
  public:
   using Base::Base;
 
- protected:
   std::ostream& logPrefix(std::ostream& os) {
     return os << "StreamResponder(" << &connection_ << ", " << streamId_
               << "): ";

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -45,6 +45,8 @@ class StreamSubscriptionRequesterBase
   void cancel();
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// Override in subclass to send the correct type of request frame
   virtual void sendRequestFrame(FrameFlags, size_t, Payload&&) = 0;
@@ -58,8 +60,6 @@ class StreamSubscriptionRequesterBase
   void onNextFrame(Frame_RESPONSE&&);
 
   void onNextFrame(Frame_ERROR&&);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
   /// State of the Subscription requester.

--- a/src/automata/StreamSubscriptionResponderBase.h
+++ b/src/automata/StreamSubscriptionResponderBase.h
@@ -45,6 +45,8 @@ class StreamSubscriptionResponderBase
   void onError(folly::exception_wrapper);
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal);
@@ -53,8 +55,6 @@ class StreamSubscriptionResponderBase
   using Base::onNextFrame;
 
   void onNextFrame(Frame_CANCEL&&);
-
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 
   /// State of the Subscription responder.

--- a/src/automata/SubscriptionRequester.h
+++ b/src/automata/SubscriptionRequester.h
@@ -33,10 +33,11 @@ class SubscriptionRequesterBase : public StreamSubscriptionRequesterBase {
  public:
   using Base::Base;
 
+  std::ostream& logPrefix(std::ostream& os);
+
  protected:
   /// @{
   void sendRequestFrame(FrameFlags, size_t, Payload&&) override;
-  std::ostream& logPrefix(std::ostream& os);
   /// @}
 };
 

--- a/src/automata/SubscriptionResponder.h
+++ b/src/automata/SubscriptionResponder.h
@@ -20,7 +20,6 @@ class SubscriptionResponderBase : public StreamSubscriptionResponderBase {
  public:
   using Base::Base;
 
- protected:
   std::ostream& logPrefix(std::ostream& os) {
     return os << "SubscriptionResponder(" << &connection_ << ", " << streamId_
               << "): ";

--- a/src/mixins/ConsumerMixin.h
+++ b/src/mixins/ConsumerMixin.h
@@ -45,6 +45,11 @@ class ConsumerMixin : public Base {
   }
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os) {
+    return os << "ConsumerMixin(" << &this->connection_ << ", "
+              << this->streamId_ << "): ";
+  }
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal signal) {
@@ -66,11 +71,6 @@ class ConsumerMixin : public Base {
 
   void onError(folly::exception_wrapper ex);
   /// @}
-
-  std::ostream& logPrefix(std::ostream& os) {
-    return os << "ConsumerMixin(" << &this->connection_ << ", "
-              << this->streamId_ << "): ";
-  }
 
  private:
   void sendRequests();

--- a/src/mixins/ExecutorMixin.h
+++ b/src/mixins/ExecutorMixin.h
@@ -97,6 +97,11 @@ class ExecutorMixin : public Base {
   }
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os) {
+    return os << "ExecutorMixin(" << &this->connection_ << ", "
+              << this->streamId_ << "): ";
+  }
+
  protected:
   /// @{
   template <typename Frame>
@@ -108,11 +113,6 @@ class ExecutorMixin : public Base {
     Base::onBadFrame();
   }
   /// @}
-
-  std::ostream& logPrefix(std::ostream& os) {
-    return os << "ExecutorMixin(" << &this->connection_ << ", "
-              << this->streamId_ << "): ";
-  }
 
  private:
   template <typename F>

--- a/src/mixins/LoggingMixin.h
+++ b/src/mixins/LoggingMixin.h
@@ -33,13 +33,13 @@ class LoggingMixin : public Base {
   using Base::Base;
 
   ~LoggingMixin() {
-    Base::logPrefix(LOG(INFO)) << "destroyed";
+    VLOG(6) << *this << "destroyed";
   }
 
   /// @{
   /// Publisher<Payload>
   void subscribe(Subscriber<Payload>& subscriber) {
-    Base::logPrefix(LOG(INFO)) << "subscribe(" << &subscriber << ")";
+    VLOG(6) << *this << "subscribe(" << &subscriber << ")";
     Base::subscribe(subscriber);
   }
   /// @}
@@ -47,12 +47,12 @@ class LoggingMixin : public Base {
   /// @{
   /// Subscription
   void request(size_t n) {
-    Base::logPrefix(LOG(INFO)) << "request(" << n << ")";
+    VLOG(7) << *this << "request(" << n << ")";
     Base::request(n);
   }
 
   void cancel() {
-    Base::logPrefix(LOG(INFO)) << "cancel()";
+    VLOG(6) << *this << "cancel()";
     Base::cancel();
   }
   /// @}
@@ -60,22 +60,22 @@ class LoggingMixin : public Base {
   /// @{
   /// Subscriber<Payload>
   void onSubscribe(Subscription& subscription) {
-    Base::logPrefix(LOG(INFO)) << "onSubscribe(" << &subscription << ")";
+    VLOG(6) << *this << "onSubscribe(" << &subscription << ")";
     Base::onSubscribe(subscription);
   }
 
   void onNext(Payload payload) {
-    Base::logPrefix(LOG(INFO)) << "onNext(" << payload << ")";
+    VLOG(8) << *this << "onNext(" << payload << ")";
     Base::onNext(std::move(payload));
   }
 
   void onNext(Payload payload, FrameFlags flags) {
-    Base::logPrefix(LOG(INFO)) << "onNext(" << payload << ", " << flags << ")";
+    VLOG(8) << *this << "onNext(" << payload << ", " << flags << ")";
     Base::onNext(std::move(payload), flags);
   }
 
   void onComplete() {
-    Base::logPrefix(LOG(INFO)) << "onComplete()";
+    VLOG(6) << *this << "onComplete()";
     Base::onComplete();
   }
 
@@ -87,16 +87,20 @@ class LoggingMixin : public Base {
 
   /// @{
   void endStream(StreamCompletionSignal signal) {
-    Base::logPrefix(LOG(INFO)) << "endStream(" << signal << ")";
+    VLOG(6) << *this << "endStream(" << signal << ")";
     Base::endStream(signal);
   }
   /// @}
+
+  friend std::ostream& operator<<(std::ostream& os, Base& base) {
+    return base.logPrefix(os);
+  }
 
  protected:
   /// @{
   template <typename Frame>
   void onNextFrame(Frame&& frame) {
-    Base::logPrefix(LOG(INFO)) << frame;
+    VLOG(8) << *this << frame;
     Base::onNextFrame(std::move(frame));
   }
 

--- a/src/mixins/MemoryMixin.h
+++ b/src/mixins/MemoryMixin.h
@@ -90,6 +90,11 @@ class MemoryMixin : public Base {
   }
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os) {
+    return os << "MemoryMixin(" << &this->connection_ << ", " << this->streamId_
+              << "): ";
+  }
+
  protected:
   /// @{
   template <typename Frame>
@@ -101,11 +106,6 @@ class MemoryMixin : public Base {
     Base::onBadFrame();
   }
   /// @}
-
-  std::ostream& logPrefix(std::ostream& os) {
-    return os << "MemoryMixin(" << &this->connection_ << ", " << this->streamId_
-              << "): ";
-  }
 };
 
 namespace details {

--- a/src/mixins/MixinTerminator.h
+++ b/src/mixins/MixinTerminator.h
@@ -49,6 +49,10 @@ class MixinTerminator
   explicit MixinTerminator(Parameters params)
       : connection_(std::move(params.connection)), streamId_(params.streamId) {}
 
+  /// Logs an identification string of the automaton.
+  std::ostream& logPrefix(std::ostream& os) /* = 0 */;
+  /// @}
+
  protected:
   /// @{
   /// Each mixin in the stack implements a subset of this API.
@@ -71,10 +75,6 @@ class MixinTerminator
   void onNextFrame(Frame_ERROR&&) {}
 
   void onBadFrame() {}
-
-  /// Logs an identification string of the automaton.
-  std::ostream& logPrefix(std::ostream& os) /* = 0 */;
-  /// @}
 
   /// A partially-owning pointer to the connection, the stream runs on.
   const std::shared_ptr<ConnectionAutomaton> connection_;

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -35,6 +35,11 @@ class PublisherMixin : public Base {
   }
   /// @}
 
+  std::ostream& logPrefix(std::ostream& os) {
+    return os << "PublisherMixin(" << &this->connection_ << ", "
+              << this->streamId_ << "): ";
+  }
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal signal) {
@@ -65,11 +70,6 @@ class PublisherMixin : public Base {
     Base::onNextFrame(std::move(frame));
   }
   /// @}
-
-  std::ostream& logPrefix(std::ostream& os) {
-    return os << "PublisherMixin(" << &this->connection_ << ", "
-              << this->streamId_ << "): ";
-  }
 
  private:
   /// A Subscription that constrols production of payloads.


### PR DESCRIPTION
This addresses #115.

Change most logging in `LoggingMixin.h` to use `VLOG` (except for error states).

Because `VLOG` effectively evaluates to `void` we can't use `Base::logPrefix` as before, so we overload `<<` in `LoggingMixin` to write the prefix. This requires `logPrefix` to be made public.