### PR TITLE
Change assert in ConnectionAutomaton to connection error

### DIFF
--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -148,8 +148,8 @@ void ConnectionAutomaton::onNext(std::unique_ptr<folly::IOBuf> frame) {
   auto streamIdPtr = FrameHeader::peekStreamId(*frame);
   if (!streamIdPtr) {
     // Failed to deserialize the frame.
-    // TODO(stupaq): handle connection-level error
-    assert(false);
+    outputFrameOrEnqueue(Frame_ERROR::invalid("invalid frame").serializeOut());
+    disconnect();
     return;
   }
   auto streamId = *streamIdPtr;

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -3,9 +3,11 @@
 #include <array>
 
 #include <folly/Memory.h>
+#include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "src/Frame.h"
 #include "src/ConnectionAutomaton.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/framed/FramedWriter.h"
@@ -15,15 +17,90 @@
 using namespace ::testing;
 using namespace ::reactivesocket;
 
-TEST(ConnectionAutomatonTest, RefuseFrame) {
-  // TODO: the following test is functionally correct and validates the
-  //       invalid frame functionality. But with the current memory model
-  //       around DuplexConnection, its Subcribers and InlineConnection
-  //       it is impossible to make the destruction and cleanup of the test
-  //       clean and without use-after-free
-  // TODO(lehecka): will fix this in the next iteration, with a different
-  //                memory model
+namespace {
 
+std::unique_ptr<folly::IOBuf> makeInvalidHeader() {
+  // Create a header without the stream id
+  folly::IOBufQueue queue(folly::IOBufQueue::cacheChainLength());
+  queue.append(folly::IOBuf::create(FrameHeader::kSize - sizeof(StreamId)));
+  folly::io::QueueAppender appender(&queue, /* do not grow */ 0);
+  appender.writeBE<uint16_t>(static_cast<uint16_t>(FrameType::REQUEST_N));
+  appender.writeBE<uint16_t>(FrameFlags_EMPTY);
+  return queue.move();
+}
+
+}
+
+// TODO: the following tests are functionally correct and validates the
+//       invalid frame functionality. But with the current memory model
+//       around DuplexConnection, its Subcribers and InlineConnection
+//       it is impossible to make the destruction and cleanup of the test
+//       clean and without use-after-free
+// Both tests in this file use InlineConnection which will be destructed
+// inside InlineConnection::setInput() when it calls inputSink.onSubscribe().
+// TODO(lehecka): will fix this in the next iteration, with a different
+//                memory model
+
+TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
+  // auto automatonConnection = folly::make_unique<InlineConnection>();
+  // auto testConnection = folly::make_unique<InlineConnection>();
+  //
+  // automatonConnection->connectTo(*testConnection);
+  //
+  // auto framedAutomatonConnection = folly::make_unique<FramedDuplexConnection>(
+  //     std::move(automatonConnection));
+  //
+  // auto framedTestConnection =
+  //     folly::make_unique<FramedDuplexConnection>(std::move(testConnection));
+  //
+  // // Dump 1 invalid frame and expect an error
+  //
+  // UnmanagedMockSubscription inputSubscription;
+  //
+  // Sequence s;
+  //
+  // EXPECT_CALL(inputSubscription, request_(_))
+  //     .InSequence(s)
+  //     .WillOnce(Invoke([&](size_t n) {
+  //       auto& framedWriter =
+  //           dynamic_cast<FramedWriter&>(framedTestConnection->getOutput());
+  //
+  //       std::vector<std::unique_ptr<folly::IOBuf>> frames;
+  //       frames.push_back(makeInvalidHeader());
+  //       framedWriter.onNextMultiple(std::move(frames));
+  //     }));
+  //
+  // UnmanagedMockSubscriber<std::unique_ptr<folly::IOBuf>> testOutputSubscriber;
+  // EXPECT_CALL(testOutputSubscriber, onSubscribe_(_))
+  //     .WillOnce(Invoke([&](Subscription* subscription) {
+  //       // allow receiving frames from the automaton
+  //       subscription->request(std::numeric_limits<size_t>::max());
+  //     }));
+  // EXPECT_CALL(testOutputSubscriber, onNext_(_))
+  //     .InSequence(s)
+  //     .WillOnce(Invoke([&](std::unique_ptr<folly::IOBuf>& frame) {
+  //       auto frameType = FrameHeader::peekType(*frame);
+  //       Frame_ERROR error;
+  //       ASSERT_EQ(FrameType::ERROR, frameType);
+  //       ASSERT_TRUE(error.deserializeFrom(std::move(frame)));
+  //       ASSERT_EQ("invalid frame", error.payload_.moveDataToString());
+  //     }));
+  // EXPECT_CALL(testOutputSubscriber, onComplete_()).Times(1).InSequence(s);
+  // EXPECT_CALL(inputSubscription, cancel_()).Times(1).InSequence(s);
+  //
+  // framedTestConnection->setInput(testOutputSubscriber);
+  // framedTestConnection->getOutput().onSubscribe(inputSubscription);
+  //
+  // ConnectionAutomaton connectionAutomaton(
+  //     std::move(framedAutomatonConnection),
+  //     [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+  //     nullptr,
+  //     Stats::noop(),
+  //     false);
+  // connectionAutomaton.connect();
+}
+
+TEST(ConnectionAutomatonTest, RefuseFrame) {
   //  auto automatonConnection = folly::make_unique<InlineConnection>();
   //  auto testConnection = folly::make_unique<InlineConnection>();
   //

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -17,19 +17,19 @@
 using namespace ::testing;
 using namespace ::reactivesocket;
 
-namespace {
-
-std::unique_ptr<folly::IOBuf> makeInvalidHeader() {
-  // Create a header without the stream id
-  folly::IOBufQueue queue(folly::IOBufQueue::cacheChainLength());
-  queue.append(folly::IOBuf::create(FrameHeader::kSize - sizeof(StreamId)));
-  folly::io::QueueAppender appender(&queue, /* do not grow */ 0);
-  appender.writeBE<uint16_t>(static_cast<uint16_t>(FrameType::REQUEST_N));
-  appender.writeBE<uint16_t>(FrameFlags_EMPTY);
-  return queue.move();
-}
-
-}
+// namespace {
+//
+// std::unique_ptr<folly::IOBuf> makeInvalidHeader() {
+//   // Create a header without the stream id
+//   folly::IOBufQueue queue(folly::IOBufQueue::cacheChainLength());
+//   queue.append(folly::IOBuf::create(FrameHeader::kSize - sizeof(StreamId)));
+//   folly::io::QueueAppender appender(&queue, /* do not grow */ 0);
+//   appender.writeBE<uint16_t>(static_cast<uint16_t>(FrameType::REQUEST_N));
+//   appender.writeBE<uint16_t>(FrameFlags_EMPTY);
+//   return queue.move();
+// }
+//
+// }
 
 // TODO: the following tests are functionally correct and validates the
 //       invalid frame functionality. But with the current memory model


### PR DESCRIPTION
The added test works but leads to a use-after-free (like the test below it):
```
blom:build connection-assert$ ./tests --gtest_filter=ConnectionAutomatonTest.InvalidFrameHeader
Note: Google Test filter = ConnectionAutomatonTest.InvalidFrameHeader
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from ConnectionAutomatonTest
[ RUN      ] ConnectionAutomatonTest.InvalidFrameHeader
=================================================================
==73464==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c00000b698 at pc 0x00010a6f4073 bp 0x7fff55680010 sp 0x7fff55680008
READ of size 1 at 0x60c00000b698 thread T0
    #0 0x10a6f4072 in reactivesocket::InlineConnection::setInput(reactivestreams::Subscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper>&) InlineConnection.cpp:44
    #1 0x10a86845b in reactivesocket::FramedDuplexConnection::setInput(reactivestreams::Subscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper>&) FramedDuplexConnection.cpp:38
    #2 0x10a81c367 in reactivesocket::ConnectionAutomaton::connect() ConnectionAutomaton.cpp:46
    #3 0x10a6e0104 in ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody() ConnectionAutomatonTest.cpp:100
    #4 0x10aa06bd9 in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) (tests+0x10048abd9)
    #5 0x10a9cbf66 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (tests+0x10044ff66)
    #6 0x10a9cbea4 in testing::Test::Run() (tests+0x10044fea4)
    #7 0x10a9cd9c7 in testing::TestInfo::Run() (tests+0x1004519c7)
    #8 0x10a9cefb6 in testing::TestCase::Run() (tests+0x100452fb6)
    #9 0x10a9dd1eb in testing::internal::UnitTestImpl::RunAllTests() (tests+0x1004611eb)
    #10 0x10aa07b49 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests+0x10048bb49)
    #11 0x10a9dcbf6 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests+0x100460bf6)
    #12 0x10a9dcaa7 in testing::UnitTest::Run() (tests+0x100460aa7)
    #13 0x10a7d8870 in RUN_ALL_TESTS() gtest.h:2233
    #14 0x10a7d87e1 in main Test.cpp:14
    #15 0x7fff878075ac in start (libdyld.dylib+0x35ac)

0x60c00000b698 is located 24 bytes inside of 120-byte region [0x60c00000b680,0x60c00000b6f8)
freed by thread T0 here:
    #0 0x10b348c2b in wrap__ZdlPv (libclang_rt.asan_osx_dynamic.dylib+0x57c2b)
    #1 0x10a6f2781 in reactivesocket::InlineConnection::~InlineConnection() InlineConnection.cpp:21
    #2 0x10a866ddf in reactivesocket::FramedDuplexConnection::~FramedDuplexConnection() memory:2525
    #3 0x10a866e2f in reactivesocket::FramedDuplexConnection::~FramedDuplexConnection() FramedDuplexConnection.cpp:16
    #4 0x10a866ef8 in reactivesocket::FramedDuplexConnection::~FramedDuplexConnection() FramedDuplexConnection.cpp:16
    #5 0x10a81cc31 in reactivesocket::ConnectionAutomaton::disconnect() memory:2525
    #6 0x10a822a4d in reactivesocket::ConnectionAutomaton::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) ConnectionAutomaton.cpp:152
    #7 0x10a86af2e in reactivestreams::SubscriberPtr<reactivestreams::Subscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper> >::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) const SmartPointers.h:65
    #8 0x10a869dd8 in reactivesocket::FramedReader::parseFrames() FramedReader.cpp:64
    #9 0x10a869258 in reactivesocket::FramedReader::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) FramedReader.cpp:33
    #10 0x10a86a648 in non-virtual thunk to reactivesocket::FramedReader::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) FramedReader.cpp:27
    #11 0x10a6fc83f in reactivesocket::InlineConnection::getOutput()::$_1::operator()(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&) const InlineConnection.cpp:93
    #12 0x10a6fb584 in void testing::internal::InvokeHelper<void, std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> >::Invoke<reactivesocket::InlineConnection::getOutput()::$_1>(reactivesocket::InlineConnection::getOutput()::$_1, std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> const&) gmock-generated-actions.h:74
    #13 0x10a6fb3ca in void testing::internal::InvokeAction<reactivesocket::InlineConnection::getOutput()::$_1>::Perform<void, std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> >(std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> const&) gmock-more-actions.h:61
    #14 0x10a6fb25b in testing::PolymorphicAction<testing::internal::InvokeAction<reactivesocket::InlineConnection::getOutput()::$_1> >::MonomorphicImpl<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::Perform(std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> const&) gmock-actions.h:446
    #15 0x10a5bb84c in testing::Action<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::Perform(std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> const&) const gmock-actions.h:395
    #16 0x10a5bbdd8 in testing::internal::ActionResultHolder<void>* testing::internal::ActionResultHolder<void>::PerformAction<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>(testing::Action<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)> const&, testing::internal::Function<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::ArgumentTuple const&) gmock-spec-builders.h:1443
    #17 0x10a5b92f2 in testing::internal::FunctionMockerBase<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::UntypedPerformAction(void const*, void const*) const gmock-spec-builders.h:1542
    #18 0x10aa19cd3 in testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void const*) (tests+0x10049dcd3)
    #19 0x10a5c92f0 in testing::internal::FunctionMockerBase<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::InvokeWith(std::__1::tuple<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&> const&) gmock-spec-builders.h:1585
    #20 0x10a5c9190 in testing::internal::FunctionMocker<void (std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&)>::Invoke(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&) gmock-generated-function-mockers.h:101
    #21 0x10a5c8fa4 in reactivestreams::MockSubscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper>::onNext_(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >&) Mocks.h:86
    #22 0x10a5b0204 in reactivestreams::MockSubscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper>::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) Mocks.h:99
    #23 0x10a86af2e in reactivestreams::SubscriberPtr<reactivestreams::Subscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper> >::onNext(std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >) const SmartPointers.h:65
    #24 0x10a87128a in reactivesocket::FramedWriter::onNextMultiple(std::__1::vector<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, std::__1::allocator<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> > > >) FramedWriter.cpp:66
    #25 0x10a6e67b8 in ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody()::$_1::operator()(unsigned long) const ConnectionAutomatonTest.cpp:70
    #26 0x10a6e52c4 in void testing::internal::InvokeHelper<void, std::__1::tuple<unsigned long> >::Invoke<ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody()::$_1>(ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody()::$_1, std::__1::tuple<unsigned long> const&) gmock-generated-actions.h:74
    #27 0x10a6e510a in void testing::internal::InvokeAction<ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody()::$_1>::Perform<void, std::__1::tuple<unsigned long> >(std::__1::tuple<unsigned long> const&) gmock-more-actions.h:61
    #28 0x10a6e4f3b in testing::PolymorphicAction<testing::internal::InvokeAction<ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody()::$_1> >::MonomorphicImpl<void (unsigned long)>::Perform(std::__1::tuple<unsigned long> const&) gmock-actions.h:446
    #29 0x10a5976ec in testing::Action<void (unsigned long)>::Perform(std::__1::tuple<unsigned long> const&) const gmock-actions.h:395

previously allocated by thread T0 here:
    #0 0x10b34866b in wrap__Znwm (libclang_rt.asan_osx_dynamic.dylib+0x5766b)
    #1 0x10a6dd120 in ConnectionAutomatonTest_InvalidFrameHeader_Test::TestBody() memory:3141
    #2 0x10aa06bd9 in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) (tests+0x10048abd9)
    #3 0x10a9cbf66 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (tests+0x10044ff66)
    #4 0x10a9cbea4 in testing::Test::Run() (tests+0x10044fea4)
    #5 0x10a9cd9c7 in testing::TestInfo::Run() (tests+0x1004519c7)
    #6 0x10a9cefb6 in testing::TestCase::Run() (tests+0x100452fb6)
    #7 0x10a9dd1eb in testing::internal::UnitTestImpl::RunAllTests() (tests+0x1004611eb)
    #8 0x10aa07b49 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests+0x10048bb49)
    #9 0x10a9dcbf6 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests+0x100460bf6)
    #10 0x10a9dcaa7 in testing::UnitTest::Run() (tests+0x100460aa7)
    #11 0x10a7d8870 in RUN_ALL_TESTS() gtest.h:2233
    #12 0x10a7d87e1 in main Test.cpp:14
    #13 0x7fff878075ac in start (libdyld.dylib+0x35ac)

SUMMARY: AddressSanitizer: heap-use-after-free InlineConnection.cpp:44 in reactivesocket::InlineConnection::setInput(reactivestreams::Subscriber<std::__1::unique_ptr<folly::IOBuf, std::__1::default_delete<folly::IOBuf> >, folly::exception_wrapper>&)
Shadow bytes around the buggy address:
  0x1c1800001680: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x1c1800001690: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x1c18000016a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c18000016b0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x1c18000016c0: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
=>0x1c18000016d0: fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fa
  0x1c18000016e0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x1c18000016f0: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x1c1800001700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c1800001710: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x1c1800001720: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==73464==ABORTING
Abort trap: 6
```