### PR TITLE
Change uses of INVALID to CONNECTION_ERROR

### DIFF
--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -148,7 +148,8 @@ void ConnectionAutomaton::onNext(std::unique_ptr<folly::IOBuf> frame) {
   auto streamIdPtr = FrameHeader::peekStreamId(*frame);
   if (!streamIdPtr) {
     // Failed to deserialize the frame.
-    outputFrameOrEnqueue(Frame_ERROR::invalid("invalid frame").serializeOut());
+    outputFrameOrEnqueue(
+      Frame_ERROR::connectionError("invalid frame").serializeOut());
     disconnect();
     return;
   }
@@ -189,7 +190,8 @@ void ConnectionAutomaton::onConnectionFrame(
             outputFrameOrEnqueue(frame.serializeOut());
           } else {
             outputFrameOrEnqueue(
-                Frame_ERROR::invalid("keepalive without flag").serializeOut());
+                Frame_ERROR::connectionError("keepalive without flag")
+                .serializeOut());
             disconnect();
           }
         }
@@ -234,7 +236,7 @@ void ConnectionAutomaton::onConnectionFrame(
           resumeCache_->retransmitFromPosition(frame.position_, *this);
         } else {
           outputFrameOrEnqueue(
-              Frame_ERROR::canNotResume("can not resume").serializeOut());
+              Frame_ERROR::connectionError("can not resume").serializeOut());
           disconnect();
         }
       } else {
@@ -251,7 +253,7 @@ void ConnectionAutomaton::onConnectionFrame(
           resumeCache_->retransmitFromPosition(frame.position_, *this);
         } else {
           outputFrameOrEnqueue(
-              Frame_ERROR::canNotResume("can not resume").serializeOut());
+              Frame_ERROR::connectionError("can not resume").serializeOut());
           disconnect();
         }
       } else {
@@ -321,8 +323,8 @@ void ConnectionAutomaton::handleUnknownStream(
   // IDs -- let's forget about them for a moment
   if (!factory_(streamId, std::move(payload))) {
     outputFrameOrEnqueue(
-        Frame_ERROR::invalid("unknown stream " + folly::to<std::string>(streamId))
-            .serializeOut());
+        Frame_ERROR::connectionError(
+          folly::to<std::string>("unknown stream ", streamId)).serializeOut());
     disconnect();
   }
 }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -345,18 +345,18 @@ Frame_ERROR Frame_ERROR::badSetupFrame(const std::string& message) {
   return Frame_ERROR(0, ErrorCode::INVALID_SETUP, Payload(message));
 }
 
-Frame_ERROR Frame_ERROR::invalid(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::INVALID, Payload(message));
+Frame_ERROR Frame_ERROR::connectionError(const std::string& message) {
+  return Frame_ERROR(0, ErrorCode::CONNECTION_ERROR, Payload(message));
+}
+
+Frame_ERROR Frame_ERROR::invalid(StreamId streamId, const std::string& message) {
+  return Frame_ERROR(streamId, ErrorCode::INVALID, Payload(message));
 }
 
 Frame_ERROR Frame_ERROR::applicationError(
     StreamId streamId,
     const std::string& message) {
   return Frame_ERROR(streamId, ErrorCode::APPLICATION_ERROR, Payload(message));
-}
-
-Frame_ERROR Frame_ERROR::canNotResume(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::CONNECTION_ERROR, Payload(message));
 }
 
 std::unique_ptr<folly::IOBuf> Frame_ERROR::serializeOut() {

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -56,13 +56,29 @@ std::ostream& operator<<(std::ostream&, FrameType);
 
 enum class ErrorCode : uint32_t {
   RESERVED = 0x00000000,
+  // The Setup frame is invalid for the server (it could be that the client is
+  // too recent for the old server). Stream ID MUST be 0.
   INVALID_SETUP = 0x00000001,
+  // Some (or all) of the parameters specified by the client are unsupported by
+  // the server. Stream ID MUST be 0.
   UNSUPPORTED_SETUP = 0x00000002,
+  // The server rejected the setup, it can specify the reason in the payload.
+  // Stream ID MUST be 0.
   REJECTED_SETUP = 0x00000003,
+  // The connection is being terminated. Stream ID MUST be 0.
   CONNECTION_ERROR = 0x00000101,
+  // Application layer logic generating a Reactive Streams onError event.
+  // Stream ID MUST be non-0.
   APPLICATION_ERROR = 0x00000201,
+  // Despite being a valid request, the Responder decided to reject it. The
+  //Responder guarantees that it didn't process the request. The reason for the
+  // rejection is explained in the metadata section. Stream ID MUST be non-0.
   REJECTED = 0x00000202,
+  // The responder canceled the request but potentially have started processing
+  // it (almost identical to REJECTED but doesn't garantee that no side-effect
+  // have been started). Stream ID MUST be non-0.
   CANCELED = 0x00000203,
+  // The request is invalid. Stream ID MUST be non-0.
   INVALID = 0x00000204,
   // EXT = 0xFFFFFFFF,
 };
@@ -357,11 +373,11 @@ class Frame_ERROR {
 
   static Frame_ERROR unexpectedFrame();
   static Frame_ERROR badSetupFrame(const std::string& message);
-  static Frame_ERROR invalid(const std::string& message);
+  static Frame_ERROR connectionError(const std::string& message);
+  static Frame_ERROR invalid(StreamId streamId, const std::string& message);
   static Frame_ERROR applicationError(
       StreamId streamId,
       const std::string& message);
-  static Frame_ERROR canNotResume(const std::string& message);
 
   FrameHeader header_;
   ErrorCode errorCode_;


### PR DESCRIPTION
INVALID MUST take a non-zero stream id but we always gave it 0, we should be
using CONNECTION_ERROR instead. Change all uses of invalid() to new method
connectionError() and switch existing uses of canNotResume(), which maps
to CONNECTION_ERROR to connectionError().