### PR TITLE
One terminal signal for SubscriberBase users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,21 +165,22 @@ enable_testing()
 
 add_executable(
   tests
+  test/concurrent/OneToOneRingBufferTest.cpp
+  test/ConnectionAutomatonTest.cpp
   test/framed/FramedReaderTest.cpp
   test/framed/FramedWriterTest.cpp
   test/FrameTest.cpp
-  test/ConnectionAutomatonTest.cpp
   test/InlineConnection.cpp
   test/InlineConnection.h
   test/InlineConnectionTest.cpp
   test/MockDuplexConnection.h
   test/MockRequestHandler.h
-  test/ReactiveSocketTest.cpp
-  test/ReactiveSocketConcurrencyTest.cpp
-  test/ReactiveStreamsMocksCompat.h
-  test/Test.cpp
   test/MockStats.h
-  test/concurrent/OneToOneRingBufferTest.cpp
+  test/ReactiveSocketConcurrencyTest.cpp
+  test/ReactiveSocketTest.cpp
+  test/ReactiveStreamsMocksCompat.h
+  test/SubscriberBaseTest.cpp
+  test/Test.cpp
 )
 
 target_link_libraries(

--- a/TARGETS
+++ b/TARGETS
@@ -42,12 +42,13 @@ cpp_library(
         'src/automata/ChannelResponder.cpp',
         'src/automata/RequestResponseRequester.cpp',
         'src/automata/RequestResponseResponder.cpp',
+        'src/automata/StreamRequester.cpp',
         'src/automata/StreamSubscriptionRequesterBase.cpp',
         'src/automata/StreamSubscriptionResponderBase.cpp',
-        'src/automata/StreamRequester.cpp',
         'src/automata/SubscriptionRequester.cpp',
         'src/ConnectionAutomaton.cpp',
         'src/ConnectionSetupPayload.cpp',
+        'src/Executor.cpp',
         'src/Frame.cpp',
         'src/NullRequestHandler.cpp',
         'src/Payload.cpp',
@@ -69,11 +70,14 @@ cpp_library(
     name = 'reactivesocket',
 
     headers = [
+        'src/EnableSharedFromThis.h',
         'src/NullRequestHandler.h',
         'src/Payload.h',
-        'src/RequestHandler.h',
         'src/ReactiveSocket.h',
+        'src/RequestHandler.h',
         'src/Stats.h',
+        'src/SubscriberBase.h',
+        'src/SubscriptionBase.h',
     ],
     deps = [
         ':reactivesocket-internal',
@@ -114,9 +118,15 @@ cpp_unittest(
     headers = subdir_glob([
         ('test', '**/*.h'),
     ]),
-    srcs = glob(['test/*.cpp']),
+    srcs = glob([
+        'test/*.cpp',
+        'test/concurrent/*.cpp',
+        'test/framed/*.cpp',
+        'test/simple/*.cpp',
+        ]),
     deps = [
         ':reactivesocket-internal',
+        ':reactivesocket-plugins',
         ':reactivesocket-streams-mocks',
         '//folly/io/async:util',
     ],

--- a/src/SubscriberBase.h
+++ b/src/SubscriberBase.h
@@ -9,6 +9,18 @@
 
 namespace reactivesocket {
 
+//
+// SubscriberBase is designed to be a general purpose base class for
+// implementors of Subscriber<T> interface. It provides 2 key features:
+// 1. ExecutorBase: You can specify the Executor you want to use to execute the
+//    on{Subscribe,Next,Complete,Error} methods. Eq. by providing EventBase
+//    as an executor, you can call the methods from any thread and the
+//    marshaling to the right EventBase thread will happen automatically.
+// 2. once the user cancels the subscriber via the subscription, it is
+//    garanteed that no more callbacks will be called. It is safe for the client
+//    to do cleanup and releasing of resources. User doesn't have to call
+//    subscription::cancel in on{Complete,Error}.
+//
 template <typename T>
 class SubscriberBaseT : public Subscriber<T>,
                         public EnableSharedFromThisBase<SubscriberBaseT<T>>,
@@ -18,34 +30,110 @@ class SubscriberBaseT : public Subscriber<T>,
   virtual void onCompleteImpl() = 0;
   virtual void onErrorImpl(folly::exception_wrapper ex) = 0;
 
+  // used to be able to cancel subscription immediatelly, making sure we dont
+  // deliver any other signals after that
+  // also to break the reference cycle involving storing subscription pointer
+  // for the users of the SubscriberBase
+  class SubscriptionShim : public Subscription {
+   public:
+    explicit SubscriptionShim(
+        std::shared_ptr<SubscriberBaseT<T>> parentSubscriber)
+        : parentSubscriber_(std::move(parentSubscriber)) {}
+
+    void request(size_t n) override final {
+      if (auto parent = parentSubscriber_.lock()) {
+        parent->runInExecutor([parent, n]() {
+          if (!parent->cancelled_) {
+            parent->originalSubscription_->request(n);
+          }
+        });
+      }
+    }
+
+    void cancel() override final {
+      if (auto parent = parentSubscriber_.lock()) {
+        if (!parent->cancelled_.exchange(true)) {
+          parent->runInExecutor([parent]() {
+            if (!parent->cancelled_) {
+              parent->originalSubscription_->cancel();
+              parent->originalSubscription_ = nullptr;
+            }
+          });
+        }
+      }
+    }
+
+   private:
+    // we don't want to create cycle with parent subscriber. If we do, we would
+    // have to make sure the class deriving from SubscriberBase would have to
+    // nullify subscription pointer after calling cancel. That is too strong of
+    // a requirement for the users.
+    std::weak_ptr<SubscriberBaseT<T>> parentSubscriber_;
+  };
+
+  friend class SubscriptionShim;
+
  public:
   using ExecutorBase::ExecutorBase;
 
   void onSubscribe(std::shared_ptr<Subscription> subscription) override final {
     auto thisPtr = this->shared_from_this();
-    runInExecutor(
-        [thisPtr, subscription]() { thisPtr->onSubscribeImpl(subscription); });
+    runInExecutor([thisPtr, subscription]() {
+      CHECK(!thisPtr->cancelled_);
+      CHECK(!thisPtr->originalSubscription_);
+      thisPtr->originalSubscription_ = std::move(subscription);
+      thisPtr->onSubscribeImpl(
+          std::make_shared<SubscriptionShim>(thisPtr->shared_from_this()));
+    });
   }
 
   void onNext(T payload) override final {
     auto movedPayload = folly::makeMoveWrapper(std::move(payload));
     auto thisPtr = this->shared_from_this();
     runInExecutor([thisPtr, movedPayload]() mutable {
-      thisPtr->onNextImpl(movedPayload.move());
+      if (!thisPtr->cancelled_) {
+        thisPtr->onNextImpl(movedPayload.move());
+      }
     });
   }
 
   void onComplete() override final {
     auto thisPtr = this->shared_from_this();
-    runInExecutor([thisPtr]() { thisPtr->onCompleteImpl(); });
+    runInExecutor([thisPtr]() {
+      if (!thisPtr->cancelled_.exchange(true)) {
+        thisPtr->onCompleteImpl();
+
+        DCHECK(thisPtr->originalSubscription_);
+        thisPtr->originalSubscription_->cancel();
+        thisPtr->originalSubscription_ = nullptr;
+      }
+    });
   }
 
   void onError(folly::exception_wrapper ex) override final {
     auto movedEx = folly::makeMoveWrapper(std::move(ex));
     auto thisPtr = this->shared_from_this();
-    runInExecutor(
-        [thisPtr, movedEx]() mutable { thisPtr->onErrorImpl(movedEx.move()); });
+    runInExecutor([thisPtr, movedEx]() mutable {
+      if (!thisPtr->cancelled_.exchange(true)) {
+        thisPtr->onErrorImpl(movedEx.move());
+
+        DCHECK(thisPtr->originalSubscription_);
+        thisPtr->originalSubscription_->cancel();
+        thisPtr->originalSubscription_ = nullptr;
+      }
+    });
   }
+
+ private:
+  // Once the subscription is cancelled we will no longer deliver any
+  // other signals.
+  // Scheduling the calls is not atomic operation so it may very well happen
+  // that 2 threads race for sending onNext and onComplete. We need to make sure
+  // that once the terminating signal is delivered we no longer try to deliver
+  // onNext.
+  std::atomic<bool> cancelled_{false};
+
+  std::shared_ptr<Subscription> originalSubscription_;
 };
 
 extern template class SubscriberBaseT<Payload>;

--- a/src/SubscriberBase.h
+++ b/src/SubscriberBase.h
@@ -30,7 +30,7 @@ class SubscriberBaseT : public Subscriber<T>,
   virtual void onCompleteImpl() = 0;
   virtual void onErrorImpl(folly::exception_wrapper ex) = 0;
 
-  // used to be able to cancel subscription immediatelly, making sure we dont
+  // used to be able to cancel subscription immediately, making sure we dont
   // deliver any other signals after that
   // also to break the reference cycle involving storing subscription pointer
   // for the users of the SubscriberBase
@@ -79,7 +79,8 @@ class SubscriberBaseT : public Subscriber<T>,
   // maybe its gcc issue
   explicit SubscriberBaseT(
       folly::Executor& executor = defaultExecutor(),
-      bool startExecutor = true) : ExecutorBase(executor, startExecutor), cancelled_(false) {}
+      bool startExecutor = true)
+      : ExecutorBase(executor, startExecutor), cancelled_(false) {}
 
   void onSubscribe(std::shared_ptr<Subscription> subscription) override final {
     auto thisPtr = this->shared_from_this();

--- a/src/SubscriberBase.h
+++ b/src/SubscriberBase.h
@@ -16,10 +16,10 @@ namespace reactivesocket {
 //    on{Subscribe,Next,Complete,Error} methods. Eq. by providing EventBase
 //    as an executor, you can call the methods from any thread and the
 //    marshaling to the right EventBase thread will happen automatically.
-// 2. once the user cancels the subscriber via the subscription, it is
-//    garanteed that no more callbacks will be called. It is safe for the client
-//    to do cleanup and releasing of resources. User doesn't have to call
-//    subscription::cancel in on{Complete,Error}.
+// 2. once the user cancels the subscriber via the subscription::cancel, it is
+//    guaranteed that no more callbacks will be called. It is safe for the
+// client to do cleanup and releasing of resources. User doesn't have to call
+//    subscription::cancel in on{Complete,Error} methods.
 //
 template <typename T>
 class SubscriberBaseT : public Subscriber<T>,

--- a/src/framed/FramedReader.cpp
+++ b/src/framed/FramedReader.cpp
@@ -58,11 +58,13 @@ void FramedReader::parseFrames() {
 void FramedReader::onCompleteImpl() {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   frames_.onComplete();
+  streamSubscription_.cancel();
 }
 
 void FramedReader::onErrorImpl(folly::exception_wrapper ex) {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   frames_.onError(std::move(ex));
+  streamSubscription_.cancel();
 }
 
 void FramedReader::requestImpl(size_t n) {
@@ -81,6 +83,7 @@ void FramedReader::requestStream() {
 void FramedReader::cancelImpl() {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   streamSubscription_.cancel();
+  frames_.onComplete();
 }
 
 } // reactive socket

--- a/src/framed/FramedWriter.cpp
+++ b/src/framed/FramedWriter.cpp
@@ -68,10 +68,12 @@ void FramedWriter::onNextMultiple(
 
 void FramedWriter::onCompleteImpl() {
   stream_.onComplete();
+  writerSubscription_.cancel();
 }
 
 void FramedWriter::onErrorImpl(folly::exception_wrapper ex) {
   stream_.onError(std::move(ex));
+  writerSubscription_.cancel();
 }
 
 void FramedWriter::requestImpl(size_t n) {
@@ -80,6 +82,7 @@ void FramedWriter::requestImpl(size_t n) {
 
 void FramedWriter::cancelImpl() {
   writerSubscription_.cancel();
+  stream_.onComplete();
 }
 
 } // reactive socket

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -50,9 +50,6 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
       .InSequence(s)
       .WillOnce(Invoke([&](size_t n) {
         framedTestConnection->getOutput()->onNext(makeInvalidFrameHeader());
-      }))
-      .WillOnce(Invoke([&](size_t n) {
-        // ignored
       }));
 
   auto testOutputSubscriber =
@@ -106,9 +103,7 @@ static void terminateTest(
 
   auto inputSubscription = std::make_shared<MockSubscription>();
 
-  if (inOnSubscribe) {
-    EXPECT_CALL(*inputSubscription, request_(_)).Times(0);
-  } else {
+  if (!inOnSubscribe) {
     auto&& exp = EXPECT_CALL(*inputSubscription, request_(_))
                      .WillOnce(Invoke([&](size_t n) {
                        if (inRequest) {
@@ -227,9 +222,6 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
         frames.push_back(Frame_REQUEST_N(streamId + 2, 1).serializeOut());
 
         framedWriter->onNextMultiple(std::move(frames));
-      }))
-      .WillOnce(Invoke([&](size_t n) {
-        // ignoring
       }));
   EXPECT_CALL(*testOutputSubscriber, onNext_(_))
       .InSequence(s)

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -69,9 +69,6 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
         ASSERT_EQ("invalid frame", error.payload_.moveDataToString());
       }));
   EXPECT_CALL(*testOutputSubscriber, onComplete_()).Times(1).InSequence(s);
-  EXPECT_CALL(*inputSubscription, cancel_()).InSequence(s).WillOnce(Invoke([&] {
-    framedTestConnection->getOutput()->onComplete();
-  }));
 
   framedTestConnection->setInput(testOutputSubscriber);
   framedTestConnection->getOutput()->onSubscribe(inputSubscription);
@@ -104,20 +101,13 @@ static void terminateTest(
   auto inputSubscription = std::make_shared<MockSubscription>();
 
   if (!inOnSubscribe) {
-    auto&& exp = EXPECT_CALL(*inputSubscription, request_(_))
-                     .WillOnce(Invoke([&](size_t n) {
-                       if (inRequest) {
-                         framedTestConnection->getOutput()->onComplete();
-                       } else {
-                         framedTestConnection->getOutput()->onNext(
-                             makeInvalidFrameHeader());
-                       }
-                     }));
-    if (!inRequest) {
-      exp.WillOnce(Invoke([&](size_t n) {
-        // ignored
-      }));
-    }
+    EXPECT_CALL(*inputSubscription, request_(_)).WillOnce(Invoke([&](size_t n) {
+      if (inRequest) {
+        framedTestConnection->getOutput()->onComplete();
+      } else {
+        framedTestConnection->getOutput()->onNext(makeInvalidFrameHeader());
+      }
+    }));
   }
 
   auto testOutputSubscriber =
@@ -146,9 +136,6 @@ static void terminateTest(
   }));
 
   auto testOutput = framedTestConnection->getOutput();
-  EXPECT_CALL(*inputSubscription, cancel_()).WillOnce(Invoke([&] {
-    testOutput->onComplete();
-  }));
 
   framedTestConnection->setInput(testOutputSubscriber);
   framedTestConnection->getOutput()->onSubscribe(inputSubscription);
@@ -230,9 +217,6 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
         ASSERT_EQ(FrameType::ERROR, frameType);
       }));
   EXPECT_CALL(*testOutputSubscriber, onComplete_()).Times(1).InSequence(s);
-  EXPECT_CALL(*inputSubscription, cancel_()).InSequence(s).WillOnce(Invoke([&] {
-    framedTestConnection->getOutput()->onComplete();
-  }));
 
   framedTestConnection->setInput(testOutputSubscriber);
   framedTestConnection->getOutput()->onSubscribe(inputSubscription);

--- a/test/InlineConnectionTest.cpp
+++ b/test/InlineConnectionTest.cpp
@@ -48,10 +48,6 @@ TEST(InlineConnectionTest, PingPong) {
   output[0]->onSubscribe(outputSub[0]);
   end[1].setInput(input[1]);
 
-  // Whitebox: we do know the connection passes subscription objects verbatim.
-  EXPECT_EQ(outputSub[1].get(), inputSub[0].get());
-  EXPECT_EQ(outputSub[0].get(), inputSub[1].get());
-
   auto originalPayload = folly::IOBuf::copyBuffer("request1");
   EXPECT_CALL(*outputSub[1], request_(1)).InSequence(s);
   EXPECT_CALL(*outputSub[0], request_(1))

--- a/test/SubscriberBaseTest.cpp
+++ b/test/SubscriberBaseTest.cpp
@@ -1,0 +1,128 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <gmock/gmock.h>
+#include "src/SubscriberBase.h"
+#include "test/ReactiveStreamsMocksCompat.h"
+
+using namespace ::testing;
+using namespace ::reactivesocket;
+
+class SubscriberBaseMock : public SubscriberBaseT<int> {
+ public:
+  using SubscriberBaseT::SubscriberBaseT;
+
+  MOCK_METHOD1(
+      onSubscribeImpl_,
+      void(std::shared_ptr<Subscription> subscription));
+  MOCK_METHOD1(onNextImpl_, void(int value));
+  MOCK_METHOD0(onCompleteImpl_, void());
+  MOCK_METHOD1_T(onErrorImpl_, void(folly::exception_wrapper ex));
+
+ private:
+  void onSubscribeImpl(
+      std::shared_ptr<Subscription> subscription) override final {
+    onSubscribeImpl_(subscription);
+  }
+
+  void onNextImpl(int value) override final {
+    onNextImpl_(value);
+  }
+
+  void onCompleteImpl() override final {
+    onCompleteImpl_();
+  }
+
+  void onErrorImpl(folly::exception_wrapper ex) override final {
+    onErrorImpl_(std::move(ex));
+  }
+};
+
+TEST(SubscriberBaseTest, NoSignalAfterCancel) {
+  auto subscriber = std::make_shared<SubscriberBaseMock>();
+
+  std::shared_ptr<Subscription> outSubscription;
+  EXPECT_CALL(*subscriber, onSubscribeImpl_(_))
+      .WillOnce(Invoke([&](std::shared_ptr<Subscription> s) {
+        outSubscription = s;
+        s->cancel();
+      }));
+
+  EXPECT_CALL(*subscriber, onNextImpl_(_)).Times(0);
+  EXPECT_CALL(*subscriber, onCompleteImpl_()).Times(0);
+  EXPECT_CALL(*subscriber, onErrorImpl_(_)).Times(0);
+
+  auto subscription = std::make_shared<MockSubscription>();
+  std::shared_ptr<Subscriber<int>> ptr = subscriber;
+  ptr->onSubscribe(subscription);
+
+  ptr->onNext(1);
+  ptr->onNext(2);
+  ptr->onNext(3);
+  ptr->onComplete();
+  ptr->onError(std::runtime_error("error"));
+}
+
+TEST(SubscriberBaseTest, OnNextDelivered) {
+  folly::ScopedEventBaseThread thread2;
+  std::atomic<bool> done{false};
+
+  auto subscriber =
+      std::make_shared<SubscriberBaseMock>(*thread2.getEventBase());
+
+  std::shared_ptr<Subscription> outSubscription;
+  EXPECT_CALL(*subscriber, onSubscribeImpl_(_))
+      .WillOnce(Invoke(
+          [&](std::shared_ptr<Subscription> s) { outSubscription = s; }));
+
+  EXPECT_CALL(*subscriber, onNextImpl_(_)).Times(3);
+  EXPECT_CALL(*subscriber, onCompleteImpl_()).WillOnce(Invoke([&]() {
+    done = true;
+  }));
+  EXPECT_CALL(*subscriber, onErrorImpl_(_)).Times(0);
+
+  auto subscription = std::make_shared<MockSubscription>();
+  std::shared_ptr<Subscriber<int>> ptr = subscriber;
+  ptr->onSubscribe(subscription);
+
+  ptr->onNext(1);
+  ptr->onNext(2);
+  ptr->onNext(3);
+  ptr->onComplete();
+
+  while (!done)
+    ;
+}
+
+TEST(SubscriberBaseTest, CancelStopsOnNext) {
+  folly::ScopedEventBaseThread thread2;
+  std::atomic<bool> done{false};
+
+  auto subscriber =
+      std::make_shared<SubscriberBaseMock>(*thread2.getEventBase());
+
+  std::shared_ptr<Subscription> outSubscription;
+  EXPECT_CALL(*subscriber, onSubscribeImpl_(_))
+      .WillOnce(Invoke(
+          [&](std::shared_ptr<Subscription> s) { outSubscription = s; }));
+
+  EXPECT_CALL(*subscriber, onNextImpl_(_))
+      .WillOnce(Invoke([&](int) {}))
+      .WillOnce(Invoke([&](int) {
+        done = true;
+        outSubscription->cancel();
+      }));
+  EXPECT_CALL(*subscriber, onCompleteImpl_()).Times(0);
+  EXPECT_CALL(*subscriber, onErrorImpl_(_)).Times(0);
+
+  auto subscription = std::make_shared<MockSubscription>();
+  std::shared_ptr<Subscriber<int>> ptr = subscriber;
+  ptr->onSubscribe(subscription);
+
+  ptr->onNext(1);
+  ptr->onNext(2);
+  ptr->onNext(3);
+
+  while (!done)
+    ;
+}

--- a/test/framed/FramedReaderTest.cpp
+++ b/test/framed/FramedReaderTest.cpp
@@ -49,7 +49,6 @@ TEST(FramedReaderTest, Read1Frame) {
 
   // to delete objects
   EXPECT_CALL(*frameSubscriber, onComplete_()).Times(1);
-  EXPECT_CALL(*wireSubscription, cancel_()).Times(1);
 
   frameSubscriber->subscription()->cancel();
   framedReader->onComplete();
@@ -106,7 +105,6 @@ TEST(FramedReaderTest, Read3Frames) {
 
   // to delete objects
   EXPECT_CALL(*frameSubscriber, onComplete_()).Times(1);
-  EXPECT_CALL(*wireSubscription, cancel_()).Times(1);
 
   frameSubscriber->subscription()->cancel();
   framedReader->onComplete();
@@ -159,7 +157,6 @@ TEST(FramedReaderTest, Read1FrameIncomplete) {
   framedReader->onNext(std::move(payload));
   // to delete objects
   EXPECT_CALL(*frameSubscriber, onComplete_()).Times(1);
-  EXPECT_CALL(*wireSubscription, cancel_()).Times(1);
 
   frameSubscriber->subscription()->cancel();
   framedReader->onComplete();

--- a/test/framed/FramedWriterTest.cpp
+++ b/test/framed/FramedWriterTest.cpp
@@ -19,7 +19,6 @@ TEST(FramedWriterTest, Subscribe) {
   auto subscription = makeMockSubscription();
 
   EXPECT_CALL(*subscriber, onSubscribe_(_)).Times(1);
-  EXPECT_CALL(*subscription, cancel_()).Times(1);
 
   auto writer = std::make_shared<FramedWriter>(subscriber);
   writer->onSubscribe(subscription);
@@ -85,7 +84,6 @@ static void nextSingleFrameTest(int headroom) {
 
   // to delete objects
   EXPECT_CALL(*subscriber, onComplete_()).Times(1);
-  EXPECT_CALL(*subscription, cancel_()).Times(1);
 
   // TODO: cancel should be called automatically
   subscriber->subscription()->cancel();
@@ -141,7 +139,6 @@ static void nextTwoFramesTest(int headroom) {
 
   // to delete objects
   EXPECT_CALL(*subscriber, onComplete_()).Times(1);
-  EXPECT_CALL(*subscription, cancel_()).Times(1);
 
   subscriber->subscription()->cancel();
   writer->onComplete();

--- a/test/streams/Mocks.h
+++ b/test/streams/Mocks.h
@@ -38,8 +38,32 @@ std::shared_ptr<MockSubscriber<T, E>> makeMockSubscriber() {
   return std::make_shared<MockSubscriber<T, E>>();
 }
 
+using CheckpointPtr = std::shared_ptr<testing::MockFunction<void()>>;
+
 template <typename T, typename E>
 class MockSubscriber : public Subscriber<T, E> {
+  class SubscriptionShim : public Subscription {
+   public:
+    explicit SubscriptionShim(
+        std::shared_ptr<Subscription> originalSubscription,
+        CheckpointPtr checkpoint)
+        : originalSubscription_(std::move(originalSubscription)),
+          checkpoint_(std::move(checkpoint)) {}
+
+    void request(size_t n) override final {
+      originalSubscription_->request(n);
+    }
+
+    void cancel() override final {
+      checkpoint_->Call();
+      originalSubscription_->cancel();
+    }
+
+   private:
+    std::shared_ptr<Subscription> originalSubscription_;
+    CheckpointPtr checkpoint_;
+  };
+
  public:
   MOCK_METHOD1(onSubscribe_, void(std::shared_ptr<Subscription> subscription));
   MOCK_METHOD1_T(onNext_, void(T& value));
@@ -47,10 +71,11 @@ class MockSubscriber : public Subscriber<T, E> {
   MOCK_METHOD1_T(onError_, void(E ex));
 
   void onSubscribe(std::shared_ptr<Subscription> subscription) override {
-    subscription_ = subscription;
+    subscription_ = std::make_shared<SubscriptionShim>(
+        std::move(subscription), checkpoint_);
     // We allow registering the same subscriber with multiple Publishers.
-    EXPECT_CALL(checkpoint_, Call());
-    onSubscribe_(subscription);
+    EXPECT_CALL(*checkpoint_, Call()).Times(testing::AtLeast(1));
+    onSubscribe_(subscription_);
   }
 
   void onNext(T element) override {
@@ -58,13 +83,13 @@ class MockSubscriber : public Subscriber<T, E> {
   }
 
   void onComplete() override {
-    checkpoint_.Call();
+    checkpoint_->Call();
     onComplete_();
     subscription_ = nullptr;
   }
 
   void onError(E ex) override {
-    checkpoint_.Call();
+    checkpoint_->Call();
     onError_(ex);
     subscription_ = nullptr;
   }
@@ -74,8 +99,8 @@ class MockSubscriber : public Subscriber<T, E> {
   }
 
  private:
-  std::shared_ptr<Subscription> subscription_;
-  testing::MockFunction<void()> checkpoint_;
+  std::shared_ptr<SubscriptionShim> subscription_;
+  CheckpointPtr checkpoint_{std::make_shared<testing::MockFunction<void()>>()};
 };
 
 /// GoogleMock-compatible Subscriber implementation for fast prototyping.
@@ -87,21 +112,12 @@ class MockSubscription : public Subscription {
   MOCK_METHOD0(cancel_, void());
 
   void request(size_t n) override {
-    if (!requested_) {
-      requested_ = true;
-      EXPECT_CALL(checkpoint_, Call()).Times(1);
-    }
     request_(n);
   }
 
   void cancel() override {
-    checkpoint_.Call();
     cancel_();
   }
-
- private:
-  bool requested_{false};
-  testing::MockFunction<void()> checkpoint_;
 };
 
 // TODO: remove


### PR DESCRIPTION
from the code:

//    once the user cancels the subscriber via the subscription::cancel, it is
//    guaranteed that no more callbacks will be called on the subscriber. It is safe for the client
//    to do cleanup and releasing of resources. User doesn't have to call
//    subscription::cancel in on{Complete,Error} methods.

I left most of the documentation in the code.