### PR TITLE
initial resume API for SETUP/RESUME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,8 @@ add_library(
   src/EnableSharedFromThis.h
   src/SubscriberBase.h
   src/SubscriptionBase.h
-  src/Executor.cpp)
+  src/Executor.cpp
+  src/StreamState.h)
 
 target_link_libraries(
   ReactiveSocket

--- a/src/ConnectionSetupPayload.h
+++ b/src/ConnectionSetupPayload.h
@@ -5,6 +5,7 @@
 #include <folly/io/IOBuf.h>
 #include <string>
 #include "Payload.h"
+#include "StreamState.h"
 
 namespace reactivesocket {
 class ConnectionSetupPayload {
@@ -12,14 +13,18 @@ class ConnectionSetupPayload {
   ConnectionSetupPayload(
       std::string _metadataMimeType = "",
       std::string _dataMimeType = "",
-      Payload _payload = Payload())
+      Payload _payload = Payload(),
+      const ResumeIdentificationToken& token =
+          { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } })
       : metadataMimeType(std::move(_metadataMimeType)),
         dataMimeType(std::move(_dataMimeType)),
-        payload(std::move(_payload)){};
+        payload(std::move(_payload)),
+        token(token) {};
 
   std::string metadataMimeType;
   std::string dataMimeType;
   Payload payload;
+  const ResumeIdentificationToken token;
 };
 
 std::ostream& operator<<(std::ostream&, const ConnectionSetupPayload&);

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -27,11 +27,6 @@ namespace reactivesocket {
 // TODO(stupaq): strong typedef and forward declarations all around
 using StreamId = uint32_t;
 
-/// unique identification token for resumption identification purposes
-using ResumeIdentificationToken = std::array<uint8_t, 16>;
-/// position for resumption
-using ResumePosition = int64_t;
-
 enum class FrameType : uint16_t {
   // TODO(stupaq): commented frame types indicate unimplemented frames
   RESERVED = 0x0000,

--- a/src/NullRequestHandler.cpp
+++ b/src/NullRequestHandler.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "NullRequestHandler.h"
+#include "StreamState.h"
 
 #include <folly/ExceptionWrapper.h>
 
@@ -57,6 +58,9 @@ void NullRequestHandler::handleFireAndForgetRequest(Payload /*request*/) {}
 void NullRequestHandler::handleMetadataPush(
     std::unique_ptr<folly::IOBuf> /*request*/) {}
 
-void NullRequestHandler::handleSetupPayload(
-    ConnectionSetupPayload /*request*/) {}
+std::shared_ptr<StreamState> NullRequestHandler::handleSetupPayload(
+    ConnectionSetupPayload /*request*/) { return std::make_shared<StreamState>(); }
+
+std::shared_ptr<StreamState> NullRequestHandler::handleResume(
+    const ResumeIdentificationToken& /*token*/) { return std::make_shared<StreamState> ();}
 } // reactivesocket

--- a/src/NullRequestHandler.h
+++ b/src/NullRequestHandler.h
@@ -45,7 +45,9 @@ class NullRequestHandler : public RequestHandler {
 
   void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override;
 
-  void handleSetupPayload(ConnectionSetupPayload request) override;
+  std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) override;
+
+  std::shared_ptr<StreamState> handleResume(const ResumeIdentificationToken& token) override;
 };
 
 using DefaultRequestHandler = NullRequestHandler;

--- a/src/Payload.h
+++ b/src/Payload.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <array>
 
 namespace folly {
 class IOBuf;
@@ -19,6 +20,10 @@ namespace reactivesocket {
 // TODO(lehecka): share the definition with Frame.h
 using FrameFlags = uint16_t;
 const FrameFlags FrameFlags_METADATA = 0x4000;
+/// unique identification token for resumption identification purposes
+using ResumeIdentificationToken = std::array<uint8_t, 16>;
+/// position for resumption
+using ResumePosition = int64_t;
 
 /// The type of a read-only view on a binary buffer.
 /// MUST manage the lifetime of the underlying buffer.

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -12,6 +12,8 @@ class Executor;
 
 namespace reactivesocket {
 
+class StreamState;
+
 class SubscriberFactory {
  public:
   virtual ~SubscriberFactory() = default;
@@ -59,7 +61,11 @@ class RequestHandlerBase {
 
   /// Temporary home - this should eventually be an input to asking for a
   /// RequestHandler so negotiation is possible
-  virtual void handleSetupPayload(ConnectionSetupPayload request) = 0;
+  virtual std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) = 0;
+
+  /// Temporary home - this should accompany handleSetupPayload
+  /// Return stream state for the given token. Reutn nullptr to disable resume
+  virtual std::shared_ptr<StreamState> handleResume(const ResumeIdentificationToken& token) = 0;
 };
 
 class RequestHandler : public RequestHandlerBase {

--- a/src/StreamState.h
+++ b/src/StreamState.h
@@ -1,0 +1,34 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <unordered_map>
+
+#include "ResumeTracker.h"
+#include "ResumeCache.h"
+
+namespace reactivesocket {
+
+class AbstractStreamAutomaton;
+using StreamId = uint32_t;
+
+class StreamState
+{
+public:
+    StreamState()
+        : resumeTracker_(new ResumeTracker()),
+          resumeCache_(new ResumeCache()) {
+    }
+
+    virtual ~StreamState() = default;
+
+    std::unordered_map<StreamId, std::shared_ptr<AbstractStreamAutomaton>>
+        streams_;
+    std::unique_ptr<ResumeTracker> resumeTracker_;
+    std::unique_ptr<ResumeCache> resumeCache_;
+};
+
+}

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -76,6 +76,7 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
       [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),
       false);
@@ -143,6 +144,7 @@ static void terminateTest(
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
       [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),
       false);
@@ -224,6 +226,7 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
       [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),
       false);

--- a/test/MockRequestHandler.h
+++ b/test/MockRequestHandler.h
@@ -31,7 +31,8 @@ class MockRequestHandlerBase : public RequestHandlerBase {
   MOCK_METHOD1(
       handleMetadataPush_,
       void(std::unique_ptr<folly::IOBuf>& request));
-  MOCK_METHOD1(handleSetupPayload_, void(ConnectionSetupPayload& request));
+  MOCK_METHOD1(handleSetupPayload_, std::shared_ptr<StreamState>(ConnectionSetupPayload& request));
+  MOCK_METHOD1(handleResume_, std::shared_ptr<StreamState>(const ResumeIdentificationToken & token));
 
   std::shared_ptr<Subscriber<Payload>> onRequestChannel(
       Payload request,
@@ -63,9 +64,14 @@ class MockRequestHandlerBase : public RequestHandlerBase {
     handleMetadataPush_(request);
   }
 
-  void handleSetupPayload(ConnectionSetupPayload request) override {
-    handleSetupPayload_(request);
+  std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) override {
+    return handleSetupPayload_(request);
   }
+
+  std::shared_ptr<StreamState> handleResume(const ResumeIdentificationToken& token) override {
+    return handleResume_(token);
+  }
+
 };
 
 class MockRequestHandler : public RequestHandler {
@@ -88,7 +94,8 @@ class MockRequestHandler : public RequestHandler {
   MOCK_METHOD1(
       handleMetadataPush_,
       void(std::unique_ptr<folly::IOBuf>& request));
-  MOCK_METHOD1(handleSetupPayload_, void(ConnectionSetupPayload& request));
+  MOCK_METHOD1(handleSetupPayload_, std::shared_ptr<StreamState>(ConnectionSetupPayload& request));
+  MOCK_METHOD1(handleResume_, std::shared_ptr<StreamState>(const ResumeIdentificationToken & token));
 
   std::shared_ptr<Subscriber<Payload>> handleRequestChannel(
       Payload request,
@@ -122,8 +129,13 @@ class MockRequestHandler : public RequestHandler {
     handleMetadataPush_(request);
   }
 
-  void handleSetupPayload(ConnectionSetupPayload request) override {
-    handleSetupPayload_(request);
+  std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) override {
+    return handleSetupPayload_(request);
   }
+
+  std::shared_ptr<StreamState> handleResume(const ResumeIdentificationToken& token) override {
+    return handleResume_(token);
+  }
+
 };
 }

--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -38,7 +38,8 @@ class ClientSideConcurrencyTest : public testing::Test {
     auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_));
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+        .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
     serverSock = ReactiveSocket::fromServerConnection(
         std::move(serverConn), std::move(serverHandler));
@@ -240,7 +241,8 @@ class ServerSideConcurrencyTest : public testing::Test {
         folly::make_unique<StrictMock<MockRequestHandlerBase>>();
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_));
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+        .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
     serverSock = ReactiveSocket::fromServerConnection(
         std::move(serverConn), std::move(serverHandler));

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -59,7 +59,9 @@ TEST(ReactiveSocketTest, RequestChannel) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -173,7 +175,9 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -257,7 +261,9 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -338,7 +344,9 @@ TEST(ReactiveSocketTest, RequestSubscription) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -420,7 +428,9 @@ TEST(ReactiveSocketTest, RequestSubscriptionSurplusResponse) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -489,7 +499,9 @@ TEST(ReactiveSocketTest, RequestResponse) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -557,7 +569,9 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -592,7 +606,9 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -627,7 +643,9 @@ TEST(ReactiveSocketTest, SetupData) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));
@@ -673,7 +691,9 @@ TEST(ReactiveSocketTest, Destructor) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_)).InSequence(s);
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .InSequence(s)
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler), serverStats);
@@ -748,7 +768,8 @@ TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
   auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_));
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
       std::move(serverConn), std::move(serverHandler));

--- a/test/tcp/TcpServer.cpp
+++ b/test/tcp/TcpServer.cpp
@@ -79,8 +79,9 @@ class ServerRequestHandler : public DefaultRequestHandler {
               << request->moveToFbString();
   }
 
-  void handleSetupPayload(ConnectionSetupPayload request) override {
+  std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) override {
     LOG(INFO) << "ServerRequestHandler.handleSetupPayload " << request;
+    return std::make_shared<StreamState>();
   }
 };
 


### PR DESCRIPTION
I've been iterating on the API for resume. Feedback welcome.

The hideous method of "resumeFromSocket" and technique has been removed. Now RequestHandler has a `handleResume` method that is called instead.

The state for the connection is kept in a `StreamState` object (name is not very good, but can't think of a better one. Open to suggestions). This state is now created by the return value of `RequestHandler::handleSetupPayload` and returned in `RequestHandler::handleResume`.

This is not perfect, but it seems cleaner. By bringing the stream state out into its own object, it can be managed easier. It also decouples it from the ReactiveSocket. RequestHandler is maybe not the perfect place to put SETUP and RESUME logic, but we could break those out into their own handler. Would love opinions on that.

The aspects of marking dirty/clean are not included in this PR. I wanted to get feedback on this first and get it sorted then include what I have been playing with for dirty/clean.
