### PR TITLE
making ReactiveSocket::createResponder method static

### DIFF
--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -221,13 +221,13 @@ void ConnectionAutomaton::onConnectionFrame(
     case FrameType::SETUP: {
       // TODO(tmont): check for ENABLE_RESUME and make sure isResumable_ is true
 
-      if (!factory_(0, std::move(payload))) {
+      if (!factory_(*this, 0, std::move(payload))) {
         assert(false);
       }
       return;
     }
     case FrameType::METADATA_PUSH: {
-      if (!factory_(0, std::move(payload))) {
+      if (!factory_(*this, 0, std::move(payload))) {
         assert(false);
       }
       return;
@@ -343,7 +343,7 @@ void ConnectionAutomaton::handleUnknownStream(
     std::unique_ptr<folly::IOBuf> payload) {
   // TODO(stupaq): there are some rules about monotonically increasing stream
   // IDs -- let's forget about them for a moment
-  if (!factory_(streamId, std::move(payload))) {
+  if (!factory_(*this, streamId, std::move(payload))) {
     outputFrameOrEnqueue(
         Frame_ERROR::connectionError(
             folly::to<std::string>("unknown stream ", streamId))

--- a/src/ConnectionAutomaton.h
+++ b/src/ConnectionAutomaton.h
@@ -22,6 +22,8 @@ enum class FrameType : uint16_t;
 enum class StreamCompletionSignal;
 using StreamId = uint32_t;
 
+class ConnectionAutomaton;
+
 /// Creates, registers and spins up responder for provided new stream ID and
 /// serialised frame.
 ///
@@ -30,8 +32,10 @@ using StreamId = uint32_t;
 /// Returns true if the responder has been created successfully, false if the
 /// frame cannot start a new stream, in which case the frame (passed by a
 /// mutable referece) must not be modified.
-using StreamAutomatonFactory =
-    std::function<bool(StreamId, std::unique_ptr<folly::IOBuf>)>;
+using StreamAutomatonFactory = std::function<bool(
+    ConnectionAutomaton& connection,
+    StreamId,
+    std::unique_ptr<folly::IOBuf>)>;
 
 using ResumeListener = std::function<std::shared_ptr<StreamState>(
     const ResumeIdentificationToken& token)>;

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -108,12 +108,12 @@ class ReactiveSocket {
   ReactiveSocket(
       bool isServer,
       std::unique_ptr<DuplexConnection> connection,
-      std::unique_ptr<RequestHandlerBase> handler,
+      std::shared_ptr<RequestHandlerBase> handler,
       Stats& stats,
       std::unique_ptr<KeepaliveTimer> keepaliveTimer);
 
   static bool createResponder(
-      const std::shared_ptr<RequestHandlerBase>& handler,
+      RequestHandlerBase& handler,
       ConnectionAutomaton& connection,
       StreamId streamId,
       std::unique_ptr<folly::IOBuf> frame);

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -112,12 +112,16 @@ class ReactiveSocket {
       Stats& stats,
       std::unique_ptr<KeepaliveTimer> keepaliveTimer);
 
-  bool createResponder(StreamId streamId, std::unique_ptr<folly::IOBuf> frame);
+  static bool createResponder(
+      const std::shared_ptr<RequestHandlerBase>& handler,
+      ConnectionAutomaton& connection,
+      StreamId streamId,
+      std::unique_ptr<folly::IOBuf> frame);
   std::shared_ptr<StreamState> resumeListener(
       const ResumeIdentificationToken& token);
 
+  std::shared_ptr<RequestHandlerBase> handler_;
   const std::shared_ptr<ConnectionAutomaton> connection_;
-  std::unique_ptr<RequestHandlerBase> handler_;
   StreamId nextStreamId_;
   std::unique_ptr<KeepaliveTimer> keepaliveTimer_;
 };

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -75,7 +75,9 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
 
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
-      [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      [](ConnectionAutomaton&, StreamId, std::unique_ptr<folly::IOBuf>) {
+        return false;
+      },
       std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),
@@ -143,7 +145,9 @@ static void terminateTest(
 
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
-      [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      [](ConnectionAutomaton&, StreamId, std::unique_ptr<folly::IOBuf>) {
+        return false;
+      },
       std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),
@@ -225,7 +229,9 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
 
   auto connectionAutomaton = std::make_shared<ConnectionAutomaton>(
       std::move(framedAutomatonConnection),
-      [](StreamId, std::unique_ptr<folly::IOBuf>) { return false; },
+      [](ConnectionAutomaton&, StreamId, std::unique_ptr<folly::IOBuf>) {
+        return false;
+      },
       std::make_shared<StreamState>(),
       nullptr,
       Stats::noop(),


### PR DESCRIPTION
For my next PR I want to be able to release the instance of ReactiveSocket while in the RequestHandler::handleRequestXXX.
If I do it today I will end up destroying the instance while in the ReactiveSocket::createResponder method in on the stack and accessing member variables.
This change is turning the method into the static method which will guarantee its not accessing any member variables.