### PR TITLE
initial resume dirty/clean API

### DIFF
--- a/src/AbstractStreamAutomaton.h
+++ b/src/AbstractStreamAutomaton.h
@@ -85,6 +85,9 @@ class AbstractStreamAutomaton {
   /// 3. per "unsubscribe handshake", the automaton must deliver corresponding
   ///   terminal signal to the connection.
   virtual void endStream(StreamCompletionSignal signal) = 0;
+
+  virtual void onCleanResume() = 0;
+  virtual void onDirtyResume() = 0;
   /// @}
 
  protected:

--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -255,8 +255,18 @@ void ConnectionAutomaton::onConnectionFrame(
           outputFrameOrEnqueue(
               Frame_RESUME_OK(streamState_->resumeTracker_->impliedPosition())
                   .serializeOut());
-          streamState_->resumeCache_->retransmitFromPosition(
-              frame.position_, *this);
+
+            if (streamState_->resumeCache_->isPositionAvailable(frame.position_)) {
+              // clean
+              for (auto it : streamState_->streams_) {
+                it.second->onCleanResume();
+              }
+            } else {
+              // dirty
+              for (auto it : streamState_->streams_) {
+                it.second->onDirtyResume();
+              }
+            }
         } else {
           outputFrameOrEnqueue(
               Frame_ERROR::connectionError("can not resume").serializeOut());
@@ -422,7 +432,7 @@ void ConnectionAutomaton::useStreamState(
     std::shared_ptr<StreamState> streamState) {
   CHECK(streamState);
   if (isServer_ && isResumable_) {
-    streamState_ = streamState;
+    streamState_.swap(streamState);
   }
 }
 }

--- a/src/NullRequestHandler.cpp
+++ b/src/NullRequestHandler.cpp
@@ -67,4 +67,11 @@ std::shared_ptr<StreamState> NullRequestHandler::handleResume(
     const ResumeIdentificationToken& /*token*/) {
   return std::make_shared<StreamState>();
 }
+
+void NullRequestHandler::handleCleanResume(
+    std::shared_ptr<Subscription> /* response */) {}
+
+void NullRequestHandler::handleDirtyResume(
+    std::shared_ptr<Subscription> /* response */) {}
+
 } // reactivesocket

--- a/src/NullRequestHandler.h
+++ b/src/NullRequestHandler.h
@@ -50,6 +50,10 @@ class NullRequestHandler : public RequestHandler {
 
   std::shared_ptr<StreamState> handleResume(
       const ResumeIdentificationToken& token) override;
+
+  void handleCleanResume(std::shared_ptr<Subscription> response) override;
+
+  void handleDirtyResume(std::shared_ptr<Subscription> response) override;
 };
 
 using DefaultRequestHandler = NullRequestHandler;

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -113,7 +113,7 @@ class ReactiveSocket {
       std::unique_ptr<KeepaliveTimer> keepaliveTimer);
 
   static bool createResponder(
-      RequestHandlerBase& handler,
+      std::shared_ptr<RequestHandlerBase> handler,
       ConnectionAutomaton& connection,
       StreamId streamId,
       std::unique_ptr<folly::IOBuf> frame);

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -68,6 +68,10 @@ class RequestHandlerBase {
   /// Return stream state for the given token. Reutn nullptr to disable resume
   virtual std::shared_ptr<StreamState> handleResume(
       const ResumeIdentificationToken& token) = 0;
+
+  virtual void handleCleanResume(std::shared_ptr<Subscription> response) = 0;
+
+  virtual void handleDirtyResume(std::shared_ptr<Subscription> response) = 0;
 };
 
 class RequestHandler : public RequestHandlerBase {

--- a/src/mixins/MixinTerminator.h
+++ b/src/mixins/MixinTerminator.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <functional>
 
+
 #include "src/RequestHandler.h"
 
 namespace reactivesocket {

--- a/src/mixins/MixinTerminator.h
+++ b/src/mixins/MixinTerminator.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <functional>
 
-#include "src/Requesthandler.h"
+#include "src/RequestHandler.h"
 
 namespace reactivesocket {
 

--- a/src/mixins/MixinTerminator.h
+++ b/src/mixins/MixinTerminator.h
@@ -5,6 +5,9 @@
 #include <cstdint>
 #include <iosfwd>
 #include <memory>
+#include <functional>
+
+#include "src/Requesthandler.h"
 
 namespace reactivesocket {
 
@@ -36,18 +39,25 @@ class MixinTerminator {
     Parameters() = default;
     Parameters(
         const std::shared_ptr<ConnectionAutomaton>& _connection,
-        StreamId _streamId)
-        : connection(_connection), streamId(_streamId) {}
+        StreamId _streamId,
+        std::shared_ptr<RequestHandlerBase> _handler)
+        : connection(_connection), streamId(_streamId), handler(_handler) {}
 
     std::shared_ptr<ConnectionAutomaton> connection{nullptr};
     StreamId streamId{0};
+    std::shared_ptr<RequestHandlerBase> handler;
   };
   explicit MixinTerminator(Parameters params)
-      : connection_(std::move(params.connection)), streamId_(params.streamId) {}
+      : connection_(std::move(params.connection)),
+      streamId_(params.streamId),
+      requestHandler_(params.handler) {}
 
   /// Logs an identification string of the automaton.
   std::ostream& logPrefix(std::ostream& os) /* = 0 */;
   /// @}
+
+  void onCleanResume() {}
+  void onDirtyResume() {}
 
  protected:
   bool isTerminated() const {
@@ -83,5 +93,6 @@ class MixinTerminator {
   /// An ID of the stream (within the connection) this automaton manages.
   const StreamId streamId_;
   bool isTerminated_{false};
+  std::shared_ptr<RequestHandlerBase> requestHandler_;
 };
 }

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -41,6 +41,19 @@ class PublisherMixin : public Base {
               << this->streamId_ << "): ";
   }
 
+  void onCleanResume() {
+    Base::requestHandler_->handleCleanResume(producingSubscription_);
+    Base::onCleanResume();
+  }
+  void onDirtyResume() {
+    Base::requestHandler_->handleDirtyResume(producingSubscription_);
+    Base::onDirtyResume();
+  }
+
+  std::shared_ptr<Subscription> subscription() {
+    return producingSubscription_;
+  }
+
  protected:
   /// @{
   void endStream(StreamCompletionSignal signal) {

--- a/src/mixins/StreamIfMixin.h
+++ b/src/mixins/StreamIfMixin.h
@@ -52,5 +52,13 @@ class StreamIfMixin : public Base, public AbstractStreamAutomaton {
   void onBadFrame() override final {
     Base::onBadFrame();
   }
+
+  void onCleanResume() override final {
+    Base::onCleanResume();
+  }
+
+  void onDirtyResume() override final {
+    Base::onDirtyResume();
+  }
 };
 }

--- a/test/MockRequestHandler.h
+++ b/test/MockRequestHandler.h
@@ -77,6 +77,9 @@ class MockRequestHandlerBase : public RequestHandlerBase {
       const ResumeIdentificationToken& token) override {
     return handleResume_(token);
   }
+
+  void handleCleanResume(std::shared_ptr<Subscription> response) override {}
+  void handleDirtyResume(std::shared_ptr<Subscription> response) override {}
 };
 
 class MockRequestHandler : public RequestHandler {
@@ -147,5 +150,8 @@ class MockRequestHandler : public RequestHandler {
       const ResumeIdentificationToken& token) override {
     return handleResume_(token);
   }
+
+  void handleCleanResume(std::shared_ptr<Subscription> response) override {}
+  void handleDirtyResume(std::shared_ptr<Subscription> response) override {}
 };
 }

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -82,7 +82,7 @@ class ServerRequestHandler : public DefaultRequestHandler {
     for (uint8_t byte : request.token) {
       str << (int)byte;
     }
-    str << "> " << streamState_.get() << "\n";
+    str << "> " << streamState_.get() << " " << streamState_->streams_.size() << "\n";
     LOG(INFO) << str.str();
     return streamState_;
   }
@@ -95,10 +95,18 @@ class ServerRequestHandler : public DefaultRequestHandler {
     for (uint8_t byte : token) {
       str << (int)byte;
     }
-    str << "> " << streamState_.get() << "\n";
+    str << "> " << streamState_.get() << " " << streamState_->streams_.size() << "\n";
 
     LOG(INFO) << str.str();
     return streamState_;
+  }
+
+  void handleCleanResume(std::shared_ptr<Subscription> response) override {
+    LOG(INFO) << "clean resume stream" << "\n";
+  }
+
+  void handleDirtyResume(std::shared_ptr<Subscription> response) override {
+    LOG(INFO) << "dirty resume stream" << "\n";
   }
 
  private:


### PR DESCRIPTION
Resume dirty/clean API via RequestHandler methods for discussion. This does not touch the ReactiveStreams classes to add the dirty/clean methods.

This allows all streams to be handled the same. Individual streams may need some form of distinction. Which could be done by the application.