### PR TITLE
replacing CHECK with onError in FramedReader

### DIFF
--- a/src/ConnectionAutomaton.h
+++ b/src/ConnectionAutomaton.h
@@ -136,6 +136,8 @@ class ConnectionAutomaton :
   void onClose(ConnectionCloseListener listener);
 
  private:
+  void closeDuplexConnection(folly::exception_wrapper ex);
+
   /// Performs the same actions as ::endStream without propagating closure
   /// signal to the underlying connection.
   ///

--- a/src/framed/FramedReader.cpp
+++ b/src/framed/FramedReader.cpp
@@ -38,7 +38,7 @@ void FramedReader::parseFrames() {
     }
 
     folly::io::Cursor c(payloadQueue_.front());
-    const auto nextFrameSize = c.readBE<int32_t>();
+    const auto nextFrameSize = static_cast<size_t>(c.readBE<int32_t>());
 
     // the frame size includes the payload size and the size value
     // so if the size value is less than sizeof(int32_t) something is wrong
@@ -47,7 +47,7 @@ void FramedReader::parseFrames() {
       break;
     }
 
-    if (payloadQueue_.chainLength() < (size_t)nextFrameSize) {
+    if (payloadQueue_.chainLength() < nextFrameSize) {
       // need to accumulate more data
       break;
     }

--- a/src/framed/FramedReader.cpp
+++ b/src/framed/FramedReader.cpp
@@ -39,7 +39,10 @@ void FramedReader::parseFrames() {
 
     folly::io::Cursor c(payloadQueue_.front());
     const auto nextFrameSize = c.readBE<int32_t>();
-    CHECK_GE(nextFrameSize, sizeof(int32_t));
+
+    if (nextFrameSize > sizeof(int32_t)) {
+        onErrorImpl(std::runtime_error("invalid data stream"));
+    }
 
     if (payloadQueue_.chainLength() < (size_t)nextFrameSize) {
       // need to accumulate more data

--- a/test/InlineConnection.cpp
+++ b/test/InlineConnection.cpp
@@ -56,8 +56,14 @@ std::shared_ptr<Subscriber<std::unique_ptr<folly::IOBuf>>>
 InlineConnection::getOutput() {
   using namespace ::testing;
 
+  if (outputSink_) {
+    return outputSink_;
+  }
+
   auto outputSink =
       std::make_shared<MockSubscriber<std::unique_ptr<folly::IOBuf>>>();
+  outputSink_ = outputSink;
+
   // A check point for either of the terminal signals.
   auto* checkpoint = new MockFunction<void()>();
 

--- a/test/InlineConnection.h
+++ b/test/InlineConnection.h
@@ -67,5 +67,6 @@ class InlineConnection : public DuplexConnection {
 
   std::shared_ptr<SharedState> other_;
   std::shared_ptr<SharedState> this_{std::make_shared<SharedState>()};
+  std::shared_ptr<Subscriber<std::unique_ptr<folly::IOBuf>>> outputSink_;
 };
 }


### PR DESCRIPTION
This is along the way of not crashing when handling invalid input, but rather fail gracefully.