### PR TITLE
implementing disconnecting of ReactiveSocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,8 @@ add_executable(
   test/ReactiveStreamsMocksCompat.h
   test/SubscriberBaseTest.cpp
   test/Test.cpp
-  test/folly/FollyKeepaliveTimerTest.cpp)
+  test/folly/FollyKeepaliveTimerTest.cpp
+  test/ReactiveSocketResumabilityTest.cpp)
 
 target_link_libraries(
   tests

--- a/src/AbstractStreamAutomaton.cpp
+++ b/src/AbstractStreamAutomaton.cpp
@@ -10,27 +10,6 @@
 
 namespace reactivesocket {
 
-std::ostream& operator<<(std::ostream& os, StreamCompletionSignal signal) {
-  switch (signal) {
-    case StreamCompletionSignal::GRACEFUL:
-      return os << "GRACEFUL";
-    case StreamCompletionSignal::ERROR:
-      return os << "ERROR";
-    case StreamCompletionSignal::INVALID_SETUP:
-      return os << "INVALID_SETUP";
-    case StreamCompletionSignal::UNSUPPORTED_SETUP:
-      return os << "UNSUPPORTED_SETUP";
-    case StreamCompletionSignal::REJECTED_SETUP:
-      return os << "REJECTED_SETUP";
-    case StreamCompletionSignal::CONNECTION_ERROR:
-      return os << "CONNECTION_ERROR";
-    case StreamCompletionSignal::CONNECTION_END:
-      return os << "CONNECTION_END";
-  }
-  // this should be never hit because the switch is over all cases
-  std::abort();
-}
-
 void AbstractStreamAutomaton::onNextFrame(
     std::unique_ptr<folly::IOBuf> payload) {
   assert(payload);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -18,7 +18,7 @@ static const char* getTerminatingSignalErrorMessage(int terminatingSignal) {
       return "reactive socket closed";
     case StreamCompletionSignal::GRACEFUL:
       DCHECK(false) << "throwing exception for GRACEFUL termination?";
-      return "gracefull termination";
+      return "graceful termination";
     default:
       return "stream interrupted";
   }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -14,12 +14,37 @@ static const char* getTerminatingSignalErrorMessage(int terminatingSignal) {
       return "connection error";
     case StreamCompletionSignal::ERROR:
       return "general error";
+    case StreamCompletionSignal::SOCKET_CLOSED:
+      return "reactive socket closed";
     case StreamCompletionSignal::GRACEFUL:
       DCHECK(false) << "throwing exception for GRACEFUL termination?";
       return "gracefull termination";
     default:
       return "stream interrupted";
   }
+}
+
+std::ostream& operator<<(std::ostream& os, StreamCompletionSignal signal) {
+  switch (signal) {
+    case StreamCompletionSignal::GRACEFUL:
+      return os << "GRACEFUL";
+    case StreamCompletionSignal::ERROR:
+      return os << "ERROR";
+    case StreamCompletionSignal::INVALID_SETUP:
+      return os << "INVALID_SETUP";
+    case StreamCompletionSignal::UNSUPPORTED_SETUP:
+      return os << "UNSUPPORTED_SETUP";
+    case StreamCompletionSignal::REJECTED_SETUP:
+      return os << "REJECTED_SETUP";
+    case StreamCompletionSignal::CONNECTION_ERROR:
+      return os << "CONNECTION_ERROR";
+    case StreamCompletionSignal::CONNECTION_END:
+      return os << "CONNECTION_END";
+    case StreamCompletionSignal::SOCKET_CLOSED:
+      return os << "SOCKET_CLOSED";
+  }
+  // this should be never hit because the switch is over all cases
+  LOG(FATAL) << "unknown StreamCompletionSignal=" << (int)signal;
 }
 
 StreamInterruptedException::StreamInterruptedException(int _terminatingSignal)

--- a/src/Common.h
+++ b/src/Common.h
@@ -29,6 +29,7 @@ enum class StreamCompletionSignal {
   REJECTED_SETUP,
   CONNECTION_ERROR,
   CONNECTION_END,
+  SOCKET_CLOSED,
 };
 
 std::ostream& operator<<(std::ostream&, StreamCompletionSignal);

--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -60,11 +60,9 @@ void ConnectionAutomaton::connect() {
     // provided
     // subscription, which might deliver frames in-line.
     // it can also call onComplete which will call disconnect/close and reset
-    // the
-    // connection_
-    // while still inside of the connection_::setInput method. We will create
-    // a hard reference for that case and keep the object alive until we
-    // return from the setInput method
+    // the connection_ while still inside of the connection_::setInput method.
+    // We will create a hard reference for that case and keep the object alive
+    // until setInput method returns
     auto connectionCopy = connection_;
     connectionCopy->setInput(shared_from_this());
   }

--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -17,6 +17,7 @@ ConnectionAutomaton::ConnectionAutomaton(
     Stats& stats,
     const std::shared_ptr<KeepaliveTimer>& keepaliveTimer,
     bool isServer,
+    bool isResumable,
     std::function<void()> onConnected,
     std::function<void()> onDisconnected,
     std::function<void()> onClosed)
@@ -25,7 +26,7 @@ ConnectionAutomaton::ConnectionAutomaton(
       streamState_(std::move(streamState)),
       stats_(stats),
       isServer_(isServer),
-      isResumable_(true),
+      isResumable_(isResumable),
       onConnected_(std::move(onConnected)),
       onDisconnected_(std::move(onDisconnected)),
       onClosed_(std::move(onClosed)),
@@ -41,19 +42,25 @@ ConnectionAutomaton::ConnectionAutomaton(
   CHECK(onClosed_);
 }
 
+ConnectionAutomaton::~ConnectionAutomaton() {
+  VLOG(6) << "~ConnectionAutomaton";
+  // We rely on SubscriptionPtr and SubscriberPtr to dispatch appropriate
+  // terminal signals.
+}
+
 void ConnectionAutomaton::connect() {
   CHECK(connection_);
   connectionOutput_.reset(connection_->getOutput());
   connectionOutput_.onSubscribe(shared_from_this());
 
   // the onSubscribe call on the previous line may have called the terminating
-  // signal
-  // which would call disconnect
+  // signal which would call disconnect/close
   if (connection_) {
     // This may call ::onSubscribe in-line, which calls ::request on the
     // provided
     // subscription, which might deliver frames in-line.
-    // it can also call onComplete which will call disconnect() and reset the
+    // it can also call onComplete which will call disconnect/close and reset
+    // the
     // connection_
     // while still inside of the connection_::setInput method. We will create
     // a hard reference for that case and keep the object alive until we
@@ -62,43 +69,48 @@ void ConnectionAutomaton::connect() {
     connectionCopy->setInput(shared_from_this());
   }
 
+  if (connection_) {
+    onConnected_();
+  }
+
   // TODO: move to appropriate place
   stats_.socketCreated();
-  onConnected_();
 }
 
-std::unique_ptr<DuplexConnection> ConnectionAutomaton::disconnect() {
+void ConnectionAutomaton::disconnect() {
   VLOG(6) << "disconnect";
-  // TODO(lehecka):
-  // 1. make sure that all streams will stay intact
-  // 2. make sure duplex connection will not call back into *this
-  // 3. keep output buffers open, so that existing streams can write output
-  // frames
-  onDisconnected_();
-  return nullptr;
-}
-
-void ConnectionAutomaton::close() {
-  VLOG(6) << "close";
-  closeDuplexConnection(folly::exception_wrapper());
-}
-
-void ConnectionAutomaton::closeWithError(Frame_ERROR&& error) {
-  VLOG(4) << "closeWithError "
-          << error.payload_.data->cloneAsValue().moveToFbString();
-
-  outputFrameOrEnqueue(error.serializeOut());
-  close();
-}
-
-void ConnectionAutomaton::closeDuplexConnection(folly::exception_wrapper ex) {
-  if (!connectionOutput_) {
+  if (!connection_) {
     return;
   }
 
-  LOG_IF(WARNING, !streamState_->pendingWrites_.empty())
-      << "closing with pending writes (" << streamState_->pendingWrites_.size()
-      << ")";
+  closeDuplexConnection(folly::exception_wrapper());
+  stats_.socketDisconnected();
+  onDisconnected_();
+}
+
+void ConnectionAutomaton::close() {
+  close(folly::exception_wrapper(), StreamCompletionSignal::SOCKET_CLOSED);
+}
+
+void ConnectionAutomaton::close(
+    folly::exception_wrapper ex,
+    StreamCompletionSignal signal) {
+  VLOG(6) << "close";
+  closeStreams(signal);
+  closeDuplexConnection(std::move(ex));
+  if (onClosed_) {
+    stats_.socketClosed();
+    onClosed_();
+    onClosed_ = nullptr;
+  }
+}
+
+void ConnectionAutomaton::closeDuplexConnection(folly::exception_wrapper ex) {
+  if (!connection_) {
+    return;
+  }
+
+  auto oldConnection = std::move(connection_);
 
   // Send terminal signals to the DuplexConnection's input and output before
   // tearing it down. We must do this per DuplexConnection specification (see
@@ -109,10 +121,14 @@ void ConnectionAutomaton::closeDuplexConnection(folly::exception_wrapper ex) {
     connectionOutput_.onComplete();
   }
   connectionInputSub_.cancel();
-  connection_.reset();
+}
 
-  stats_.socketClosed();
-  onClosed_();
+void ConnectionAutomaton::closeWithError(Frame_ERROR&& error) {
+  VLOG(4) << "closeWithError "
+          << error.payload_.data->cloneAsValue().moveToFbString();
+
+  outputFrameOrEnqueue(error.serializeOut());
+  close(folly::exception_wrapper(), StreamCompletionSignal::ERROR);
 }
 
 void ConnectionAutomaton::reconnect(
@@ -125,12 +141,6 @@ void ConnectionAutomaton::reconnect(
   disconnect();
   connection_ = std::shared_ptr<DuplexConnection>(std::move(newConnection));
   connect();
-}
-
-ConnectionAutomaton::~ConnectionAutomaton() {
-  VLOG(6) << "~ConnectionAutomaton";
-  // We rely on SubscriptionPtr and SubscriberPtr to dispatch appropriate
-  // terminal signals.
 }
 
 void ConnectionAutomaton::addStream(
@@ -169,6 +179,21 @@ bool ConnectionAutomaton::endStreamInternal(
   streamState_->streams_.erase(it);
   automaton->endStream(signal);
   return true;
+}
+
+void ConnectionAutomaton::closeStreams(StreamCompletionSignal signal) {
+  // Close all streams.
+  while (!streamState_->streams_.empty()) {
+    auto oldSize = streamState_->streams_.size();
+    auto result =
+        endStreamInternal(streamState_->streams_.begin()->first, signal);
+    (void)oldSize;
+    (void)result;
+    // TODO(stupaq): what kind of a user action could violate these
+    // assertions?
+    assert(result);
+    assert(streamState_->streams_.size() == oldSize - 1);
+  }
 }
 
 /// @{
@@ -215,12 +240,26 @@ void ConnectionAutomaton::onNext(std::unique_ptr<folly::IOBuf> frame) {
   automaton->onNextFrame(std::move(frame));
 }
 
+void ConnectionAutomaton::onDuplexConnectionTerminal(
+    folly::exception_wrapper ex,
+    StreamCompletionSignal signal) {
+  if (isResumable_) {
+    disconnect();
+  } else {
+    close(std::move(ex), signal);
+  }
+}
+
 void ConnectionAutomaton::onComplete() {
-  onTerminal(folly::exception_wrapper());
+  VLOG(6) << "onComplete";
+  onDuplexConnectionTerminal(
+      folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
 }
 
 void ConnectionAutomaton::onError(folly::exception_wrapper ex) {
-  onTerminal(std::move(ex));
+  VLOG(6) << "onError" << ex.what();
+  onDuplexConnectionTerminal(
+      std::move(ex), StreamCompletionSignal::CONNECTION_ERROR);
 }
 
 void ConnectionAutomaton::onConnectionFrame(
@@ -321,34 +360,6 @@ void ConnectionAutomaton::onConnectionFrame(
 }
 /// @}
 
-void ConnectionAutomaton::onTerminal(folly::exception_wrapper ex) {
-  VLOG(6) << "onTerminal";
-  // TODO(stupaq): we should rather use error codes that we do understand
-  // instead of exceptions we have no idea about
-  auto signal = ex ? StreamCompletionSignal::CONNECTION_ERROR
-                   : StreamCompletionSignal::CONNECTION_END;
-
-  if (ex) {
-    VLOG(1) << signal << " from " << ex.what();
-  }
-
-  // Close all streams.
-  while (!streamState_->streams_.empty()) {
-    auto oldSize = streamState_->streams_.size();
-    auto result =
-        endStreamInternal(streamState_->streams_.begin()->first, signal);
-    (void)oldSize;
-    (void)result;
-    // TODO(stupaq): what kind of a user action could violate these
-    // assertions?
-    assert(result);
-    assert(streamState_->streams_.size() == oldSize - 1);
-  }
-
-  closeDuplexConnection(std::move(ex));
-}
-
-/// @{
 void ConnectionAutomaton::request(size_t n) {
   if (writeAllowance_.release(n) > 0) {
     // There are no pending writes or we already have this method on the
@@ -360,14 +371,9 @@ void ConnectionAutomaton::request(size_t n) {
 
 void ConnectionAutomaton::cancel() {
   VLOG(6) << "cancel";
-
-  streamState_->pendingWrites_.clear();
-
-  // TODO(lehecka): if this is resumable, then call disconnect, otherwise call
-  // close
-  close();
+  onDuplexConnectionTerminal(
+      folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
 }
-/// @}
 
 /// @{
 void ConnectionAutomaton::handleUnknownStream(
@@ -407,18 +413,17 @@ ResumePosition ConnectionAutomaton::positionDifference(
 
 void ConnectionAutomaton::outputFrameOrEnqueue(
     std::unique_ptr<folly::IOBuf> frame) {
-  if (!connectionOutput_) {
-    return; // RS destructor has disconnected us from the DuplexConnection
+  if (connection_) {
+    drainOutputFramesQueue();
+    if (streamState_->pendingWrites_.empty() && writeAllowance_.tryAcquire()) {
+      outputFrame(std::move(frame));
+      return;
+    }
   }
-
-  drainOutputFramesQueue();
-  if (streamState_->pendingWrites_.empty() && writeAllowance_.tryAcquire()) {
-    outputFrame(std::move(frame));
-  } else {
-    // We either have no allowance to perform the operation, or the queue has
-    // not been drained (e.g. we're looping in ::request).
-    streamState_->pendingWrites_.emplace_back(std::move(frame));
-  }
+  // We either have no allowance to perform the operation, or the queue has
+  // not been drained (e.g. we're looping in ::request).
+  // or we are disconnected
+  streamState_->pendingWrites_.emplace_back(std::move(frame));
 }
 
 void ConnectionAutomaton::drainOutputFramesQueue() {

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -69,13 +69,15 @@ class ReactiveSocket {
       Stats& stats = Stats::noop(),
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(nullptr),
+      bool isResumable = false,
       const ResumeIdentificationToken& token =
           ResumeIdentificationToken::generateNew());
 
   static std::unique_ptr<ReactiveSocket> fromServerConnection(
       std::unique_ptr<DuplexConnection> connection,
       std::unique_ptr<RequestHandlerBase> handler,
-      Stats& stats = Stats::noop());
+      Stats& stats = Stats::noop(),
+      bool isResumable = false);
 
   std::shared_ptr<Subscriber<Payload>> requestChannel(
       const std::shared_ptr<Subscriber<Payload>>& responseSink,
@@ -99,7 +101,7 @@ class ReactiveSocket {
   void requestFireAndForget(Payload request);
 
   void close();
-  std::unique_ptr<DuplexConnection> disconnect();
+  void disconnect();
 
   void onConnected(ReactiveSocketCallback listener);
   void onDisconnected(ReactiveSocketCallback listener);
@@ -116,6 +118,7 @@ class ReactiveSocket {
  private:
   ReactiveSocket(
       bool isServer,
+      bool isResumable,
       std::unique_ptr<DuplexConnection> connection,
       std::shared_ptr<RequestHandlerBase> handler,
       Stats& stats,
@@ -132,6 +135,8 @@ class ReactiveSocket {
   std::function<void()> executeListenersFunc(
       std::shared_ptr<std::list<ReactiveSocketCallback>> listeners);
 
+  void checkNotClosed() const;
+
   std::shared_ptr<RequestHandlerBase> handler_;
   const std::shared_ptr<KeepaliveTimer> keepaliveTimer_;
 
@@ -142,7 +147,7 @@ class ReactiveSocket {
   std::shared_ptr<std::list<ReactiveSocketCallback>> onCloseListeners_{
       std::make_shared<std::list<ReactiveSocketCallback>>()};
 
-  const std::shared_ptr<ConnectionAutomaton> connection_;
+  std::shared_ptr<ConnectionAutomaton> connection_;
   StreamId nextStreamId_;
 };
 }

--- a/src/Stats.cpp
+++ b/src/Stats.cpp
@@ -8,13 +8,16 @@ namespace reactivesocket {
 class NoopStats : public Stats {
  public:
   void socketCreated() override{};
+  void socketDisconnected() override{};
   void socketClosed() override{};
-  void connectionCreated(
+
+  void duplexConnectionCreated(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) override{};
-  void connectionClosed(
+  void duplexConnectionClosed(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) override{};
+
   void bytesWritten(size_t bytes) override{};
   void bytesRead(size_t bytes) override{};
   void frameWritten(const std::string& frameType) override{};

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -12,13 +12,16 @@ class Stats {
   static Stats& noop();
 
   virtual void socketCreated() = 0;
+  virtual void socketDisconnected() = 0;
   virtual void socketClosed() = 0;
-  virtual void connectionCreated(
+
+  virtual void duplexConnectionCreated(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) = 0;
-  virtual void connectionClosed(
+  virtual void duplexConnectionClosed(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) = 0;
+
   virtual void bytesWritten(size_t bytes) = 0;
   virtual void bytesRead(size_t bytes) = 0;
   virtual void frameWritten(const std::string& frameType) = 0;

--- a/src/tcp/TcpDuplexConnection.cpp
+++ b/src/tcp/TcpDuplexConnection.cpp
@@ -126,11 +126,11 @@ TcpDuplexConnection::TcpDuplexConnection(
     : tcpReaderWriter_(
           std::make_shared<TcpReaderWriter>(std::move(socket), stats)),
       stats_(stats) {
-  stats_.connectionCreated("tcp", this);
+  stats_.duplexConnectionCreated("tcp", this);
 }
 
 TcpDuplexConnection::~TcpDuplexConnection() {
-  stats_.connectionClosed("tcp", this);
+  stats_.duplexConnectionClosed("tcp", this);
 }
 
 std::shared_ptr<Subscriber<std::unique_ptr<folly::IOBuf>>>

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -80,6 +80,7 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
       Stats::noop(),
       std::shared_ptr<KeepaliveTimer>(),
       false,
+      false,
       [] {},
       [] {},
       [] {});
@@ -153,6 +154,7 @@ static void terminateTest(
       nullptr,
       Stats::noop(),
       std::shared_ptr<KeepaliveTimer>(),
+      false,
       false,
       [] {},
       [] {},
@@ -241,6 +243,7 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
       nullptr,
       Stats::noop(),
       std::shared_ptr<KeepaliveTimer>(),
+      false,
       false,
       [] {},
       [] {},

--- a/test/MockStats.h
+++ b/test/MockStats.h
@@ -16,12 +16,15 @@ class MockStats : public Stats {
  public:
   MOCK_METHOD0(socketCreated_, void());
   MOCK_METHOD0(socketClosed_, void());
+  MOCK_METHOD0(socketDisconnected_, void());
+
   MOCK_METHOD2(
-      connectionCreated_,
+      duplexConnectionCreated_,
       void(const std::string&, reactivesocket::DuplexConnection*));
   MOCK_METHOD2(
-      connectionClosed_,
+      duplexConnectionClosed_,
       void(const std::string&, reactivesocket::DuplexConnection*));
+
   MOCK_METHOD1(bytesWritten_, void(size_t));
   MOCK_METHOD1(bytesRead_, void(size_t));
   MOCK_METHOD1(frameWritten_, void(const std::string&));
@@ -35,16 +38,20 @@ class MockStats : public Stats {
     socketClosed_();
   }
 
-  void connectionCreated(
-      const std::string& type,
-      reactivesocket::DuplexConnection* connection) override {
-    connectionCreated_(type, connection);
+  void socketDisconnected() override {
+    socketDisconnected_();
   }
 
-  void connectionClosed(
+  void duplexConnectionCreated(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) override {
-    connectionClosed_(type, connection);
+    duplexConnectionCreated_(type, connection);
+  }
+
+  void duplexConnectionClosed(
+      const std::string& type,
+      reactivesocket::DuplexConnection* connection) override {
+    duplexConnectionClosed_(type, connection);
   }
 
   virtual void bytesWritten(size_t bytes) override {

--- a/test/ReactiveSocketResumabilityTest.cpp
+++ b/test/ReactiveSocketResumabilityTest.cpp
@@ -1,0 +1,73 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/IOBuf.h>
+#include <gmock/gmock.h>
+
+#include "src/NullRequestHandler.h"
+#include "src/ReactiveSocket.h"
+#include "test/InlineConnection.h"
+#include "test/MockStats.h"
+#include "test/ReactiveStreamsMocksCompat.h"
+
+using namespace ::testing;
+using namespace ::reactivesocket;
+
+TEST(ReactiveSocketResumabilityTest, Disconnect) {
+  auto socketConnection = folly::make_unique<InlineConnection>();
+  auto testConnection = folly::make_unique<InlineConnection>();
+
+  socketConnection->connectTo(*testConnection);
+
+  auto testInputSubscription = std::make_shared<MockSubscription>();
+
+  auto testOutputSubscriber =
+      std::make_shared<MockSubscriber<std::unique_ptr<folly::IOBuf>>>();
+  EXPECT_CALL(*testOutputSubscriber, onSubscribe_(_))
+      .WillOnce(Invoke([&](std::shared_ptr<Subscription> subscription) {
+        // allow receiving frames from the automaton
+        subscription->request(std::numeric_limits<size_t>::max());
+      }));
+
+  testConnection->setInput(testOutputSubscriber);
+  testConnection->getOutput()->onSubscribe(testInputSubscription);
+
+  MockStats stats;
+
+  auto socket = ReactiveSocket::fromClientConnection(
+      std::move(socketConnection),
+      folly::make_unique<DefaultRequestHandler>(),
+      ConnectionSetupPayload(),
+      stats);
+
+  auto responseSubscriber = std::make_shared<MockSubscriber<Payload>>();
+  EXPECT_CALL(*responseSubscriber, onSubscribe_(_))
+      .Times(1)
+      .WillOnce(Invoke([&](std::shared_ptr<Subscription> subscription) {
+        subscription->request(std::numeric_limits<size_t>::max());
+      }));
+
+  EXPECT_CALL(*responseSubscriber, onComplete_()).Times(0);
+  EXPECT_CALL(*responseSubscriber, onError_(_)).Times(0);
+
+  socket->requestResponse(Payload(), responseSubscriber);
+
+  EXPECT_CALL(*testOutputSubscriber, onComplete_()).Times(1);
+  EXPECT_CALL(*testInputSubscription, cancel_()).Times(1);
+  EXPECT_CALL(stats, socketDisconnected_()).Times(1);
+  EXPECT_CALL(stats, socketClosed_()).Times(0);
+
+  socket->disconnect();
+
+  Mock::VerifyAndClearExpectations(responseSubscriber.get());
+  Mock::VerifyAndClearExpectations(testOutputSubscriber.get());
+  Mock::VerifyAndClearExpectations(testInputSubscription.get());
+  Mock::VerifyAndClearExpectations(&stats);
+
+  EXPECT_CALL(*responseSubscriber, onError_(_)).Times(1);
+  EXPECT_CALL(stats, socketDisconnected_()).Times(0);
+  EXPECT_CALL(stats, socketClosed_()).Times(1);
+
+  socket->close();
+  socket.reset();
+  testConnection->getOutput()->onComplete();
+}

--- a/test/resume/TcpResumeClient.cpp
+++ b/test/resume/TcpResumeClient.cpp
@@ -85,6 +85,7 @@ int main(int argc, char* argv[]) {
         stats,
         folly::make_unique<FollyKeepaliveTimer>(
             *eventBaseThread.getEventBase(), std::chrono::milliseconds(5000)),
+        true,
         token);
 
     reactiveSocket->requestSubscription(

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -145,7 +145,7 @@ class Callback : public AsyncServerSocket::AcceptCallback {
         folly::make_unique<ServerRequestHandler>(streamState_);
 
     std::unique_ptr<ReactiveSocket> rs = ReactiveSocket::fromServerConnection(
-        std::move(framedConnection), std::move(requestHandler), stats_);
+        std::move(framedConnection), std::move(requestHandler), stats_, true);
 
     std::cout << "RS " << rs.get() << std::endl;
 

--- a/test/simple/StatsPrinter.cpp
+++ b/test/simple/StatsPrinter.cpp
@@ -11,13 +11,17 @@ void StatsPrinter::socketClosed() {
   LOG(INFO) << "socketClosed";
 }
 
-void StatsPrinter::connectionCreated(
+void StatsPrinter::socketDisconnected() {
+  LOG(INFO) << "socketDisconnected";
+}
+
+void StatsPrinter::duplexConnectionCreated(
     const std::string& type,
     reactivesocket::DuplexConnection* connection) {
   LOG(INFO) << "connectionCreated " << type;
 }
 
-void StatsPrinter::connectionClosed(
+void StatsPrinter::duplexConnectionClosed(
     const std::string& type,
     reactivesocket::DuplexConnection* connection) {
   LOG(INFO) << "connectionClosed " << type;

--- a/test/simple/StatsPrinter.h
+++ b/test/simple/StatsPrinter.h
@@ -10,12 +10,15 @@ class StatsPrinter : public Stats {
  public:
   void socketCreated() override;
   void socketClosed() override;
-  virtual void connectionCreated(
+  void socketDisconnected() override;
+
+  virtual void duplexConnectionCreated(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) override;
-  virtual void connectionClosed(
+  virtual void duplexConnectionClosed(
       const std::string& type,
       reactivesocket::DuplexConnection* connection) override;
+
   virtual void bytesWritten(size_t bytes) override;
   virtual void bytesRead(size_t bytes) override;
   virtual void frameWritten(const std::string& frameType) override;


### PR DESCRIPTION
this diff allows a new state of ReactiveSocket instance when the instance is disconnected from the network and the streams stay alive.

new unit test included