### PR TITLE
Automatically cancel Subscription in ~SubscriberBase

### DIFF
--- a/src/SubscriberBase.h
+++ b/src/SubscriberBase.h
@@ -83,6 +83,14 @@ class SubscriberBaseT : public Subscriber<T>,
       bool startExecutor = true)
       : ExecutorBase(executor, startExecutor), cancelled_(false) {}
 
+  virtual ~SubscriberBaseT() {
+    if (!cancelled_ && originalSubscription_) {
+      runInExecutor([subscription = std::move(originalSubscription_)] {
+        subscription->cancel();
+      });
+    }
+  }
+
   void onSubscribe(std::shared_ptr<Subscription> subscription) override final {
     auto thisPtr = this->shared_from_this();
     runInExecutor([thisPtr, subscription]() {

--- a/src/SubscriberBase.h
+++ b/src/SubscriberBase.h
@@ -85,7 +85,8 @@ class SubscriberBaseT : public Subscriber<T>,
 
   virtual ~SubscriberBaseT() {
     if (!cancelled_ && originalSubscription_) {
-      runInExecutor([subscription = std::move(originalSubscription_)] {
+      auto subscription = std::move(originalSubscription_);
+      runInExecutor([subscription] {
         subscription->cancel();
       });
     }

--- a/test/SubscriberBaseTest.cpp
+++ b/test/SubscriberBaseTest.cpp
@@ -159,3 +159,13 @@ TEST(SubscriberBaseTest, SubscriptionCancel) {
   std::shared_ptr<Subscriber<int>> ptr = subscriber;
   ptr->onSubscribe(originalSubscription);
 }
+
+TEST(SubscriberBaseTest, SubscriptionCancelsUponSubscriberDestruction) {
+  auto subscriber = std::make_shared<SubscriberBaseMock>();
+
+  auto originalSubscription = std::make_shared<StrictMock<MockSubscription>>();
+  EXPECT_CALL(*originalSubscription, cancel_()).Times(1);
+
+  subscriber->onSubscribe(originalSubscription);
+  originalSubscription.reset();
+}


### PR DESCRIPTION
I expected this to already be the case while testing some behaviors built on top of RS, and was surprised to find out that it's not. I'm not sure if we ever saw any bad behavior without this, but it seems safe and like the proper thing to do.