### PR TITLE
Replace ResumeIdentificationToken::empty() with a default constructor

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -52,10 +52,10 @@ StreamInterruptedException::StreamInterruptedException(int _terminatingSignal)
     : std::runtime_error(getTerminatingSignalErrorMessage(_terminatingSignal)),
       terminatingSignal(_terminatingSignal) {}
 
-ResumeIdentificationToken ResumeIdentificationToken::empty() {
-  return ResumeIdentificationToken(
-      Data() = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}});
-}
+ResumeIdentificationToken::ResumeIdentificationToken()
+    : ResumeIdentificationToken(
+          Data() = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}) {}
+
 ResumeIdentificationToken ResumeIdentificationToken::generateNew() {
   // TODO: this will be replaced with a variable length bit array and the value
   // will be generated outside of reactivesocket
@@ -76,7 +76,7 @@ ResumeIdentificationToken ResumeIdentificationToken::generateNew() {
 ResumeIdentificationToken ResumeIdentificationToken::fromString(
     const std::string& /*str*/) {
   CHECK(false) << "not implemented";
-  return empty();
+  return ResumeIdentificationToken();
 }
 
 std::string ResumeIdentificationToken::toString() const {

--- a/src/Common.h
+++ b/src/Common.h
@@ -47,7 +47,9 @@ class ResumeIdentificationToken {
  public:
   using Data = std::array<uint8_t, 16>;
 
-  static ResumeIdentificationToken empty();
+  /// Creates an empty token.
+  ResumeIdentificationToken();
+
   static ResumeIdentificationToken generateNew();
   static ResumeIdentificationToken fromString(const std::string& str);
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -444,7 +444,7 @@ class Frame_SETUP {
   uint32_t version_;
   uint32_t keepaliveTime_;
   uint32_t maxLifetime_;
-  ResumeIdentificationToken token_{ResumeIdentificationToken::empty()};
+  ResumeIdentificationToken token_;
   std::string metadataMimeType_;
   std::string dataMimeType_;
   Payload payload_;
@@ -489,7 +489,7 @@ class Frame_RESUME {
   bool deserializeFrom(std::unique_ptr<folly::IOBuf> in);
 
   FrameHeader header_;
-  ResumeIdentificationToken token_{ResumeIdentificationToken::empty()};
+  ResumeIdentificationToken token_;
   ResumePosition position_;
 };
 std::ostream& operator<<(std::ostream&, const Frame_RESUME&);

--- a/test/FrameTest.cpp
+++ b/test/FrameTest.cpp
@@ -142,7 +142,7 @@ TEST(FrameTest, Frame_SETUP) {
   uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
   ResumeIdentificationToken::Data tokenData;
   tokenData.fill(1);
-  auto token = ResumeIdentificationToken::empty();
+  ResumeIdentificationToken token;
   token.set(std::move(tokenData));
   auto data = folly::IOBuf::copyBuffer("424242");
   auto frame = reserialize<Frame_SETUP>(


### PR DESCRIPTION
In my opinion, this is more idiomatic C++. It also allows me to declare `ResumeIdentificationToken`s as instance variables of Objective-C objects (where no explicit initialization is permitted).