### PR TITLE
ReactiveSocket interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,8 @@ add_library(
   src/NullRequestHandler.h
   src/Payload.cpp
   src/Payload.h
-  src/ReactiveSocket.cpp
-  src/ReactiveSocket.h
+        src/StandardReactiveSocket.cpp
+        src/StandardReactiveSocket.h
   src/ReactiveStreamsCompat.h
   src/RequestHandler.h
   src/ResumeCache.cpp
@@ -166,7 +166,7 @@ add_library(
   src/automata/SubscriptionResponder.cpp
   src/FrameTransport.cpp
   src/FrameTransport.h
-  src/FrameProcessor.h)
+  src/FrameProcessor.h src/ReactiveSocket.h)
 
 target_link_libraries(
   ReactiveSocket
@@ -223,8 +223,8 @@ add_executable(
         test/tcp/TcpClient.cpp
         test/simple/PrintSubscriber.cpp
         test/simple/PrintSubscriber.h
-        src/ReactiveSocket.cpp
-        src/ReactiveSocket.h
+        src/StandardReactiveSocket.cpp
+        src/StandardReactiveSocket.h
         test/simple/StatsPrinter.cpp
         test/simple/StatsPrinter.h)
 
@@ -286,8 +286,8 @@ add_executable(
         test/resume/TcpResumeClient.cpp
         test/simple/PrintSubscriber.cpp
         test/simple/PrintSubscriber.h
-        src/ReactiveSocket.cpp
-        src/ReactiveSocket.h
+        src/StandardReactiveSocket.cpp
+        src/StandardReactiveSocket.h
         test/simple/StatsPrinter.cpp
         test/simple/StatsPrinter.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,8 @@ add_library(
   src/automata/SubscriptionResponder.cpp
   src/FrameTransport.cpp
   src/FrameTransport.h
-  src/FrameProcessor.h src/ReactiveSocket.h)
+  src/FrameProcessor.h
+  src/ReactiveSocket.h)
 
 target_link_libraries(
   ReactiveSocket

--- a/TARGETS
+++ b/TARGETS
@@ -58,6 +58,7 @@ cpp_library(
         'src/ReactiveSocket.h',
         'src/RequestHandler.h',
         'src/SmartPointers.h', #will be removed soon
+        'src/StandardReactiveSocket.h',
         'src/Stats.h',
         'src/SubscriberBase.h',
         'src/SubscriptionBase.h',

--- a/TARGETS
+++ b/TARGETS
@@ -73,9 +73,9 @@ cpp_library(
         'src/FrameTransport.cpp',
         'src/NullRequestHandler.cpp',
         'src/Payload.cpp',
-        'src/ReactiveSocket.cpp',
         'src/RequestHandler.cpp',
         'src/ResumeCache.cpp',
+        'src/StandardReactiveSocket.cpp',
         'src/Stats.cpp',
     ]),
     deps = [

--- a/src/Common.h
+++ b/src/Common.h
@@ -16,9 +16,9 @@
 
 namespace reactivesocket {
 
-class ReactiveSocket;
+class StandardReactiveSocket;
 
-using ReactiveSocketCallback = std::function<void(ReactiveSocket&)>;
+using ReactiveSocketCallback = std::function<void(StandardReactiveSocket&)>;
 using StreamId = uint32_t;
 using ResumePosition = int64_t;
 

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -13,149 +13,62 @@
 #include "src/Stats.h"
 
 namespace folly {
-class Executor;
+  class Executor;
 }
 
 namespace reactivesocket {
+  class ClientResumeStatusCallback;
+  class ConnectionAutomaton;
+  class DuplexConnection;
+  class FrameTransport;
 
-class ClientResumeStatusCallback;
-class ConnectionAutomaton;
-class DuplexConnection;
-class FrameTransport;
-class RequestHandler;
-class ReactiveSocket;
+  class ReactiveSocket {
+  public:
+    virtual ~ReactiveSocket() = default;
 
-folly::Executor& defaultExecutor();
+    virtual void requestStream(
+        Payload payload,
+        const std::shared_ptr<Subscriber<Payload>>& responseSink) = 0;
 
-// TODO(stupaq): Here is some heavy problem with the recursion on shutdown.
-// Giving someone ownership over this object would probably lead to a deadlock
-// (or a crash) if one calls ::~ReactiveSocket from a terminal signal handler
-// of any of the connections. It seems natural to follow ReactiveStreams
-// specification and make this object "self owned", so that we don't need to
-// perform all of the cleanup from a d'tor. We could give out a "proxy" object
-// that (internally) holds a weak reference (conceptually, not std::weak_ptr)
-// and forbids any interactions with the socket after the shutdown procedure has
-// been initiated.
-class ReactiveSocket {
- public:
-  ReactiveSocket(ReactiveSocket&&) = delete;
-  ReactiveSocket& operator=(ReactiveSocket&&) = delete;
-  ReactiveSocket(const ReactiveSocket&) = delete;
-  ReactiveSocket& operator=(const ReactiveSocket&) = delete;
+    virtual void requestSubscription(
+        Payload payload,
+        const std::shared_ptr<Subscriber<Payload>>& responseSink) = 0;
 
-  ~ReactiveSocket();
+    virtual void requestResponse(
+        Payload payload,
+        const std::shared_ptr<Subscriber<Payload>>& responseSink) = 0;
 
-  static std::unique_ptr<ReactiveSocket> fromClientConnection(
-      folly::Executor& executor,
-      std::unique_ptr<DuplexConnection> connection,
-      std::unique_ptr<RequestHandler> handler,
-      ConnectionSetupPayload setupPayload = ConnectionSetupPayload(),
-      Stats& stats = Stats::noop(),
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
-          std::unique_ptr<KeepaliveTimer>(nullptr));
+    virtual void requestFireAndForget(Payload request) = 0;
 
-  static std::unique_ptr<ReactiveSocket> disconnectedClient(
-      folly::Executor& executor,
-      std::unique_ptr<RequestHandler> handler,
-      Stats& stats = Stats::noop(),
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
-          std::unique_ptr<KeepaliveTimer>(nullptr));
+    virtual void metadataPush(std::unique_ptr<folly::IOBuf> metadata) = 0;
 
-  static std::unique_ptr<ReactiveSocket> fromServerConnection(
-      folly::Executor& executor,
-      std::unique_ptr<DuplexConnection> connection,
-      std::unique_ptr<RequestHandler> handler,
-      Stats& stats = Stats::noop(),
-      bool isResumable = false);
+    virtual void clientConnect(
+        std::shared_ptr<FrameTransport> frameTransport,
+        ConnectionSetupPayload setupPayload = ConnectionSetupPayload()) = 0;
 
-  static std::unique_ptr<ReactiveSocket> disconnectedServer(
-      folly::Executor& executor,
-      std::unique_ptr<RequestHandler> handler,
-      Stats& stats = Stats::noop());
+    virtual void serverConnect(
+        std::shared_ptr<FrameTransport> frameTransport,
+        bool isResumable) = 0;
 
-  std::shared_ptr<Subscriber<Payload>> requestChannel(
-      const std::shared_ptr<Subscriber<Payload>>& responseSink);
+    virtual void close() = 0;
+    virtual void disconnect() = 0;
+    virtual std::shared_ptr<FrameTransport> detachFrameTransport() = 0;
 
-  void requestStream(
-      Payload payload,
-      const std::shared_ptr<Subscriber<Payload>>& responseSink);
+    virtual void onConnected(ReactiveSocketCallback listener) = 0;
+    virtual void onDisconnected(ReactiveSocketCallback listener) = 0;
+    virtual void onClosed(ReactiveSocketCallback listener) = 0;
 
-  void requestSubscription(
-      Payload payload,
-      const std::shared_ptr<Subscriber<Payload>>& responseSink);
+    virtual void tryClientResume(
+        const ResumeIdentificationToken& token,
+        std::shared_ptr<FrameTransport> frameTransport,
+        std::unique_ptr<ClientResumeStatusCallback> resumeCallback) = 0;
 
-  void requestResponse(
-      Payload payload,
-      const std::shared_ptr<Subscriber<Payload>>& responseSink);
+    virtual bool tryResumeServer(
+        std::shared_ptr<FrameTransport> frameTransport,
+        ResumePosition position) = 0;
 
-  void requestFireAndForget(Payload request);
+    virtual folly::Executor& executor() = 0;
 
-  void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
-
-  void clientConnect(
-      std::shared_ptr<FrameTransport> frameTransport,
-      ConnectionSetupPayload setupPayload = ConnectionSetupPayload());
-
-  void serverConnect(
-      std::shared_ptr<FrameTransport> frameTransport,
-      bool isResumable);
-
-  void close();
-  void disconnect();
-  std::shared_ptr<FrameTransport> detachFrameTransport();
-
-  void onConnected(ReactiveSocketCallback listener);
-  void onDisconnected(ReactiveSocketCallback listener);
-  void onClosed(ReactiveSocketCallback listener);
-
-  void tryClientResume(
-      const ResumeIdentificationToken& token,
-      std::shared_ptr<FrameTransport> frameTransport,
-      std::unique_ptr<ClientResumeStatusCallback> resumeCallback);
-
-  bool tryResumeServer(
-      std::shared_ptr<FrameTransport> frameTransport,
-      ResumePosition position);
-
-  folly::Executor& executor() {
-    return executor_;
-  }
-
-  DuplexConnection* duplexConnection() const;
-
- private:
-  ReactiveSocket(
-      bool isServer,
-      std::shared_ptr<RequestHandler> handler,
-      Stats& stats,
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer,
-      folly::Executor& executor);
-
-  void createResponder(
-      std::shared_ptr<RequestHandler> handler,
-      ConnectionAutomaton& connection,
-      StreamId streamId,
-      std::unique_ptr<folly::IOBuf> frame);
-
-  std::shared_ptr<StreamState> resumeListener(
-      const ResumeIdentificationToken& token);
-
-  std::function<void()> executeListenersFunc(
-      std::shared_ptr<std::list<ReactiveSocketCallback>> listeners);
-
-  void checkNotClosed() const;
-
-  std::shared_ptr<RequestHandler> handler_;
-
-  std::shared_ptr<std::list<ReactiveSocketCallback>> onConnectListeners_{
-      std::make_shared<std::list<ReactiveSocketCallback>>()};
-  std::shared_ptr<std::list<ReactiveSocketCallback>> onDisconnectListeners_{
-      std::make_shared<std::list<ReactiveSocketCallback>>()};
-  std::shared_ptr<std::list<ReactiveSocketCallback>> onCloseListeners_{
-      std::make_shared<std::list<ReactiveSocketCallback>>()};
-
-  std::shared_ptr<ConnectionAutomaton> connection_;
-  StreamId nextStreamId_;
-  folly::Executor& executor_;
-};
+    virtual DuplexConnection* duplexConnection() const = 0;
+  };
 }

--- a/src/ReactiveSocket.h
+++ b/src/ReactiveSocket.h
@@ -13,65 +13,65 @@
 #include "src/Stats.h"
 
 namespace folly {
-  class Executor;
+class Executor;
 }
 
 namespace reactivesocket {
-  class ClientResumeStatusCallback;
-  class ConnectionAutomaton;
-  class DuplexConnection;
-  class FrameTransport;
+class ClientResumeStatusCallback;
+class ConnectionAutomaton;
+class DuplexConnection;
+class FrameTransport;
 
-  class ReactiveSocket {
-  public:
-    virtual ~ReactiveSocket() = default;
+class ReactiveSocket {
+ public:
+  virtual ~ReactiveSocket() = default;
 
-    virtual std::shared_ptr<Subscriber<Payload>> requestChannel(
-        std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
+  virtual std::shared_ptr<Subscriber<Payload>> requestChannel(
+      std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
 
-    virtual void requestStream(
-        Payload payload,
-        const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
+  virtual void requestStream(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
 
-    virtual void requestSubscription(
-        Payload payload,
-        const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
+  virtual void requestSubscription(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
 
-    virtual void requestResponse(
-        Payload payload,
-        const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
+  virtual void requestResponse(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>> responseSink) = 0;
 
-    virtual void requestFireAndForget(Payload request) = 0;
+  virtual void requestFireAndForget(Payload request) = 0;
 
-    virtual void metadataPush(std::unique_ptr<folly::IOBuf> metadata) = 0;
+  virtual void metadataPush(std::unique_ptr<folly::IOBuf> metadata) = 0;
 
-    virtual void clientConnect(
-        std::shared_ptr<FrameTransport> frameTransport,
-        ConnectionSetupPayload setupPayload = ConnectionSetupPayload()) = 0;
+  virtual void clientConnect(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ConnectionSetupPayload setupPayload = ConnectionSetupPayload()) = 0;
 
-    virtual void serverConnect(
-        std::shared_ptr<FrameTransport> frameTransport,
-        bool isResumable) = 0;
+  virtual void serverConnect(
+      std::shared_ptr<FrameTransport> frameTransport,
+      bool isResumable) = 0;
 
-    virtual void close() = 0;
-    virtual void disconnect() = 0;
-    virtual std::shared_ptr<FrameTransport> detachFrameTransport() = 0;
+  virtual void close() = 0;
+  virtual void disconnect() = 0;
+  virtual std::shared_ptr<FrameTransport> detachFrameTransport() = 0;
 
-    virtual void onConnected(ReactiveSocketCallback listener) = 0;
-    virtual void onDisconnected(ReactiveSocketCallback listener) = 0;
-    virtual void onClosed(ReactiveSocketCallback listener) = 0;
+  virtual void onConnected(ReactiveSocketCallback listener) = 0;
+  virtual void onDisconnected(ReactiveSocketCallback listener) = 0;
+  virtual void onClosed(ReactiveSocketCallback listener) = 0;
 
-    virtual void tryClientResume(
-        const ResumeIdentificationToken& token,
-        std::shared_ptr<FrameTransport> frameTransport,
-        std::unique_ptr<ClientResumeStatusCallback> resumeCallback) = 0;
+  virtual void tryClientResume(
+      const ResumeIdentificationToken& token,
+      std::shared_ptr<FrameTransport> frameTransport,
+      std::unique_ptr<ClientResumeStatusCallback> resumeCallback) = 0;
 
-    virtual bool tryResumeServer(
-        std::shared_ptr<FrameTransport> frameTransport,
-        ResumePosition position) = 0;
+  virtual bool tryResumeServer(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ResumePosition position) = 0;
 
-    virtual folly::Executor& executor() = 0;
+  virtual folly::Executor& executor() = 0;
 
-    virtual DuplexConnection* duplexConnection() const = 0;
-  };
+  virtual DuplexConnection* duplexConnection() const = 0;
+};
 }

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -62,7 +62,8 @@ StandardReactiveSocket::StandardReactiveSocket(
   stats.socketCreated();
 }
 
-std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromClientConnection(
+std::unique_ptr<StandardReactiveSocket>
+StandardReactiveSocket::fromClientConnection(
     folly::Executor& executor,
     std::unique_ptr<DuplexConnection> connection,
     std::unique_ptr<RequestHandler> handler,
@@ -77,7 +78,8 @@ std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromClientConnec
   return socket;
 }
 
-std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedClient(
+std::unique_ptr<StandardReactiveSocket>
+StandardReactiveSocket::disconnectedClient(
     folly::Executor& executor,
     std::unique_ptr<RequestHandler> handler,
     Stats& stats,
@@ -87,7 +89,8 @@ std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedClie
   return socket;
 }
 
-std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromServerConnection(
+std::unique_ptr<StandardReactiveSocket>
+StandardReactiveSocket::fromServerConnection(
     folly::Executor& executor,
     std::unique_ptr<DuplexConnection> connection,
     std::unique_ptr<RequestHandler> handler,
@@ -101,12 +104,13 @@ std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromServerConnec
   return socket;
 }
 
-std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedServer(
+std::unique_ptr<StandardReactiveSocket>
+StandardReactiveSocket::disconnectedServer(
     folly::Executor& executor,
     std::unique_ptr<RequestHandler> handler,
     Stats& stats) {
-  std::unique_ptr<StandardReactiveSocket> socket(
-      new StandardReactiveSocket(true, std::move(handler), stats, nullptr, executor));
+  std::unique_ptr<StandardReactiveSocket> socket(new StandardReactiveSocket(
+      true, std::move(handler), stats, nullptr, executor));
   return socket;
 }
 
@@ -183,7 +187,8 @@ void StandardReactiveSocket::requestResponse(
   automaton->start();
 }
 
-void StandardReactiveSocket::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
+void StandardReactiveSocket::metadataPush(
+    std::unique_ptr<folly::IOBuf> metadata) {
   checkNotClosed();
   connection_->outputFrameOrEnqueue(
       Frame_METADATA_PUSH(std::move(metadata)).serializeOut());

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 
 #include <folly/ExceptionWrapper.h>
 #include <folly/Memory.h>
@@ -8,6 +8,7 @@
 #include "src/ClientResumeStatusCallback.h"
 #include "src/ConnectionAutomaton.h"
 #include "src/FrameTransport.h"
+#include "src/ReactiveSocket.h"
 #include "src/automata/ChannelRequester.h"
 #include "src/automata/ChannelResponder.h"
 #include "src/automata/RequestResponseRequester.h"
@@ -19,7 +20,7 @@
 
 namespace reactivesocket {
 
-ReactiveSocket::~ReactiveSocket() {
+StandardReactiveSocket::~StandardReactiveSocket() {
   // Force connection closure, this will trigger terminal signals to be
   // delivered to all stream automata.
   close();
@@ -30,7 +31,7 @@ ReactiveSocket::~ReactiveSocket() {
   onCloseListeners_->clear();
 }
 
-ReactiveSocket::ReactiveSocket(
+StandardReactiveSocket::StandardReactiveSocket(
     bool isServer,
     std::shared_ptr<RequestHandler> handler,
     Stats& stats,
@@ -47,7 +48,7 @@ ReactiveSocket::ReactiveSocket(
           },
           std::make_shared<StreamState>(),
           std::bind(
-              &ReactiveSocket::resumeListener,
+              &StandardReactiveSocket::resumeListener,
               this,
               std::placeholders::_1),
           stats,
@@ -61,7 +62,7 @@ ReactiveSocket::ReactiveSocket(
   stats.socketCreated();
 }
 
-std::unique_ptr<ReactiveSocket> ReactiveSocket::fromClientConnection(
+std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromClientConnection(
     folly::Executor& executor,
     std::unique_ptr<DuplexConnection> connection,
     std::unique_ptr<RequestHandler> handler,
@@ -76,17 +77,17 @@ std::unique_ptr<ReactiveSocket> ReactiveSocket::fromClientConnection(
   return socket;
 }
 
-std::unique_ptr<ReactiveSocket> ReactiveSocket::disconnectedClient(
+std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedClient(
     folly::Executor& executor,
     std::unique_ptr<RequestHandler> handler,
     Stats& stats,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer) {
-  std::unique_ptr<ReactiveSocket> socket(new ReactiveSocket(
+  std::unique_ptr<StandardReactiveSocket> socket(new StandardReactiveSocket(
       false, std::move(handler), stats, std::move(keepaliveTimer), executor));
   return socket;
 }
 
-std::unique_ptr<ReactiveSocket> ReactiveSocket::fromServerConnection(
+std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::fromServerConnection(
     folly::Executor& executor,
     std::unique_ptr<DuplexConnection> connection,
     std::unique_ptr<RequestHandler> handler,
@@ -100,16 +101,16 @@ std::unique_ptr<ReactiveSocket> ReactiveSocket::fromServerConnection(
   return socket;
 }
 
-std::unique_ptr<ReactiveSocket> ReactiveSocket::disconnectedServer(
+std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedServer(
     folly::Executor& executor,
     std::unique_ptr<RequestHandler> handler,
     Stats& stats) {
-  std::unique_ptr<ReactiveSocket> socket(
-      new ReactiveSocket(true, std::move(handler), stats, nullptr, executor));
+  std::unique_ptr<StandardReactiveSocket> socket(
+      new StandardReactiveSocket(true, std::move(handler), stats, nullptr, executor));
   return socket;
 }
 
-std::shared_ptr<Subscriber<Payload>> ReactiveSocket::requestChannel(
+std::shared_ptr<Subscriber<Payload>> StandardReactiveSocket::requestChannel(
     const std::shared_ptr<Subscriber<Payload>>& responseSink) {
   checkNotClosed();
   // TODO(stupaq): handle any exceptions
@@ -124,7 +125,7 @@ std::shared_ptr<Subscriber<Payload>> ReactiveSocket::requestChannel(
   return automaton;
 }
 
-void ReactiveSocket::requestStream(
+void StandardReactiveSocket::requestStream(
     Payload request,
     const std::shared_ptr<Subscriber<Payload>>& responseSink) {
   checkNotClosed();
@@ -140,7 +141,7 @@ void ReactiveSocket::requestStream(
   automaton->start();
 }
 
-void ReactiveSocket::requestSubscription(
+void StandardReactiveSocket::requestSubscription(
     Payload request,
     const std::shared_ptr<Subscriber<Payload>>& responseSink) {
   checkNotClosed();
@@ -156,7 +157,7 @@ void ReactiveSocket::requestSubscription(
   automaton->start();
 }
 
-void ReactiveSocket::requestFireAndForget(Payload request) {
+void StandardReactiveSocket::requestFireAndForget(Payload request) {
   checkNotClosed();
   // TODO(stupaq): handle any exceptions
   StreamId streamId = nextStreamId_;
@@ -166,7 +167,7 @@ void ReactiveSocket::requestFireAndForget(Payload request) {
   connection_->outputFrameOrEnqueue(frame.serializeOut());
 }
 
-void ReactiveSocket::requestResponse(
+void StandardReactiveSocket::requestResponse(
     Payload payload,
     const std::shared_ptr<Subscriber<Payload>>& responseSink) {
   checkNotClosed();
@@ -183,13 +184,13 @@ void ReactiveSocket::requestResponse(
   automaton->start();
 }
 
-void ReactiveSocket::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
+void StandardReactiveSocket::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
   checkNotClosed();
   connection_->outputFrameOrEnqueue(
       Frame_METADATA_PUSH(std::move(metadata)).serializeOut());
 }
 
-void ReactiveSocket::createResponder(
+void StandardReactiveSocket::createResponder(
     std::shared_ptr<RequestHandler> handler,
     ConnectionAutomaton& connection,
     StreamId streamId,
@@ -340,7 +341,7 @@ void ReactiveSocket::createResponder(
   }
 }
 
-std::shared_ptr<StreamState> ReactiveSocket::resumeListener(
+std::shared_ptr<StreamState> StandardReactiveSocket::resumeListener(
     const ResumeIdentificationToken& token) {
   CHECK(false) << "not implemented";
   // TODO(lehecka)
@@ -348,7 +349,7 @@ std::shared_ptr<StreamState> ReactiveSocket::resumeListener(
   //  return handler_->handleResume(token);
 }
 
-void ReactiveSocket::clientConnect(
+void StandardReactiveSocket::clientConnect(
     std::shared_ptr<FrameTransport> frameTransport,
     ConnectionSetupPayload setupPayload) {
   CHECK(frameTransport && !frameTransport->isClosed());
@@ -376,49 +377,49 @@ void ReactiveSocket::clientConnect(
   connection_->connect(std::move(frameTransport), true);
 }
 
-void ReactiveSocket::serverConnect(
+void StandardReactiveSocket::serverConnect(
     std::shared_ptr<FrameTransport> frameTransport,
     bool isResumable) {
   connection_->setResumable(isResumable);
   connection_->connect(std::move(frameTransport), true);
 }
 
-void ReactiveSocket::close() {
+void StandardReactiveSocket::close() {
   if (connection_) {
     connection_->close();
     connection_ = nullptr;
   }
 }
 
-void ReactiveSocket::disconnect() {
+void StandardReactiveSocket::disconnect() {
   checkNotClosed();
   connection_->disconnect();
 }
 
-std::shared_ptr<FrameTransport> ReactiveSocket::detachFrameTransport() {
+std::shared_ptr<FrameTransport> StandardReactiveSocket::detachFrameTransport() {
   checkNotClosed();
   return connection_->detachFrameTransport();
 }
 
-void ReactiveSocket::onConnected(ReactiveSocketCallback listener) {
+void StandardReactiveSocket::onConnected(ReactiveSocketCallback listener) {
   checkNotClosed();
   CHECK(listener);
   onConnectListeners_->push_back(std::move(listener));
 }
 
-void ReactiveSocket::onDisconnected(ReactiveSocketCallback listener) {
+void StandardReactiveSocket::onDisconnected(ReactiveSocketCallback listener) {
   checkNotClosed();
   CHECK(listener);
   onDisconnectListeners_->push_back(std::move(listener));
 }
 
-void ReactiveSocket::onClosed(ReactiveSocketCallback listener) {
+void StandardReactiveSocket::onClosed(ReactiveSocketCallback listener) {
   checkNotClosed();
   CHECK(listener);
   onCloseListeners_->push_back(std::move(listener));
 }
 
-void ReactiveSocket::tryClientResume(
+void StandardReactiveSocket::tryClientResume(
     const ResumeIdentificationToken& token,
     std::shared_ptr<FrameTransport> frameTransport,
     std::unique_ptr<ClientResumeStatusCallback> resumeCallback) {
@@ -432,7 +433,7 @@ void ReactiveSocket::tryClientResume(
   connection_->reconnect(std::move(frameTransport), std::move(resumeCallback));
 }
 
-bool ReactiveSocket::tryResumeServer(
+bool StandardReactiveSocket::tryResumeServer(
     std::shared_ptr<FrameTransport> frameTransport,
     ResumePosition position) {
   // TODO: verify/assert that the new frameTransport is on the same event base
@@ -443,7 +444,7 @@ bool ReactiveSocket::tryResumeServer(
   return connection_->resumeFromPositionOrClose(position, true);
 }
 
-std::function<void()> ReactiveSocket::executeListenersFunc(
+std::function<void()> StandardReactiveSocket::executeListenersFunc(
     std::shared_ptr<std::list<ReactiveSocketCallback>> listeners) {
   auto* thisPtr = this;
   return [thisPtr, listeners]() mutable {
@@ -462,11 +463,11 @@ std::function<void()> ReactiveSocket::executeListenersFunc(
   };
 }
 
-void ReactiveSocket::checkNotClosed() const {
+void StandardReactiveSocket::checkNotClosed() const {
   CHECK(connection_) << "ReactiveSocket already closed";
 }
 
-DuplexConnection* ReactiveSocket::duplexConnection() const {
+DuplexConnection* StandardReactiveSocket::duplexConnection() const {
   return connection_ ? connection_->duplexConnection() : nullptr;
 }
 

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<StandardReactiveSocket> StandardReactiveSocket::disconnectedServ
   return socket;
 }
 
-std::shared_ptr<Subscriber<Payload>> ReactiveSocket::requestChannel(
+std::shared_ptr<Subscriber<Payload>> StandardReactiveSocket::requestChannel(
     std::shared_ptr<Subscriber<Payload>> responseSink) {
   checkNotClosed();
   // TODO(stupaq): handle any exceptions

--- a/src/StandardReactiveSocket.h
+++ b/src/StandardReactiveSocket.h
@@ -36,7 +36,7 @@ folly::Executor& defaultExecutor();
 // that (internally) holds a weak reference (conceptually, not std::weak_ptr)
 // and forbids any interactions with the socket after the shutdown procedure has
 // been initiated.
-class StandardReactiveSocket: public ReactiveSocket {
+class StandardReactiveSocket : public ReactiveSocket {
  public:
   StandardReactiveSocket(StandardReactiveSocket&&) = delete;
   StandardReactiveSocket& operator=(StandardReactiveSocket&&) = delete;

--- a/src/StandardReactiveSocket.h
+++ b/src/StandardReactiveSocket.h
@@ -1,0 +1,161 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <atomic>
+#include <list>
+#include <memory>
+
+#include "src/Common.h"
+#include "src/ConnectionSetupPayload.h"
+#include "src/Payload.h"
+#include "src/ReactiveSocket.h"
+#include "src/ReactiveStreamsCompat.h"
+#include "src/Stats.h"
+
+namespace folly {
+class Executor;
+}
+
+namespace reactivesocket {
+
+class ClientResumeStatusCallback;
+class ConnectionAutomaton;
+class DuplexConnection;
+class FrameTransport;
+class RequestHandler;
+
+folly::Executor& defaultExecutor();
+
+// TODO(stupaq): Here is some heavy problem with the recursion on shutdown.
+// Giving someone ownership over this object would probably lead to a deadlock
+// (or a crash) if one calls ::~ReactiveSocket from a terminal signal handler
+// of any of the connections. It seems natural to follow ReactiveStreams
+// specification and make this object "self owned", so that we don't need to
+// perform all of the cleanup from a d'tor. We could give out a "proxy" object
+// that (internally) holds a weak reference (conceptually, not std::weak_ptr)
+// and forbids any interactions with the socket after the shutdown procedure has
+// been initiated.
+class StandardReactiveSocket: public ReactiveSocket {
+ public:
+  StandardReactiveSocket(StandardReactiveSocket&&) = delete;
+  StandardReactiveSocket& operator=(StandardReactiveSocket&&) = delete;
+  StandardReactiveSocket(const StandardReactiveSocket&) = delete;
+  StandardReactiveSocket& operator=(const StandardReactiveSocket&) = delete;
+
+  ~StandardReactiveSocket();
+
+  static std::unique_ptr<StandardReactiveSocket> fromClientConnection(
+      folly::Executor& executor,
+      std::unique_ptr<DuplexConnection> connection,
+      std::unique_ptr<RequestHandler> handler,
+      ConnectionSetupPayload setupPayload = ConnectionSetupPayload(),
+      Stats& stats = Stats::noop(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(nullptr));
+
+  static std::unique_ptr<StandardReactiveSocket> disconnectedClient(
+      folly::Executor& executor,
+      std::unique_ptr<RequestHandler> handler,
+      Stats& stats = Stats::noop(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(nullptr));
+
+  static std::unique_ptr<StandardReactiveSocket> fromServerConnection(
+      folly::Executor& executor,
+      std::unique_ptr<DuplexConnection> connection,
+      std::unique_ptr<RequestHandler> handler,
+      Stats& stats = Stats::noop(),
+      bool isResumable = false);
+
+  static std::unique_ptr<StandardReactiveSocket> disconnectedServer(
+      folly::Executor& executor,
+      std::unique_ptr<RequestHandler> handler,
+      Stats& stats = Stats::noop());
+
+  std::shared_ptr<Subscriber<Payload>> requestChannel(
+      const std::shared_ptr<Subscriber<Payload>>& responseSink);
+
+  void requestStream(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>>& responseSink) override;
+
+  void requestSubscription(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>>& responseSink) override;
+
+  void requestResponse(
+      Payload payload,
+      const std::shared_ptr<Subscriber<Payload>>& responseSink) override;
+
+  void requestFireAndForget(Payload request) override;
+
+  void metadataPush(std::unique_ptr<folly::IOBuf> metadata) override;
+
+  void clientConnect(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ConnectionSetupPayload setupPayload = ConnectionSetupPayload()) override;
+
+  void serverConnect(
+      std::shared_ptr<FrameTransport> frameTransport,
+      bool isResumable) override;
+
+  void close() override;
+  void disconnect() override;
+  std::shared_ptr<FrameTransport> detachFrameTransport() override;
+
+  void onConnected(ReactiveSocketCallback listener) override;
+  void onDisconnected(ReactiveSocketCallback listener) override;
+  void onClosed(ReactiveSocketCallback listener) override;
+
+  void tryClientResume(
+      const ResumeIdentificationToken& token,
+      std::shared_ptr<FrameTransport> frameTransport,
+      std::unique_ptr<ClientResumeStatusCallback> resumeCallback) override;
+
+  bool tryResumeServer(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ResumePosition position) override;
+
+  folly::Executor& executor() override {
+    return executor_;
+  }
+
+  DuplexConnection* duplexConnection() const override;
+
+ private:
+  StandardReactiveSocket(
+      bool isServer,
+      std::shared_ptr<RequestHandler> handler,
+      Stats& stats,
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer,
+      folly::Executor& executor);
+
+  void createResponder(
+      std::shared_ptr<RequestHandler> handler,
+      ConnectionAutomaton& connection,
+      StreamId streamId,
+      std::unique_ptr<folly::IOBuf> frame);
+
+  std::shared_ptr<StreamState> resumeListener(
+      const ResumeIdentificationToken& token);
+
+  std::function<void()> executeListenersFunc(
+      std::shared_ptr<std::list<ReactiveSocketCallback>> listeners);
+
+  void checkNotClosed() const;
+
+  std::shared_ptr<RequestHandler> handler_;
+
+  std::shared_ptr<std::list<ReactiveSocketCallback>> onConnectListeners_{
+      std::make_shared<std::list<ReactiveSocketCallback>>()};
+  std::shared_ptr<std::list<ReactiveSocketCallback>> onDisconnectListeners_{
+      std::make_shared<std::list<ReactiveSocketCallback>>()};
+  std::shared_ptr<std::list<ReactiveSocketCallback>> onCloseListeners_{
+      std::make_shared<std::list<ReactiveSocketCallback>>()};
+
+  std::shared_ptr<ConnectionAutomaton> connection_;
+  StreamId nextStreamId_;
+  folly::Executor& executor_;
+};
+}

--- a/src/folly/FollyKeepaliveTimer.h
+++ b/src/folly/FollyKeepaliveTimer.h
@@ -4,7 +4,7 @@
 
 #include <folly/io/async/EventBase.h>
 #include <src/ConnectionAutomaton.h>
-#include <src/ReactiveSocket.h>
+#include <src/StandardReactiveSocket.h>
 
 namespace reactivesocket {
 class FollyKeepaliveTimer : public KeepaliveTimer {

--- a/tck-test/TestInterpreter.cpp
+++ b/tck-test/TestInterpreter.cpp
@@ -3,7 +3,7 @@
 #include "TestInterpreter.h"
 
 #include <glog/logging.h>
-#include <src/ReactiveSocket.h>
+#include <src/StandardReactiveSocket.h>
 #include "TypedCommands.h"
 
 using namespace folly;
@@ -13,7 +13,7 @@ namespace tck {
 
 TestInterpreter::TestInterpreter(
     const Test& test,
-    ReactiveSocket& reactiveSocket)
+    StandardReactiveSocket& reactiveSocket)
     : reactiveSocket_(&reactiveSocket), test_(test) {
   DCHECK(!test.empty());
 }

--- a/tck-test/TestInterpreter.h
+++ b/tck-test/TestInterpreter.h
@@ -6,8 +6,8 @@
 #include "TestSubscriber.h"
 #include "TestSuite.h"
 #include "src/Payload.h"
-#include "src/StandardReactiveSocket.h"
 #include "src/ReactiveStreamsCompat.h"
+#include "src/StandardReactiveSocket.h"
 
 namespace folly {
 class EventBase;

--- a/tck-test/TestInterpreter.h
+++ b/tck-test/TestInterpreter.h
@@ -6,7 +6,7 @@
 #include "TestSubscriber.h"
 #include "TestSuite.h"
 #include "src/Payload.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/ReactiveStreamsCompat.h"
 
 namespace folly {
@@ -15,7 +15,7 @@ class EventBase;
 
 namespace reactivesocket {
 
-class ReactiveSocket;
+class StandardReactiveSocket;
 
 namespace tck {
 
@@ -27,7 +27,7 @@ class AssertCommand;
 
 class TestInterpreter {
  public:
-  TestInterpreter(const Test& test, ReactiveSocket& reactiveSocket);
+  TestInterpreter(const Test& test, StandardReactiveSocket& reactiveSocket);
 
   bool run();
 
@@ -41,7 +41,7 @@ class TestInterpreter {
   std::shared_ptr<TestSubscriber> createTestSubscriber(const std::string& id);
   std::shared_ptr<TestSubscriber> getSubscriber(const std::string& id);
 
-  ReactiveSocket* reactiveSocket_;
+  StandardReactiveSocket* reactiveSocket_;
   const Test& test_;
   std::map<std::string, std::string> interactionIdToType_;
   std::map<std::string, std::shared_ptr<TestSubscriber>> testSubscribers_;

--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -9,7 +9,7 @@
 #include "TestInterpreter.h"
 #include "TestSuite.h"
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"
 
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
 
   folly::AsyncSocket::UniquePtr socket;
   std::unique_ptr<SocketConnectCallback> callback;
-  std::unique_ptr<ReactiveSocket> reactiveSocket;
+  std::unique_ptr<StandardReactiveSocket> reactiveSocket;
 
   evbt.getEventBase()->runInEventBaseThreadAndWait([&]() {
     socket.reset(new folly::AsyncSocket(evbt.getEventBase()));
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
     std::unique_ptr<RequestHandler> requestHandler =
         folly::make_unique<DefaultRequestHandler>();
 
-    reactiveSocket = ReactiveSocket::fromClientConnection(
+    reactiveSocket = StandardReactiveSocket::fromClientConnection(
         *evbt.getEventBase(),
         std::move(framedConnection),
         std::move(requestHandler));

--- a/test/MockKeepaliveTimer.h
+++ b/test/MockKeepaliveTimer.h
@@ -8,7 +8,7 @@
 #include <gmock/gmock.h>
 
 #include "src/ConnectionAutomaton.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 
 namespace reactivesocket {
 class MockKeepaliveTimer : public KeepaliveTimer {

--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -11,7 +11,7 @@
 #include <gmock/gmock.h>
 
 #include "MockStats.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "test/InlineConnection.h"
 #include "test/MockRequestHandler.h"
@@ -27,7 +27,7 @@ class ClientSideConcurrencyTest : public testing::Test {
     auto serverConn = folly::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
-    clientSock = ReactiveSocket::fromClientConnection(
+    clientSock = StandardReactiveSocket::fromClientConnection(
         *thread2.getEventBase(),
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
@@ -43,7 +43,7 @@ class ClientSideConcurrencyTest : public testing::Test {
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-    serverSock = ReactiveSocket::fromServerConnection(
+    serverSock = StandardReactiveSocket::fromServerConnection(
         defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
     EXPECT_CALL(*clientInput, onSubscribe_(_))
@@ -156,8 +156,8 @@ class ClientSideConcurrencyTest : public testing::Test {
     cv.wait(lock, [&]() { return isDone_; });
   }
 
-  std::unique_ptr<ReactiveSocket> clientSock;
-  std::unique_ptr<ReactiveSocket> serverSock;
+  std::unique_ptr<StandardReactiveSocket> clientSock;
+  std::unique_ptr<StandardReactiveSocket> serverSock;
 
   static std::unique_ptr<folly::IOBuf> originalPayload() {
     return folly::IOBuf::copyBuffer("foo");
@@ -233,7 +233,7 @@ class ServerSideConcurrencyTest : public testing::Test {
     auto serverConn = folly::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
-    clientSock = ReactiveSocket::fromClientConnection(
+    clientSock = StandardReactiveSocket::fromClientConnection(
         defaultExecutor(),
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
@@ -247,7 +247,7 @@ class ServerSideConcurrencyTest : public testing::Test {
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-    serverSock = ReactiveSocket::fromServerConnection(
+    serverSock = StandardReactiveSocket::fromServerConnection(
         *thread2.getEventBase(),
         std::move(serverConn),
         std::move(serverHandler),
@@ -366,8 +366,8 @@ class ServerSideConcurrencyTest : public testing::Test {
     cv.wait(lock, [&]() { return isDone_; });
   }
 
-  std::unique_ptr<ReactiveSocket> clientSock;
-  std::unique_ptr<ReactiveSocket> serverSock;
+  std::unique_ptr<StandardReactiveSocket> clientSock;
+  std::unique_ptr<StandardReactiveSocket> serverSock;
 
   const std::unique_ptr<folly::IOBuf> originalPayload{
       folly::IOBuf::copyBuffer("foo")};
@@ -513,7 +513,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
               });
             }));
 
-    serverSocket = ReactiveSocket::fromServerConnection(
+    serverSocket = StandardReactiveSocket::fromServerConnection(
         eventBase_,
         folly::make_unique<FramedDuplexConnection>(
             std::move(serverSocketConnection)),
@@ -540,7 +540,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<ReactiveSocket> serverSocket;
+  std::unique_ptr<StandardReactiveSocket> serverSocket;
   std::shared_ptr<MockSubscription> testInputSubscription;
   std::unique_ptr<DuplexConnection> testConnection;
   std::shared_ptr<MockSubscription> validatingSubscription;

--- a/test/ReactiveSocketResumabilityTest.cpp
+++ b/test/ReactiveSocketResumabilityTest.cpp
@@ -4,7 +4,7 @@
 #include <gmock/gmock.h>
 
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "test/InlineConnection.h"
 #include "test/MockStats.h"
 #include "test/ReactiveStreamsMocksCompat.h"
@@ -33,7 +33,7 @@ TEST(ReactiveSocketResumabilityTest, Disconnect) {
 
   MockStats stats;
 
-  auto socket = ReactiveSocket::fromClientConnection(
+  auto socket = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(socketConnection),
       folly::make_unique<DefaultRequestHandler>(),

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -10,7 +10,7 @@
 
 #include "MockStats.h"
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "test/InlineConnection.h"
 #include "test/MockKeepaliveTimer.h"
 #include "test/MockRequestHandler.h"
@@ -49,7 +49,7 @@ TEST(ReactiveSocketTest, RequestChannel) {
   std::shared_ptr<Subscription> clientInputSub, serverInputSub;
   std::shared_ptr<Subscriber<Payload>> clientOutput, serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -63,7 +63,7 @@ TEST(ReactiveSocketTest, RequestChannel) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -168,7 +168,7 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
   std::shared_ptr<Subscription> clientInputSub;
   std::shared_ptr<Subscriber<Payload>> serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -182,7 +182,7 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -257,7 +257,7 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
   std::shared_ptr<Subscription> clientInputSub;
   std::shared_ptr<Subscriber<Payload>> serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -271,7 +271,7 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -343,7 +343,7 @@ TEST(ReactiveSocketTest, RequestSubscription) {
   std::shared_ptr<Subscription> clientInputSub;
   std::shared_ptr<Subscriber<Payload>> serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -357,7 +357,7 @@ TEST(ReactiveSocketTest, RequestSubscription) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -431,7 +431,7 @@ TEST(ReactiveSocketTest, RequestSubscriptionSurplusResponse) {
   std::shared_ptr<Subscription> clientInputSub;
   std::shared_ptr<Subscriber<Payload>> serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -445,7 +445,7 @@ TEST(ReactiveSocketTest, RequestSubscriptionSurplusResponse) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -506,7 +506,7 @@ TEST(ReactiveSocketTest, RequestResponse) {
   std::shared_ptr<Subscription> clientInputSub;
   std::shared_ptr<Subscriber<Payload>> serverOutput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -519,7 +519,7 @@ TEST(ReactiveSocketTest, RequestResponse) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -578,7 +578,7 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
 
   StrictMock<MockSubscriber<Payload>> clientInput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -592,7 +592,7 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -617,7 +617,7 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
 
   StrictMock<MockSubscriber<Payload>> clientInput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -631,7 +631,7 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
   const auto originalPayload = folly::IOBuf::copyBuffer("foo");
@@ -654,7 +654,7 @@ TEST(ReactiveSocketTest, SetupData) {
 
   StrictMock<MockSubscriber<Payload>> clientInput;
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -669,7 +669,7 @@ TEST(ReactiveSocketTest, SetupData) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 }
 
@@ -698,7 +698,7 @@ TEST(ReactiveSocketTest, SetupWithKeepaliveAndStats) {
 
   EXPECT_CALL(*clientKeepalive, stop()).InSequence(s);
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -708,7 +708,7 @@ TEST(ReactiveSocketTest, SetupWithKeepaliveAndStats) {
       clientStats,
       std::move(clientKeepalive));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 }
 
@@ -742,7 +742,7 @@ TEST(ReactiveSocketTest, Destructor) {
   EXPECT_CALL(clientStats, socketClosed()).Times(1);
   EXPECT_CALL(serverStats, socketClosed()).Times(1);
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -757,7 +757,7 @@ TEST(ReactiveSocketTest, Destructor) {
       .InSequence(s)
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(),
       std::move(serverConn),
       std::move(serverHandler),
@@ -825,7 +825,7 @@ TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
   auto serverConn = folly::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
-  auto clientSock = ReactiveSocket::fromClientConnection(
+  auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
@@ -839,7 +839,7 @@ TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-  auto serverSock = ReactiveSocket::fromServerConnection(
+  auto serverSock = StandardReactiveSocket::fromServerConnection(
       defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 }
 
@@ -850,7 +850,7 @@ class ReactiveSocketIgnoreRequestTest : public testing::Test {
     auto serverConn = folly::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
-    clientSock = ReactiveSocket::fromClientConnection(
+    clientSock = StandardReactiveSocket::fromClientConnection(
         defaultExecutor(),
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
@@ -858,7 +858,7 @@ class ReactiveSocketIgnoreRequestTest : public testing::Test {
         folly::make_unique<StrictMock<MockRequestHandler>>(),
         ConnectionSetupPayload("", "", Payload()));
 
-    serverSock = ReactiveSocket::fromServerConnection(
+    serverSock = StandardReactiveSocket::fromServerConnection(
         defaultExecutor(),
         std::move(serverConn),
         folly::make_unique<DefaultRequestHandler>());
@@ -885,8 +885,8 @@ class ReactiveSocketIgnoreRequestTest : public testing::Test {
         }));
   }
 
-  std::unique_ptr<ReactiveSocket> clientSock;
-  std::unique_ptr<ReactiveSocket> serverSock;
+  std::unique_ptr<StandardReactiveSocket> clientSock;
+  std::unique_ptr<StandardReactiveSocket> serverSock;
 
   std::shared_ptr<StrictMock<MockSubscriber<Payload>>> clientInput{
       std::make_shared<StrictMock<MockSubscriber<Payload>>>()};
@@ -931,7 +931,7 @@ class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
     auto serverConn = folly::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
-    clientSock = ReactiveSocket::fromClientConnection(
+    clientSock = StandardReactiveSocket::fromClientConnection(
         defaultExecutor(),
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
@@ -945,7 +945,7 @@ class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(std::make_shared<StreamState>()));
 
-    serverSock = ReactiveSocket::fromServerConnection(
+    serverSock = StandardReactiveSocket::fromServerConnection(
         defaultExecutor(), std::move(serverConn), std::move(serverHandler));
 
     EXPECT_CALL(*clientInput, onSubscribe_(_))
@@ -1024,8 +1024,8 @@ class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
         }));
   }
 
-  std::unique_ptr<ReactiveSocket> clientSock;
-  std::unique_ptr<ReactiveSocket> serverSock;
+  std::unique_ptr<StandardReactiveSocket> clientSock;
+  std::unique_ptr<StandardReactiveSocket> serverSock;
 
   const std::unique_ptr<folly::IOBuf> originalPayload{
       folly::IOBuf::copyBuffer("foo")};

--- a/test/framed/FramedReaderTest.cpp
+++ b/test/framed/FramedReaderTest.cpp
@@ -6,7 +6,7 @@
 #include <folly/Format.h>
 #include <folly/io/Cursor.h>
 #include <gmock/gmock.h>
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/framed/FramedReader.h"
 #include "test/InlineConnection.h"
@@ -212,7 +212,7 @@ TEST(FramedReaderTest, InvalidDataStream) {
   testConnection->setInput(testOutputSubscriber);
   testConnection->getOutput()->onSubscribe(inputSubscription);
 
-  auto reactiveSocket = ReactiveSocket::fromClientConnection(
+  auto reactiveSocket = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(framedRsAutomatonConnection),
       // No interactions on this mock, the client will not accept any

--- a/test/resume/TcpResumeClient.cpp
+++ b/test/resume/TcpResumeClient.cpp
@@ -7,7 +7,7 @@
 #include "src/ClientResumeStatusCallback.h"
 #include "src/FrameTransport.h"
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/folly/FollyKeepaliveTimer.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 
   ScopedEventBaseThread eventBaseThread;
 
-  std::unique_ptr<ReactiveSocket> reactiveSocket;
+  std::unique_ptr<StandardReactiveSocket> reactiveSocket;
   Callback callback;
   StatsPrinter stats;
 
@@ -84,20 +84,20 @@ int main(int argc, char* argv[]) {
     std::unique_ptr<RequestHandler> requestHandler =
         folly::make_unique<DefaultRequestHandler>();
 
-    reactiveSocket = ReactiveSocket::disconnectedClient(
+    reactiveSocket = StandardReactiveSocket::disconnectedClient(
         *eventBaseThread.getEventBase(),
         std::move(requestHandler),
         stats,
         folly::make_unique<FollyKeepaliveTimer>(
             *eventBaseThread.getEventBase(), std::chrono::seconds(10)));
 
-    reactiveSocket->onConnected([](ReactiveSocket& socket) {
+    reactiveSocket->onConnected([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket connected " << &socket;
     });
-    reactiveSocket->onDisconnected([](ReactiveSocket& socket) {
+    reactiveSocket->onDisconnected([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket disconnect " << &socket;
     });
-    reactiveSocket->onClosed([](ReactiveSocket& socket) {
+    reactiveSocket->onClosed([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket closed " << &socket;
     });
 

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 #include "src/FrameTransport.h"
 #include "src/NullRequestHandler.h"
-#include "src/StandardReactiveSocket.h"
 #include "src/SmartPointers.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/SubscriptionBase.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"
@@ -21,8 +21,9 @@ DEFINE_string(address, "9898", "host:port to listen to");
 
 namespace {
 
-std::vector<
-    std::pair<std::unique_ptr<StandardReactiveSocket>, ResumeIdentificationToken>>
+std::vector<std::pair<
+    std::unique_ptr<StandardReactiveSocket>,
+    ResumeIdentificationToken>>
     g_reactiveSockets;
 
 class ServerSubscription : public SubscriptionBase {
@@ -171,8 +172,9 @@ class Callback : public AsyncServerSocket::AcceptCallback {
     std::unique_ptr<RequestHandler> requestHandler =
         folly::make_unique<ServerRequestHandler>(streamState_);
 
-    std::unique_ptr<StandardReactiveSocket> rs = StandardReactiveSocket::disconnectedServer(
-        eventBase_, std::move(requestHandler), stats_);
+    std::unique_ptr<StandardReactiveSocket> rs =
+        StandardReactiveSocket::disconnectedServer(
+            eventBase_, std::move(requestHandler), stats_);
 
     rs->onConnected([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket connected " << &socket;

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -5,7 +5,7 @@
 #include <gmock/gmock.h>
 #include "src/FrameTransport.h"
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/SmartPointers.h"
 #include "src/SubscriptionBase.h"
 #include "src/framed/FramedDuplexConnection.h"
@@ -22,7 +22,7 @@ DEFINE_string(address, "9898", "host:port to listen to");
 namespace {
 
 std::vector<
-    std::pair<std::unique_ptr<ReactiveSocket>, ResumeIdentificationToken>>
+    std::pair<std::unique_ptr<StandardReactiveSocket>, ResumeIdentificationToken>>
     g_reactiveSockets;
 
 class ServerSubscription : public SubscriptionBase {
@@ -171,19 +171,19 @@ class Callback : public AsyncServerSocket::AcceptCallback {
     std::unique_ptr<RequestHandler> requestHandler =
         folly::make_unique<ServerRequestHandler>(streamState_);
 
-    std::unique_ptr<ReactiveSocket> rs = ReactiveSocket::disconnectedServer(
+    std::unique_ptr<StandardReactiveSocket> rs = StandardReactiveSocket::disconnectedServer(
         eventBase_, std::move(requestHandler), stats_);
 
-    rs->onConnected([](ReactiveSocket& socket) {
+    rs->onConnected([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket connected " << &socket;
     });
-    rs->onDisconnected([](ReactiveSocket& socket) {
+    rs->onDisconnected([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket disconnect " << &socket;
       // to verify these frames will be queued up
       socket.requestStream(
           Payload("from server resume"), std::make_shared<PrintSubscriber>());
     });
-    rs->onClosed([](ReactiveSocket& socket) {
+    rs->onClosed([](StandardReactiveSocket& socket) {
       LOG(INFO) << "socket closed " << &socket;
     });
 
@@ -203,13 +203,13 @@ class Callback : public AsyncServerSocket::AcceptCallback {
         std::move(rs), ResumeIdentificationToken::generateNew());
   }
 
-  void removeSocket(ReactiveSocket& socket) {
+  void removeSocket(StandardReactiveSocket& socket) {
     if (!shuttingDown) {
       g_reactiveSockets.erase(std::remove_if(
           g_reactiveSockets.begin(),
           g_reactiveSockets.end(),
           [&socket](const std::pair<
-                    std::unique_ptr<ReactiveSocket>,
+                    std::unique_ptr<StandardReactiveSocket>,
                     ResumeIdentificationToken>& kv) {
             return kv.first.get() == &socket;
           }));

--- a/test/tcp/TcpClient.cpp
+++ b/test/tcp/TcpClient.cpp
@@ -5,7 +5,7 @@
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gmock/gmock.h>
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/folly/FollyKeepaliveTimer.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
 
   ScopedEventBaseThread eventBaseThread;
 
-  std::unique_ptr<ReactiveSocket> reactiveSocket;
+  std::unique_ptr<StandardReactiveSocket> reactiveSocket;
   Callback callback;
   StatsPrinter stats;
 
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
         std::unique_ptr<RequestHandler> requestHandler =
             folly::make_unique<DefaultRequestHandler>();
 
-        reactiveSocket = ReactiveSocket::fromClientConnection(
+        reactiveSocket = StandardReactiveSocket::fromClientConnection(
             *eventBaseThread.getEventBase(),
             std::move(framedConnection),
             std::move(requestHandler),

--- a/test/tcp/TcpServer.cpp
+++ b/test/tcp/TcpServer.cpp
@@ -4,8 +4,8 @@
 #include <folly/io/async/AsyncServerSocket.h>
 #include <gmock/gmock.h>
 #include "src/NullRequestHandler.h"
-#include "src/StandardReactiveSocket.h"
 #include "src/SmartPointers.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/SubscriptionBase.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"

--- a/test/tcp/TcpServer.cpp
+++ b/test/tcp/TcpServer.cpp
@@ -4,7 +4,7 @@
 #include <folly/io/async/AsyncServerSocket.h>
 #include <gmock/gmock.h>
 #include "src/NullRequestHandler.h"
-#include "src/ReactiveSocket.h"
+#include "src/StandardReactiveSocket.h"
 #include "src/SmartPointers.h"
 #include "src/SubscriptionBase.h"
 #include "src/framed/FramedDuplexConnection.h"
@@ -113,7 +113,7 @@ class Callback : public AsyncServerSocket::AcceptCallback {
     std::unique_ptr<RequestHandler> requestHandler =
         folly::make_unique<ServerRequestHandler>();
 
-    auto rs = ReactiveSocket::fromServerConnection(
+    auto rs = StandardReactiveSocket::fromServerConnection(
         eventBase_,
         std::move(framedConnection),
         std::move(requestHandler),
@@ -125,12 +125,12 @@ class Callback : public AsyncServerSocket::AcceptCallback {
     reactiveSockets_.push_back(std::move(rs));
   }
 
-  void removeSocket(ReactiveSocket& socket) {
+  void removeSocket(StandardReactiveSocket& socket) {
     if (!shuttingDown) {
       reactiveSockets_.erase(std::remove_if(
           reactiveSockets_.begin(),
           reactiveSockets_.end(),
-          [&socket](std::unique_ptr<ReactiveSocket>& vecSocket) {
+          [&socket](std::unique_ptr<StandardReactiveSocket>& vecSocket) {
             return vecSocket.get() == &socket;
           }));
     }
@@ -146,7 +146,7 @@ class Callback : public AsyncServerSocket::AcceptCallback {
   }
 
  private:
-  std::vector<std::unique_ptr<ReactiveSocket>> reactiveSockets_;
+  std::vector<std::unique_ptr<StandardReactiveSocket>> reactiveSockets_;
   EventBase& eventBase_;
   Stats& stats_;
   bool shuttingDown{false};


### PR DESCRIPTION
Clients wanting to mock ReactiveSocket face a tough ask without an interface.  While technically possible its not as elegant and the other option is mocking DuplexConnection or using Inline connection, both of which are much lower level abstractions.