### PR TITLE
Make ResumeIdentificationToken::toString() return hex representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,8 @@ add_executable(
   test/folly/FollyKeepaliveTimerTest.cpp
   test/ReactiveSocketResumabilityTest.cpp
   test/SmartPointersTest.cpp
-  test/AllowanceSemaphoreTest.cpp)
+  test/AllowanceSemaphoreTest.cpp
+  test/ResumeIdentificationTokenTest.cpp)
 
 target_link_libraries(
   tests

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -7,6 +7,12 @@
 
 namespace reactivesocket {
 
+namespace {
+
+const char* HEX_CHARS = { "0123456789abcdef" };
+
+}
+
 static const char* getTerminatingSignalErrorMessage(int terminatingSignal) {
   switch ((StreamCompletionSignal)terminatingSignal) {
     case StreamCompletionSignal::CONNECTION_END:
@@ -80,11 +86,12 @@ ResumeIdentificationToken ResumeIdentificationToken::fromString(
 }
 
 std::string ResumeIdentificationToken::toString() const {
-  std::ostringstream str;
-  for (auto& i : bits_) {
-    str << i << " ";
+  std::string str;
+  for (auto b : bits_) {
+    str += HEX_CHARS[(b & 0xF0) >> 4];
+    str += HEX_CHARS[b & 0x0F];
   }
-  return str.str();
+  return str;
 }
 
 } // reactivesocket

--- a/test/ResumeIdentificationTokenTest.cpp
+++ b/test/ResumeIdentificationTokenTest.cpp
@@ -1,0 +1,15 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "src/Common.h"
+#include "test/streams/Mocks.h"
+
+using namespace ::testing;
+using namespace ::reactivesocket;
+
+TEST(ResumeIdentificationTokenTest, ToString) {
+  ResumeIdentificationToken token;
+  token.set({{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xff, 0xed, 0xcb, 0xa9, 0x87, 0x65, 0x43, 0x21, 0x00}});
+  ASSERT_EQ("123456789abcdeffedcba98765432100", token.toString());
+}


### PR DESCRIPTION
This allows me to print this in a nice way :)

Tested by creating:
```
ResumeIdentificationToken({0xab, 0xba, 0xff, 0x12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
```

And verify it prints as:
```
ConnectionManager.cpp  I  Trying to resume socket, token: abbaff12000000000000000000000000
```