### PR TITLE
ConsumerMixin::subscribe calls onSubscribe directly

### DIFF
--- a/src/automata/ChannelRequester.cpp
+++ b/src/automata/ChannelRequester.cpp
@@ -37,7 +37,7 @@ void ChannelRequester::onNextImpl(Payload request) {
       // Pump the remaining allowance into the ConsumerMixin _after_ sending the
       // initial request.
       if (remainingN) {
-        Base::request(remainingN);
+        Base::generateRequest(remainingN);
       }
     } break;
     case State::REQUESTED:
@@ -93,7 +93,7 @@ void ChannelRequester::requestImpl(size_t n) {
       initialResponseAllowance_.release(n);
       break;
     case State::REQUESTED:
-      Base::request(n);
+      Base::generateRequest(n);
       break;
     case State::CLOSED:
       break;

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -21,21 +21,12 @@ namespace reactivesocket {
 class ChannelRequester : public PublisherMixin<
                              Frame_REQUEST_CHANNEL,
                              ConsumerMixin<Frame_RESPONSE>>,
-                         public SubscriberBase,
-                         public SubscriptionBase {
+                         public SubscriberBase {
   using Base =
       PublisherMixin<Frame_REQUEST_CHANNEL, ConsumerMixin<Frame_RESPONSE>>;
 
  public:
-  struct Parameters : Base::Parameters {
-    Parameters(
-        const typename Base::Parameters& baseParams,
-        folly::Executor& _executor)
-        : Base::Parameters(baseParams), executor(_executor) {}
-    folly::Executor& executor;
-  };
-
-  explicit ChannelRequester(const Parameters& params)
+  explicit ChannelRequester(const Base::Parameters& params)
       : ExecutorBase(params.executor, false), Base(params) {}
 
   std::ostream& logPrefix(std::ostream& os);
@@ -48,10 +39,9 @@ class ChannelRequester : public PublisherMixin<
   void onErrorImpl(folly::exception_wrapper) override;
   /// @}
 
-  /// @{
+  // implementation from ConsumerMixin::SubscriptionBase
   void requestImpl(size_t) override;
   void cancelImpl() override;
-  /// @}
 
   using Base::onNextFrame;
   void onNextFrame(Frame_RESPONSE&&) override;

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -49,7 +49,7 @@ void ChannelResponder::onErrorImpl(folly::exception_wrapper ex) {
 void ChannelResponder::requestImpl(size_t n) {
   switch (state_) {
     case State::RESPONDING:
-      Base::request(n);
+      Base::generateRequest(n);
     case State::CLOSED:
       break;
   }

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -16,21 +16,12 @@ namespace reactivesocket {
 class ChannelResponder : public PublisherMixin<
                              Frame_RESPONSE,
                              ConsumerMixin<Frame_REQUEST_CHANNEL>>,
-                         public SubscriberBase,
-                         public SubscriptionBase {
+                         public SubscriberBase {
   using Base =
       PublisherMixin<Frame_RESPONSE, ConsumerMixin<Frame_REQUEST_CHANNEL>>;
 
  public:
-  struct Parameters : Base::Parameters {
-    Parameters(
-        const typename Base::Parameters& baseParams,
-        folly::Executor& _executor)
-        : Base::Parameters(baseParams), executor(_executor) {}
-    folly::Executor& executor;
-  };
-
-  explicit ChannelResponder(const Parameters& params)
+  explicit ChannelResponder(const Base::Parameters& params)
       : ExecutorBase(params.executor, false), Base(params) {}
 
   void processInitialFrame(Frame_REQUEST_CHANNEL&&);
@@ -43,6 +34,7 @@ class ChannelResponder : public PublisherMixin<
   void onCompleteImpl() override;
   void onErrorImpl(folly::exception_wrapper) override;
 
+  // implementation from ConsumerMixin::SubscriptionBase
   void requestImpl(size_t n) override;
   void cancelImpl() override;
 

--- a/src/automata/RequestResponseRequester.cpp
+++ b/src/automata/RequestResponseRequester.cpp
@@ -8,15 +8,12 @@
 
 namespace reactivesocket {
 
-bool RequestResponseRequester::subscribe(
+void RequestResponseRequester::subscribe(
     std::shared_ptr<Subscriber<Payload>> subscriber) {
   DCHECK(!isTerminated());
   DCHECK(!consumingSubscriber_);
   consumingSubscriber_.reset(std::move(subscriber));
-  // FIXME(lehecka): now it is possible to move it here
-  // Subscriber::onSubscribe is delivered externally, as it may attempt to
-  // synchronously deliver Subscriber::request.
-  return true;
+  consumingSubscriber_.onSubscribe(SubscriptionBase::shared_from_this());
 }
 
 void RequestResponseRequester::onNext(Payload request) {

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -36,7 +36,7 @@ class RequestResponseRequester
   // TODO(lehecka): rename to avoid confusion
   void onNext(Payload);
 
-  bool subscribe(std::shared_ptr<Subscriber<Payload>> subscriber);
+  void subscribe(std::shared_ptr<Subscriber<Payload>> subscriber);
 
   std::ostream& logPrefix(std::ostream& os);
 

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -28,7 +28,7 @@ class RequestResponseResponder
   };
 
   explicit RequestResponseResponder(const Parameters& params)
-      : ExecutorBase(params.executor, false), Base(params) {}
+      : ExecutorBase(params.executor, false), Base(params, nullptr) {}
 
   void processInitialFrame(Frame_REQUEST_RESPONSE&&);
 

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -35,7 +35,7 @@ void StreamSubscriptionRequesterBase::onNextImpl(Payload request) {
       // Pump the remaining allowance into the ConsumerMixin _after_ sending the
       // initial request.
       if (remainingN) {
-        Base::request(remainingN);
+        Base::generateRequest(remainingN);
       }
     } break;
     case State::REQUESTED:
@@ -55,7 +55,7 @@ void StreamSubscriptionRequesterBase::requestImpl(size_t n) {
       initialResponseAllowance_.release(n);
       break;
     case State::REQUESTED:
-      Base::request(n);
+      Base::generateRequest(n);
       break;
     case State::CLOSED:
       break;

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -13,20 +13,11 @@ namespace reactivesocket {
 /// Implementation of stream automaton that represents a Subscription requester.
 class StreamSubscriptionRequesterBase
     : public ConsumerMixin<Frame_RESPONSE>,
-      public SubscriptionBase,
       public EnableSharedFromThisBase<StreamSubscriptionRequesterBase> {
   using Base = ConsumerMixin<Frame_RESPONSE>;
 
  public:
-  struct Parameters : Base::Parameters {
-    Parameters(
-        const typename Base::Parameters& baseParams,
-        folly::Executor& _executor)
-        : Base::Parameters(baseParams), executor(_executor) {}
-    folly::Executor& executor;
-  };
-
-  explicit StreamSubscriptionRequesterBase(const Parameters& params)
+  explicit StreamSubscriptionRequesterBase(const Base::Parameters& params)
       : ExecutorBase(params.executor, false), Base(params) {}
 
   /// Degenerate form of the Subscriber interface -- only one request payload
@@ -40,6 +31,7 @@ class StreamSubscriptionRequesterBase
   /// Override in subclass to send the correct type of request frame
   virtual void sendRequestFrame(FrameFlags, size_t, Payload&&) = 0;
 
+  // implementation from ConsumerMixin::SubscriptionBase
   void requestImpl(size_t) override;
   void cancelImpl() override;
 

--- a/src/automata/StreamSubscriptionResponderBase.h
+++ b/src/automata/StreamSubscriptionResponderBase.h
@@ -29,7 +29,7 @@ class StreamSubscriptionResponderBase
   };
 
   explicit StreamSubscriptionResponderBase(const Parameters& params)
-      : ExecutorBase(params.executor, false), Base(params) {}
+      : ExecutorBase(params.executor, false), Base(params, nullptr) {}
 
  protected:
   using Base::onNextFrame;

--- a/src/mixins/ConsumerMixin.h
+++ b/src/mixins/ConsumerMixin.h
@@ -84,8 +84,10 @@ class ConsumerMixin : public StreamAutomatonBase, public SubscriptionBase {
   /// @}
 
  private:
-  // we don't want drived classes to call these methods.
-  // Protection against bugs of that kind.
+  // we don't want derived classes to call these methods.
+  // derived classes should be calling implementation methods, not the top level
+  // methods which are for the application code.
+  // avoiding potential bugs..
   using SubscriptionBase::request;
   using SubscriptionBase::cancel;
 

--- a/src/mixins/ConsumerMixin.h
+++ b/src/mixins/ConsumerMixin.h
@@ -19,11 +19,20 @@ enum class StreamCompletionSignal;
 
 /// A mixin that represents a flow-control-aware consumer of data.
 template <typename Frame>
-class ConsumerMixin : public StreamAutomatonBase {
+class ConsumerMixin : public StreamAutomatonBase, public SubscriptionBase {
   using Base = StreamAutomatonBase;
 
  public:
-  using Base::Base;
+  struct Parameters : Base::Parameters {
+    Parameters(
+        const typename Base::Parameters& baseParams,
+        folly::Executor& _executor)
+        : Base::Parameters(baseParams), executor(_executor) {}
+    folly::Executor& executor;
+  };
+
+  explicit ConsumerMixin(const Parameters& params)
+      : ExecutorBase(params.executor, false), Base(params) {}
 
   /// Adds implicit allowance.
   ///
@@ -34,23 +43,19 @@ class ConsumerMixin : public StreamAutomatonBase {
   }
 
   /// @{
-  bool subscribe(std::shared_ptr<Subscriber<Payload>> subscriber) {
+  void subscribe(std::shared_ptr<Subscriber<Payload>> subscriber) {
     if (Base::isTerminated()) {
       subscriber->onSubscribe(std::make_shared<NullSubscription>());
       subscriber->onComplete();
-      return false;
+      return;
     }
 
     DCHECK(!consumingSubscriber_);
     consumingSubscriber_.reset(std::move(subscriber));
-
-    // TODO(lehecka): refactor this method to call
-    // subscriber->onSubscribe(enable_shared_from_this());
-    // and remove returning the boolean value
-    return true;
+    consumingSubscriber_.onSubscribe(shared_from_this());
   }
 
-  void request(size_t n) {
+  void generateRequest(size_t n) {
     allowance_.release(n);
     pendingAllowance_.release(n);
     sendRequests();
@@ -79,6 +84,11 @@ class ConsumerMixin : public StreamAutomatonBase {
   /// @}
 
  private:
+  // we don't want drived classes to call these methods.
+  // Protection against bugs of that kind.
+  using SubscriptionBase::request;
+  using SubscriptionBase::cancel;
+
   void sendRequests();
 
   void handleFlowControlError();

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <type_traits>
 #include "src/ConnectionAutomaton.h"
+#include "src/Executor.h"
 #include "src/Frame.h"
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
@@ -20,7 +21,13 @@ enum class StreamCompletionSignal;
 template <typename ProducedFrame, typename Base>
 class PublisherMixin : public Base {
  public:
-  using Base::Base;
+  explicit PublisherMixin(const typename Base::Parameters& params)
+      : ExecutorBase(params.executor, false), Base(params) {}
+
+  explicit PublisherMixin(
+      const typename Base::Parameters& params,
+      std::nullptr_t)
+      : Base(params) {}
 
   /// @{
   void onSubscribe(std::shared_ptr<Subscription> subscription) {


### PR DESCRIPTION
this is a cleanup change simplifying ReactiveSocket.cpp
onSubscribe should be called directly in subcscribe().
This clean call pattern was not possible with the mixin architecture where the base class (mixin) didn't know the end type implementing Subscription interface. Now with the regular inheritance it is possible.

Another clenaup PR is following..