### PR TITLE
Deliver onConnected after output has been requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,8 @@ add_executable(
   test/SmartPointersTest.cpp
   test/AllowanceSemaphoreTest.cpp
   test/ResumeIdentificationTokenTest.cpp
-  test/PayloadTest.cpp)
+  test/PayloadTest.cpp
+  test/FrameTransportTest.cpp)
 
 target_link_libraries(
   tests

--- a/src/ConnectionAutomaton.cpp
+++ b/src/ConnectionAutomaton.cpp
@@ -64,7 +64,6 @@ void ConnectionAutomaton::connect(
   CHECK(!frameTransport->isClosed());
 
   frameTransport_ = std::move(frameTransport);
-  onConnected_();
 
   // We need to create a hard reference to frameTransport_ to make sure the
   // instance survives until the setFrameProcessor returns. There can be
@@ -230,6 +229,10 @@ void ConnectionAutomaton::closeStreams(StreamCompletionSignal signal) {
     assert(result);
     assert(streamState_->streams_.size() == oldSize - 1);
   }
+}
+
+void ConnectionAutomaton::onReady() {
+  onConnected_();
 }
 
 void ConnectionAutomaton::processFrame(std::unique_ptr<folly::IOBuf> frame) {

--- a/src/ConnectionAutomaton.h
+++ b/src/ConnectionAutomaton.h
@@ -183,6 +183,7 @@ class ConnectionAutomaton
   /// The call is idempotent and returns false iff a stream has not been found.
   bool endStreamInternal(StreamId streamId, StreamCompletionSignal signal);
 
+  void onReady() override;
   void processFrame(std::unique_ptr<folly::IOBuf>) override;
   void onTerminal(folly::exception_wrapper, StreamCompletionSignal) override;
 

--- a/src/FrameProcessor.h
+++ b/src/FrameProcessor.h
@@ -15,6 +15,7 @@ class FrameProcessor {
  public:
   virtual ~FrameProcessor() = default;
 
+  virtual void onReady() = 0;
   virtual void processFrame(std::unique_ptr<folly::IOBuf>) = 0;
   virtual void onTerminal(folly::exception_wrapper, StreamCompletionSignal) = 0;
 };

--- a/src/FrameTransport.cpp
+++ b/src/FrameTransport.cpp
@@ -119,6 +119,11 @@ void FrameTransport::request(size_t n) {
     return;
   }
 
+  if (!deliveredOnReady_ && frameProcessor_) {
+    deliveredOnReady_ = true;
+    frameProcessor_->onReady();
+  }
+
   if (writeAllowance_.release(n) > 0) {
     // There are no pending wfrites or we already have this method on the
     // stack.

--- a/src/FrameTransport.h
+++ b/src/FrameTransport.h
@@ -71,6 +71,7 @@ class FrameTransport :
       connectionOutput_;
   reactivestreams::SubscriptionPtr<Subscription> connectionInputSub_;
 
+  bool deliveredOnReady_{false};
   std::deque<std::unique_ptr<folly::IOBuf>> pendingWrites_;
 };
 } // reactivesocekt

--- a/test/FrameTransportTest.cpp
+++ b/test/FrameTransportTest.cpp
@@ -1,0 +1,84 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/Memory.h>
+
+#include "src/StandardReactiveSocket.h"
+#include "src/FrameProcessor.h"
+#include "src/FrameTransport.h"
+
+#include "test/streams/Mocks.h"
+#include "test/InlineConnection.h"
+#include "test/MockRequestHandler.h"
+#include "test/ReactiveStreamsMocksCompat.h"
+
+using namespace ::testing;
+using namespace ::reactivesocket;
+
+namespace {
+
+class StubDuplexConnection : public DuplexConnection {
+public:
+  StubDuplexConnection()
+  : outputSubscriber_(std::make_shared<MockSubscriber<std::unique_ptr<folly::IOBuf>>>()) {}
+
+  void setInput(std::shared_ptr<Subscriber<std::unique_ptr<folly::IOBuf>>> framesSink) override {
+    // We don't care about this
+    framesSink->onSubscribe(std::make_shared<MockSubscription>());
+  };
+
+  std::shared_ptr<Subscriber<std::unique_ptr<folly::IOBuf>>> getOutput() override {
+    return outputSubscriber_;
+  }
+
+  std::shared_ptr<MockSubscriber<std::unique_ptr<folly::IOBuf>>> outputSubscriber_;
+};
+
+class MockFrameProcessor : public FrameProcessor {
+public:
+  MOCK_METHOD0(onReady, void());
+
+  void processFrame(std::unique_ptr<folly::IOBuf> buf) {
+    processFrame(buf.get());
+  }
+
+  MOCK_METHOD1(processFrame, void(folly::IOBuf*));
+  MOCK_METHOD2(onTerminal, void(folly::exception_wrapper, StreamCompletionSignal));
+};
+
+}
+
+TEST(FrameTransportTest, NoOnReady) {
+  auto duplexConnection = folly::make_unique<StubDuplexConnection>();
+
+  auto frameTransport = std::make_shared<FrameTransport>(std::move(duplexConnection));
+  auto frameProcessor = std::make_shared<StrictMock<MockFrameProcessor>>();
+
+  frameTransport->setFrameProcessor(frameProcessor);
+
+  EXPECT_CALL(*frameProcessor, onReady())
+    .Times(0);
+
+  frameTransport->close(folly::exception_wrapper());
+}
+
+TEST(FrameTransportTest, OnReady) {
+  auto duplexConnection = folly::make_unique<StubDuplexConnection>();
+  auto outputSubscription = duplexConnection->outputSubscriber_;
+
+  auto frameTransport = std::make_shared<FrameTransport>(std::move(duplexConnection));
+  auto frameProcessor = std::make_shared<StrictMock<MockFrameProcessor>>();
+
+  frameTransport->setFrameProcessor(frameProcessor);
+
+  EXPECT_CALL(*frameProcessor, onReady())
+    .Times(1);
+
+  // Simulate requesting output
+  outputSubscription->subscription()->request(1);
+  outputSubscription->subscription()->request(1);
+
+  frameTransport->close(folly::exception_wrapper());
+}


### PR DESCRIPTION
This allows us to only deliver the onConnected after we know we have a valid connection, eg after HTTP 200.