### PR TITLE
Make ResumeIdentificationToken::generateNew() be random

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -2,6 +2,7 @@
 
 #include "src/Common.h"
 #include <folly/io/IOBuf.h>
+#include <folly/Random.h>
 #include <random>
 #include "src/AbstractStreamAutomaton.h"
 
@@ -65,15 +66,11 @@ ResumeIdentificationToken ResumeIdentificationToken::generateNew() {
   // TODO: this will be replaced with a variable length bit array and the value
   // will be generated outside of reactivesocket
   // for now we will use temporary number generator
-  std::mt19937 rng;
-  rng.seed(std::random_device()());
-  auto num = rng();
-
-  static_assert(sizeof(num) <= sizeof(Data), "FIXME");
+  folly::ThreadLocalPRNG rng;
 
   Data data;
-  for (size_t i = 0; i < sizeof(num); i++) {
-    data[i] = ((uint8_t*)&num)[i];
+  for (size_t i = 0; i < data.size(); i++) {
+    data[i] = folly::Random::rand32(rng);
   }
   return ResumeIdentificationToken(std::move(data));
 }


### PR DESCRIPTION
The previous implementation wasn't very random and given we'll actually run this in limited prod it seems like we need this now. I opted to just use folly as this is to be changed anyway (according to TODO).

Before:
```
51985dbc010000009d61810401000000
f2578883ff7f00009da2230501000000
05415347ff7f00009da2230501000000
c199847dff7f00009da2230501000000
```
After:
```
c7d4f3890ee9f867fea73a7b8a4144f9
6d237cf8aa70e8864a27b4fbdefee812
4ef12e654849ca6d969a065754df92c6
113a3151b5616143a54471f3c937b339
```