### PR TITLE
Codemod folly::make_unique to std::make_unique

### DIFF
--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
 
   evbt.getEventBase()->runInEventBaseThreadAndWait([&]() {
     socket.reset(new folly::AsyncSocket(evbt.getEventBase()));
-    callback = folly::make_unique<SocketConnectCallback>();
+    callback = std::make_unique<SocketConnectCallback>();
     folly::SocketAddress addr(FLAGS_host, FLAGS_port, true);
 
     LOG(INFO) << "attempting connection to " << addr.describe();
@@ -85,13 +85,13 @@ int main(int argc, char* argv[]) {
 
   evbt.getEventBase()->runInEventBaseThreadAndWait([&]() {
     std::unique_ptr<DuplexConnection> connection =
-        folly::make_unique<TcpDuplexConnection>(
+        std::make_unique<TcpDuplexConnection>(
             std::move(socket), inlineExecutor());
     std::unique_ptr<DuplexConnection> framedConnection =
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(connection), inlineExecutor());
     std::unique_ptr<RequestHandler> requestHandler =
-        folly::make_unique<DefaultRequestHandler>();
+        std::make_unique<DefaultRequestHandler>();
 
     reactiveSocket = StandardReactiveSocket::fromClientConnection(
         *evbt.getEventBase(),

--- a/test/ConnectionAutomatonTest.cpp
+++ b/test/ConnectionAutomatonTest.cpp
@@ -29,15 +29,15 @@ static std::unique_ptr<folly::IOBuf> makeInvalidFrameHeader() {
 }
 
 TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
-  auto automatonConnection = folly::make_unique<InlineConnection>();
-  auto testConnection = folly::make_unique<InlineConnection>();
+  auto automatonConnection = std::make_unique<InlineConnection>();
+  auto testConnection = std::make_unique<InlineConnection>();
 
   automatonConnection->connectTo(*testConnection);
 
-  auto framedAutomatonConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedAutomatonConnection = std::make_unique<FramedDuplexConnection>(
       std::move(automatonConnection), inlineExecutor());
 
-  auto framedTestConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedTestConnection = std::make_unique<FramedDuplexConnection>(
       std::move(testConnection), inlineExecutor());
 
   // Dump 1 invalid frame and expect an error
@@ -100,15 +100,15 @@ static void terminateTest(
     bool inOnNext,
     bool inOnComplete,
     bool inRequest) {
-  auto automatonConnection = folly::make_unique<InlineConnection>();
-  auto testConnection = folly::make_unique<InlineConnection>();
+  auto automatonConnection = std::make_unique<InlineConnection>();
+  auto testConnection = std::make_unique<InlineConnection>();
 
   automatonConnection->connectTo(*testConnection);
 
-  auto framedAutomatonConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedAutomatonConnection = std::make_unique<FramedDuplexConnection>(
       std::move(automatonConnection), inlineExecutor());
 
-  auto framedTestConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedTestConnection = std::make_unique<FramedDuplexConnection>(
       std::move(testConnection), inlineExecutor());
 
   auto inputSubscription = std::make_shared<MockSubscription>();
@@ -202,15 +202,15 @@ TEST(ConnectionAutomatonTest, CleanTerminateRequest) {
 }
 
 TEST(ConnectionAutomatonTest, RefuseFrame) {
-  auto automatonConnection = folly::make_unique<InlineConnection>();
-  auto testConnection = folly::make_unique<InlineConnection>();
+  auto automatonConnection = std::make_unique<InlineConnection>();
+  auto testConnection = std::make_unique<InlineConnection>();
 
   automatonConnection->connectTo(*testConnection);
 
-  auto framedAutomatonConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedAutomatonConnection = std::make_unique<FramedDuplexConnection>(
       std::move(automatonConnection), inlineExecutor());
 
-  auto framedTestConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedTestConnection = std::make_unique<FramedDuplexConnection>(
       std::move(testConnection), inlineExecutor());
 
   // dump 3 frames to ConnectionAutomaton

--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -24,8 +24,8 @@ using namespace ::reactivesocket;
 class ClientSideConcurrencyTest : public testing::Test {
  public:
   ClientSideConcurrencyTest() {
-    auto clientConn = folly::make_unique<InlineConnection>();
-    auto serverConn = folly::make_unique<InlineConnection>();
+    auto clientConn = std::make_unique<InlineConnection>();
+    auto serverConn = std::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
     thread2.getEventBase()->runImmediatelyOrRunInEventBaseThreadAndWait([&] {
@@ -34,13 +34,13 @@ class ClientSideConcurrencyTest : public testing::Test {
           std::move(clientConn),
           // No interactions on this mock, the client will not accept any
           // requests.
-          folly::make_unique<StrictMock<MockRequestHandler>>(),
+          std::make_unique<StrictMock<MockRequestHandler>>(),
           ConnectionSetupPayload("", "", Payload()),
           Stats::noop(),
           nullptr);
     });
 
-    auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+    auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -250,8 +250,8 @@ TEST_F(ClientSideConcurrencyTest, RequestChannelTest) {
 class ServerSideConcurrencyTest : public testing::Test {
  public:
   ServerSideConcurrencyTest() {
-    auto clientConn = folly::make_unique<InlineConnection>();
-    auto serverConn = folly::make_unique<InlineConnection>();
+    auto clientConn = std::make_unique<InlineConnection>();
+    auto serverConn = std::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
     clientSock = StandardReactiveSocket::fromClientConnection(
@@ -259,10 +259,10 @@ class ServerSideConcurrencyTest : public testing::Test {
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
         // requests.
-        folly::make_unique<StrictMock<MockRequestHandler>>(),
+        std::make_unique<StrictMock<MockRequestHandler>>(),
         ConnectionSetupPayload("", "", Payload()));
 
-    auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+    auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -469,12 +469,12 @@ TEST_F(ServerSideConcurrencyTest, RequestChannelTest) {
 class InitialRequestNDeliveredTest : public testing::Test {
  public:
   InitialRequestNDeliveredTest() {
-    auto serverSocketConnection = folly::make_unique<InlineConnection>();
-    auto testInlineConnection = folly::make_unique<InlineConnection>();
+    auto serverSocketConnection = std::make_unique<InlineConnection>();
+    auto testInlineConnection = std::make_unique<InlineConnection>();
 
     serverSocketConnection->connectTo(*testInlineConnection);
 
-    testConnection = folly::make_unique<FramedDuplexConnection>(
+    testConnection = std::make_unique<FramedDuplexConnection>(
         std::move(testInlineConnection), inlineExecutor());
 
     testInputSubscription = std::make_shared<MockSubscription>();
@@ -501,7 +501,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
           serverSocket.reset();
         }));
 
-    auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+    auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -546,7 +546,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
 
     serverSocket = StandardReactiveSocket::fromServerConnection(
         eventBase_,
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(serverSocketConnection), inlineExecutor()),
         std::move(serverHandler),
         Stats::noop(),

--- a/test/ReactiveSocketResumabilityTest.cpp
+++ b/test/ReactiveSocketResumabilityTest.cpp
@@ -13,8 +13,8 @@ using namespace ::testing;
 using namespace ::reactivesocket;
 
 TEST(ReactiveSocketResumabilityTest, Disconnect) {
-  auto socketConnection = folly::make_unique<InlineConnection>();
-  auto testConnection = folly::make_unique<InlineConnection>();
+  auto socketConnection = std::make_unique<InlineConnection>();
+  auto testConnection = std::make_unique<InlineConnection>();
 
   socketConnection->connectTo(*testConnection);
 
@@ -36,7 +36,7 @@ TEST(ReactiveSocketResumabilityTest, Disconnect) {
   auto socket = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(socketConnection),
-      folly::make_unique<DefaultRequestHandler>(),
+      std::make_unique<DefaultRequestHandler>(),
       ConnectionSetupPayload(),
       stats);
 

--- a/test/ReactiveSocketTest.cpp
+++ b/test/ReactiveSocketTest.cpp
@@ -38,8 +38,8 @@ TEST(ReactiveSocketTest, RequestChannel) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -53,10 +53,10 @@ TEST(ReactiveSocketTest, RequestChannel) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -159,8 +159,8 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
   // mock calls will be deterministic
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -172,10 +172,10 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -248,8 +248,8 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
   // mock calls will be deterministic
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -261,10 +261,10 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -334,8 +334,8 @@ TEST(ReactiveSocketTest, RequestSubscription) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -347,10 +347,10 @@ TEST(ReactiveSocketTest, RequestSubscription) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -478,8 +478,8 @@ TEST(ReactiveSocketTest, RequestSubscriptionSurplusResponse) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -491,10 +491,10 @@ TEST(ReactiveSocketTest, RequestSubscriptionSurplusResponse) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -610,8 +610,8 @@ TEST(ReactiveSocketTest, RequestResponse) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientInput = std::make_shared<StrictMock<MockSubscriber<Payload>>>();
@@ -623,9 +623,9 @@ TEST(ReactiveSocketTest, RequestResponse) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>());
+      std::make_unique<StrictMock<MockRequestHandler>>());
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -742,8 +742,8 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   StrictMock<MockSubscriber<Payload>> clientInput;
@@ -752,10 +752,10 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -781,8 +781,8 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   StrictMock<MockSubscriber<Payload>> clientInput;
@@ -791,10 +791,10 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -818,8 +818,8 @@ TEST(ReactiveSocketTest, SetupData) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   StrictMock<MockSubscriber<Payload>> clientInput;
@@ -828,11 +828,11 @@ TEST(ReactiveSocketTest, SetupData) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload(
           "text/plain", "text/plain", Payload("meta", "data")));
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -848,18 +848,18 @@ TEST(ReactiveSocketTest, SetupWithKeepaliveAndStats) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   StrictMock<MockSubscriber<Payload>> clientInput;
   NiceMock<MockStats> clientStats;
   std::unique_ptr<MockKeepaliveTimer> clientKeepalive =
-      folly::make_unique<MockKeepaliveTimer>();
+      std::make_unique<MockKeepaliveTimer>();
 
   EXPECT_CALL(*clientKeepalive, start(_)).InSequence(s);
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -872,7 +872,7 @@ TEST(ReactiveSocketTest, SetupWithKeepaliveAndStats) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload(
           "text/plain", "text/plain", Payload("meta", "data")),
       clientStats,
@@ -887,8 +887,8 @@ TEST(ReactiveSocketTest, Destructor) {
   // mock calls will be deterministic.
   Sequence s;
 
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   // TODO: since we don't assert anything, should we just use the StatsPrinter
@@ -916,11 +916,11 @@ TEST(ReactiveSocketTest, Destructor) {
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()),
       clientStats);
 
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -991,19 +991,19 @@ TEST(ReactiveSocketTest, Destructor) {
 }
 
 TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
-  auto clientConn = folly::make_unique<InlineConnection>();
-  auto serverConn = folly::make_unique<InlineConnection>();
+  auto clientConn = std::make_unique<InlineConnection>();
+  auto serverConn = std::make_unique<InlineConnection>();
   clientConn->connectTo(*serverConn);
 
   auto clientSock = StandardReactiveSocket::fromClientConnection(
       defaultExecutor(),
       std::move(clientConn),
       // No interactions on this mock, the client will not accept any requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload()));
 
   // we don't expect any call other than setup payload
-  auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+  auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
   auto& serverHandlerRef = *serverHandler;
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
@@ -1016,8 +1016,8 @@ TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
 class ReactiveSocketIgnoreRequestTest : public testing::Test {
  public:
   ReactiveSocketIgnoreRequestTest() {
-    auto clientConn = folly::make_unique<InlineConnection>();
-    auto serverConn = folly::make_unique<InlineConnection>();
+    auto clientConn = std::make_unique<InlineConnection>();
+    auto serverConn = std::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
     clientSock = StandardReactiveSocket::fromClientConnection(
@@ -1025,13 +1025,13 @@ class ReactiveSocketIgnoreRequestTest : public testing::Test {
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
         // requests.
-        folly::make_unique<StrictMock<MockRequestHandler>>(),
+        std::make_unique<StrictMock<MockRequestHandler>>(),
         ConnectionSetupPayload("", "", Payload()));
 
     serverSock = StandardReactiveSocket::fromServerConnection(
         defaultExecutor(),
         std::move(serverConn),
-        folly::make_unique<DefaultRequestHandler>());
+        std::make_unique<DefaultRequestHandler>());
 
     // Client request.
     EXPECT_CALL(*clientInput, onSubscribe_(_))
@@ -1097,8 +1097,8 @@ TEST_F(ReactiveSocketIgnoreRequestTest, IgnoreRequestChannel) {
 class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
  public:
   ReactiveSocketOnErrorOnShutdownTest() {
-    auto clientConn = folly::make_unique<InlineConnection>();
-    auto serverConn = folly::make_unique<InlineConnection>();
+    auto clientConn = std::make_unique<InlineConnection>();
+    auto serverConn = std::make_unique<InlineConnection>();
     clientConn->connectTo(*serverConn);
 
     clientSock = StandardReactiveSocket::fromClientConnection(
@@ -1106,10 +1106,10 @@ class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
         std::move(clientConn),
         // No interactions on this mock, the client will not accept any
         // requests.
-        folly::make_unique<StrictMock<MockRequestHandler>>(),
+        std::make_unique<StrictMock<MockRequestHandler>>(),
         ConnectionSetupPayload("", "", Payload()));
 
-    auto serverHandler = folly::make_unique<StrictMock<MockRequestHandler>>();
+    auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
     EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))

--- a/test/framed/FramedReaderTest.cpp
+++ b/test/framed/FramedReaderTest.cpp
@@ -173,12 +173,12 @@ TEST(FramedReaderTest, Read1FrameIncomplete) {
 }
 
 TEST(FramedReaderTest, InvalidDataStream) {
-  auto rsConnection = folly::make_unique<InlineConnection>();
-  auto testConnection = folly::make_unique<InlineConnection>();
+  auto rsConnection = std::make_unique<InlineConnection>();
+  auto testConnection = std::make_unique<InlineConnection>();
 
   rsConnection->connectTo(*testConnection);
 
-  auto framedRsAutomatonConnection = folly::make_unique<FramedDuplexConnection>(
+  auto framedRsAutomatonConnection = std::make_unique<FramedDuplexConnection>(
       std::move(rsConnection), inlineExecutor());
 
   // Dump 1 invalid frame and expect an error
@@ -220,6 +220,6 @@ TEST(FramedReaderTest, InvalidDataStream) {
       std::move(framedRsAutomatonConnection),
       // No interactions on this mock, the client will not accept any
       // requests.
-      folly::make_unique<StrictMock<MockRequestHandler>>(),
+      std::make_unique<StrictMock<MockRequestHandler>>(),
       ConnectionSetupPayload("", "", Payload("test client payload")));
 }

--- a/test/resume/TcpResumeClient.cpp
+++ b/test/resume/TcpResumeClient.cpp
@@ -101,19 +101,19 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "attempting connection to " << addr.describe();
 
     std::unique_ptr<DuplexConnection> connection =
-        folly::make_unique<TcpDuplexConnection>(
+        std::make_unique<TcpDuplexConnection>(
             std::move(socket), inlineExecutor(), stats);
     std::unique_ptr<DuplexConnection> framedConnection =
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(connection), *eventBaseThread.getEventBase());
     std::unique_ptr<RequestHandler> requestHandler =
-        folly::make_unique<ClientRequestHandler>();
+        std::make_unique<ClientRequestHandler>();
 
     reactiveSocket = StandardReactiveSocket::disconnectedClient(
         *eventBaseThread.getEventBase(),
         std::move(requestHandler),
         stats,
-        folly::make_unique<FollyKeepaliveTimer>(
+        std::make_unique<FollyKeepaliveTimer>(
             *eventBaseThread.getEventBase(), std::chrono::seconds(10)));
 
     reactiveSocket->onConnected([](ReactiveSocket& socket) {
@@ -159,17 +159,17 @@ int main(int argc, char* argv[]) {
     socketResume->connect(&callback, addr);
 
     std::unique_ptr<DuplexConnection> connectionResume =
-        folly::make_unique<TcpDuplexConnection>(
+        std::make_unique<TcpDuplexConnection>(
             std::move(socketResume), inlineExecutor(), stats);
     std::unique_ptr<DuplexConnection> framedConnectionResume =
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(connectionResume), inlineExecutor());
 
     LOG(INFO) << "try resume ...";
     reactiveSocket->tryClientResume(
         token,
         std::make_shared<FrameTransport>(std::move(framedConnectionResume)),
-        folly::make_unique<ResumeCallback>());
+        std::make_unique<ResumeCallback>());
   });
 
   std::getline(std::cin, input);

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -193,13 +193,13 @@ class Callback : public AsyncServerSocket::AcceptCallback {
         folly::AsyncSocket::UniquePtr(new AsyncSocket(&eventBase_, fd));
 
     std::unique_ptr<DuplexConnection> connection =
-        folly::make_unique<TcpDuplexConnection>(
+        std::make_unique<TcpDuplexConnection>(
             std::move(socket), inlineExecutor(), stats_);
     std::unique_ptr<DuplexConnection> framedConnection =
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(connection), eventBase_);
     std::unique_ptr<RequestHandler> requestHandler =
-        folly::make_unique<ServerRequestHandler>(streamState_);
+        std::make_unique<ServerRequestHandler>(streamState_);
 
     std::unique_ptr<StandardReactiveSocket> rs =
         StandardReactiveSocket::disconnectedServer(

--- a/test/tcp/TcpClient.cpp
+++ b/test/tcp/TcpClient.cpp
@@ -137,13 +137,13 @@ int main(int argc, char* argv[]) {
                   << std::endl;
 
         std::unique_ptr<DuplexConnection> connection =
-            folly::make_unique<TcpDuplexConnection>(
+            std::make_unique<TcpDuplexConnection>(
                 std::move(socket), inlineExecutor(), stats);
         std::unique_ptr<DuplexConnection> framedConnection =
-            folly::make_unique<FramedDuplexConnection>(
+            std::make_unique<FramedDuplexConnection>(
                 std::move(connection), inlineExecutor());
         std::unique_ptr<RequestHandler> requestHandler =
-            folly::make_unique<ClientRequestHandler>();
+            std::make_unique<ClientRequestHandler>();
 
         reactiveSocket = StandardReactiveSocket::fromClientConnection(
             *eventBaseThread.getEventBase(),
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
             ConnectionSetupPayload(
                 "text/plain", "text/plain", Payload("meta", "data")),
             stats,
-            folly::make_unique<FollyKeepaliveTimer>(
+            std::make_unique<FollyKeepaliveTimer>(
                 *eventBaseThread.getEventBase(),
                 std::chrono::milliseconds(5000)));
 

--- a/test/tcp/TcpServer.cpp
+++ b/test/tcp/TcpServer.cpp
@@ -111,13 +111,13 @@ class Callback : public AsyncServerSocket::AcceptCallback {
         folly::AsyncSocket::UniquePtr(new AsyncSocket(&eventBase_, fd));
 
     std::unique_ptr<DuplexConnection> connection =
-        folly::make_unique<TcpDuplexConnection>(
+        std::make_unique<TcpDuplexConnection>(
             std::move(socket), inlineExecutor(), stats_);
     std::unique_ptr<DuplexConnection> framedConnection =
-        folly::make_unique<FramedDuplexConnection>(
+        std::make_unique<FramedDuplexConnection>(
             std::move(connection), inlineExecutor());
     std::unique_ptr<RequestHandler> requestHandler =
-        folly::make_unique<ServerRequestHandler>();
+        std::make_unique<ServerRequestHandler>();
 
     auto rs = StandardReactiveSocket::fromServerConnection(
         eventBase_,


### PR DESCRIPTION
Folly will soon be dropping support for GCC 4.8, which means that `folly::make_unique` will be going away, so codemod away as much as possible before then.