### PR TITLE
Make resumption token truly optional for SETUP

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -430,7 +430,11 @@ std::unique_ptr<folly::IOBuf> Frame_SETUP::serializeOut() {
   appender.writeBE(static_cast<uint32_t>(version_));
   appender.writeBE(static_cast<uint32_t>(keepaliveTime_));
   appender.writeBE(static_cast<uint32_t>(maxLifetime_));
-  appender.push((const uint8_t*)token_.data().data(), token_.data().size());
+
+  // TODO: Remove hack: https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243
+  if (header_.flags_ & FrameFlags_RESUME_ENABLE) {
+    appender.push((const uint8_t*)token_.data().data(), token_.data().size());
+  }
 
   CHECK(metadataMimeType_.length() <= std::numeric_limits<uint8_t>::max());
   appender.writeBE(static_cast<uint8_t>(metadataMimeType_.length()));
@@ -452,9 +456,15 @@ bool Frame_SETUP::deserializeFrom(std::unique_ptr<folly::IOBuf> in) {
     version_ = cur.readBE<uint32_t>();
     keepaliveTime_ = cur.readBE<uint32_t>();
     maxLifetime_ = cur.readBE<uint32_t>();
-    ResumeIdentificationToken::Data data;
-    cur.pull(data.data(), data.size());
-    token_.set(std::move(data));
+
+    // TODO: Remove hack: https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243
+    if (header_.flags_ & FrameFlags_RESUME_ENABLE) {
+      ResumeIdentificationToken::Data data;
+      cur.pull(data.data(), data.size());
+      token_.set(std::move(data));
+    } else {
+      token_ = ResumeIdentificationToken();
+    }
 
     int mdmtLen = cur.readBE<uint8_t>();
     metadataMimeType_ = cur.readFixedString(mdmtLen);

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -368,7 +368,7 @@ void StandardReactiveSocket::clientConnect(
   // TODO set correct version
   Frame_SETUP frame(
       FrameFlags_EMPTY,
-      0,
+      setupPayload.resumable ? FrameFlags_RESUME_ENABLE : 0,
       connection_->getKeepaliveTime(),
       std::numeric_limits<uint32_t>::max(),
       // TODO: resumability,

--- a/test/FrameTest.cpp
+++ b/test/FrameTest.cpp
@@ -159,6 +159,37 @@ TEST(FrameTest, Frame_SETUP) {
   EXPECT_EQ(version, frame.version_);
   EXPECT_EQ(keepaliveTime, frame.keepaliveTime_);
   EXPECT_EQ(maxLifetime, frame.maxLifetime_);
+  // Token should be default constructed
+  EXPECT_EQ(ResumeIdentificationToken(), frame.token_);
+  EXPECT_EQ("md", frame.metadataMimeType_);
+  EXPECT_EQ("d", frame.dataMimeType_);
+  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.payload_.data));
+}
+
+TEST(FrameTest, Frame_SETUP_resume) {
+  FrameFlags flags = FrameFlags_EMPTY | FrameFlags_RESUME_ENABLE;
+  uint32_t version = 0;
+  uint32_t keepaliveTime = std::numeric_limits<uint32_t>::max();
+  uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
+  ResumeIdentificationToken::Data tokenData;
+  tokenData.fill(1);
+  ResumeIdentificationToken token;
+  token.set(std::move(tokenData));
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize<Frame_SETUP>(
+      flags,
+      version,
+      keepaliveTime,
+      maxLifetime,
+      token,
+      "md",
+      "d",
+      Payload(data->clone()));
+
+  expectHeader(FrameType::SETUP, flags, 0, frame);
+  EXPECT_EQ(version, frame.version_);
+  EXPECT_EQ(keepaliveTime, frame.keepaliveTime_);
+  EXPECT_EQ(maxLifetime, frame.maxLifetime_);
   EXPECT_EQ(token, frame.token_);
   EXPECT_EQ("md", frame.metadataMimeType_);
   EXPECT_EQ("d", frame.dataMimeType_);

--- a/test/SubscriberBaseTest.cpp
+++ b/test/SubscriberBaseTest.cpp
@@ -111,8 +111,8 @@ TEST(SubscriberBaseTest, CancelStopsOnNext) {
   EXPECT_CALL(*subscriber, onNextImpl_(_))
       .WillOnce(Invoke([&](int) {}))
       .WillOnce(Invoke([&](int) {
-        done = true;
         outSubscription->cancel();
+        done = true;
       }));
   EXPECT_CALL(*subscriber, onCompleteImpl_()).Times(0);
   EXPECT_CALL(*subscriber, onErrorImpl_(_)).Times(0);


### PR DESCRIPTION
Makes the SETUP frame not send/expect the resumption token if the RESUME_ENABLE flag isn't set.

This makes it possible for us to talk to Java for the time being. This isn't complying with any specific version of the spec, but makes us support the current version here together with the Java impl of 0.1 .