### PR TITLE
Swap odd/even for server/client streams to be spec compliant

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -86,7 +86,10 @@ cpp_library(
         '@/folly:exception_wrapper',
         '@/lithium/reactivesocket-utils:reactivesocket-external-utils',
     ],
-    compiler_flags=['-DREACTIVE_SOCKET_EXTERNAL_STACK_TRACE_UTILS'],
+    compiler_flags=[
+        '-DREACTIVE_SOCKET_EXTERNAL_STACK_TRACE_UTILS',
+        '-DDONT_VERIFY_STREAM_IDS=1',
+    ],
 )
 
 cpp_library(

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -62,7 +62,7 @@ StandardReactiveSocket::StandardReactiveSocket(
           executeListenersFunc(onConnectListeners_),
           executeListenersFunc(onDisconnectListeners_),
           executeListenersFunc(onCloseListeners_))),
-      nextStreamId_(isServer ? 1 : 2),
+      nextStreamId_(!isServer ? 1 : 2),
       executor_(executor) {
   debugCheckCorrectExecutor();
   stats.socketCreated();
@@ -213,6 +213,8 @@ void StandardReactiveSocket::createResponder(
   debugCheckCorrectExecutor();
 
   if (streamId != 0) {
+// TODO: Remove this: https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243
+#ifndef DONT_VERIFY_STREAM_IDS
     if (nextStreamId_ % 2 == streamId % 2) {
       // if this is an unknown stream to the socket and this socket is
       // generating
@@ -220,6 +222,7 @@ void StandardReactiveSocket::createResponder(
       // exist
       return;
     }
+#endif
     if (streamId <= lastPeerStreamId_) {
       // receiving frame for a stream which no longer exists
       return;

--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -579,7 +579,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
   std::unique_ptr<DuplexConnection> testConnection;
   std::shared_ptr<MockSubscription> validatingSubscription;
 
-  const size_t kStreamId{2};
+  const size_t kStreamId{1};
   const size_t kRequestN{500};
 
   std::atomic<bool> done{false};


### PR DESCRIPTION
This makes C++ compliant with both the spec and the Java version. As long as only one side initiates requests this doesn't break old clients.

Depends on https://github.com/ReactiveSocket/reactivesocket-cpp/pull/241