### PR TITLE
Make KEEPALIVE respect if resume is enabled

### DIFF
--- a/src/ConnectionAutomaton.h
+++ b/src/ConnectionAutomaton.h
@@ -171,6 +171,19 @@ class ConnectionAutomaton
     }
   }
 
+  template <typename TFrame>
+  bool deserializeFrameOrError(
+      bool resumable,
+      TFrame& frame,
+      std::unique_ptr<folly::IOBuf> payload) {
+    if (frame.deserializeFrom(resumable, std::move(payload))) {
+      return true;
+    } else {
+      closeWithError(Frame_ERROR::unexpectedFrame());
+      return false;
+    }
+  }
+
   bool resumeFromPositionOrClose(ResumePosition position);
 
   uint32_t getKeepaliveTime() const;
@@ -224,6 +237,7 @@ class ConnectionAutomaton
   Stats& stats_;
   bool isServer_;
   bool isResumable_{false};
+  bool remoteResumeable_{false};
 
   std::function<void()> onConnected_;
   std::function<void()> onDisconnected_;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -402,8 +402,8 @@ class Frame_KEEPALIVE {
     assert(!(flags & FrameFlags_METADATA));
   }
 
-  std::unique_ptr<folly::IOBuf> serializeOut();
-  bool deserializeFrom(std::unique_ptr<folly::IOBuf> in);
+  std::unique_ptr<folly::IOBuf> serializeOut(bool resumable);
+  bool deserializeFrom(bool resumable, std::unique_ptr<folly::IOBuf> in);
 
   FrameHeader header_;
   ResumePosition position_;

--- a/test/FrameTest.cpp
+++ b/test/FrameTest.cpp
@@ -13,6 +13,14 @@ using namespace ::reactivesocket;
 // TODO(stupaq): tests with malformed frames
 
 template <typename Frame, typename... Args>
+Frame reserialize_resume(bool resumable, Args... args) {
+  Frame frame;
+  EXPECT_TRUE(
+      frame.deserializeFrom(resumable, Frame(std::forward<Args>(args)...).serializeOut(resumable)));
+  return frame;
+}
+
+template <typename Frame, typename... Args>
 Frame reserialize(Args... args) {
   Frame frame;
   EXPECT_TRUE(
@@ -122,16 +130,30 @@ TEST(FrameTest, Frame_ERROR) {
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.payload_.data));
 }
 
+TEST(FrameTest, Frame_KEEPALIVE_resume) {
+  uint32_t streamId = 0;
+  ResumePosition position = 101;
+  auto flags = FrameFlags_KEEPALIVE_RESPOND;
+  auto data = folly::IOBuf::copyBuffer("424242");
+  auto frame = reserialize_resume<Frame_KEEPALIVE>(true, flags, position, data->clone());
+
+  expectHeader(
+      FrameType::KEEPALIVE, FrameFlags_KEEPALIVE_RESPOND, streamId, frame);
+  EXPECT_EQ(position, frame.position_);
+  EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
+}
+
 TEST(FrameTest, Frame_KEEPALIVE) {
   uint32_t streamId = 0;
   ResumePosition position = 101;
   auto flags = FrameFlags_KEEPALIVE_RESPOND;
   auto data = folly::IOBuf::copyBuffer("424242");
-  auto frame = reserialize<Frame_KEEPALIVE>(flags, position, data->clone());
+  auto frame = reserialize_resume<Frame_KEEPALIVE>(false, flags, position, data->clone());
 
   expectHeader(
       FrameType::KEEPALIVE, FrameFlags_KEEPALIVE_RESPOND, streamId, frame);
-  EXPECT_EQ(position, frame.position_);
+  // Default position
+  EXPECT_EQ(0, frame.position_);
   EXPECT_TRUE(folly::IOBufEqual()(*data, *frame.data_));
 }
 


### PR DESCRIPTION
This means we can sent keepalive to Java and properly handle the frames it sends back.

Depends on https://github.com/ReactiveSocket/reactivesocket-cpp/pull/242