### PR TITLE
noexcept for callback methods

### DIFF
--- a/src/ClientResumeStatusCallback.h
+++ b/src/ClientResumeStatusCallback.h
@@ -11,17 +11,17 @@ class ClientResumeStatusCallback {
   virtual ~ClientResumeStatusCallback() = default;
 
   // Called when a RESUME_OK frame is received during resuming operation
-  virtual void onResumeOk() = 0;
+  virtual void onResumeOk() noexcept = 0;
 
   // Called when an ERROR frame with CONNECTION_ERROR is received during
   // resuming operation
   // TODO: in this case we should get the DuplexConnection back to
   // create a new instance of RS with it
-  virtual void onResumeError(folly::exception_wrapper ex) = 0;
+  virtual void onResumeError(folly::exception_wrapper ex) noexcept = 0;
 
   // Called when the resume operation was interrupted due to network
   // the application code may try to resume again.
-  virtual void onConnectionError(folly::exception_wrapper ex) = 0;
+  virtual void onConnectionError(folly::exception_wrapper ex) noexcept = 0;
 };
 
 } // reactivesocket

--- a/src/Common.h
+++ b/src/Common.h
@@ -18,7 +18,7 @@ namespace reactivesocket {
 
 class ReactiveSocket;
 
-using ReactiveSocketCallback = std::function<void(ReactiveSocket&)>;
+using ReactiveSocketCallback = std::function<void(ReactiveSocket&) noexcept>;
 using StreamId = uint32_t;
 using ResumePosition = int64_t;
 

--- a/src/FrameTransport.cpp
+++ b/src/FrameTransport.cpp
@@ -75,14 +75,15 @@ void FrameTransport::close(folly::exception_wrapper ex) {
   connectionInputSub_.cancel();
 }
 
-void FrameTransport::onSubscribe(std::shared_ptr<Subscription> subscription) {
+void FrameTransport::onSubscribe(
+    std::shared_ptr<Subscription> subscription) noexcept {
   CHECK(!connectionInputSub_);
   CHECK(frameProcessor_);
   connectionInputSub_.reset(std::move(subscription));
   connectionInputSub_.request(std::numeric_limits<size_t>::max());
 }
 
-void FrameTransport::onNext(std::unique_ptr<folly::IOBuf> frame) {
+void FrameTransport::onNext(std::unique_ptr<folly::IOBuf> frame) noexcept {
   if (connection_) {
     CHECK(frameProcessor_); // if *this is not closed and is pulling frames, it
     // should have frameProcessor
@@ -100,19 +101,19 @@ void FrameTransport::terminateFrameProcessor(
   }
 }
 
-void FrameTransport::onComplete() {
+void FrameTransport::onComplete() noexcept {
   VLOG(6) << "onComplete";
   terminateFrameProcessor(
       folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
 }
 
-void FrameTransport::onError(folly::exception_wrapper ex) {
+void FrameTransport::onError(folly::exception_wrapper ex) noexcept {
   VLOG(6) << "onError" << ex.what();
   terminateFrameProcessor(
       std::move(ex), StreamCompletionSignal::CONNECTION_ERROR);
 }
 
-void FrameTransport::request(size_t n) {
+void FrameTransport::request(size_t n) noexcept {
   if (!connection_) {
     // request(n) can be delivered during disconnecting
     // we don't care for it anymore
@@ -127,7 +128,7 @@ void FrameTransport::request(size_t n) {
   drainOutputFramesQueue();
 }
 
-void FrameTransport::cancel() {
+void FrameTransport::cancel() noexcept {
   VLOG(6) << "cancel";
   terminateFrameProcessor(
       folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);

--- a/src/FrameTransport.h
+++ b/src/FrameTransport.h
@@ -47,13 +47,13 @@ class FrameTransport :
  private:
   void connect();
 
-  void onSubscribe(std::shared_ptr<Subscription>) override;
-  void onNext(std::unique_ptr<folly::IOBuf>) override;
-  void onComplete() override;
-  void onError(folly::exception_wrapper) override;
+  void onSubscribe(std::shared_ptr<Subscription>) noexcept override;
+  void onNext(std::unique_ptr<folly::IOBuf>) noexcept override;
+  void onComplete() noexcept override;
+  void onError(folly::exception_wrapper) noexcept override;
 
-  void request(size_t) override;
-  void cancel() override;
+  void request(size_t) noexcept override;
+  void cancel() noexcept override;
 
   void drainOutputFramesQueue();
 

--- a/src/NullRequestHandler.cpp
+++ b/src/NullRequestHandler.cpp
@@ -7,24 +7,25 @@
 
 namespace reactivesocket {
 
-void NullSubscriber::onSubscribe(std::shared_ptr<Subscription> subscription) {
+void NullSubscriber::onSubscribe(
+    std::shared_ptr<Subscription> subscription) noexcept {
   subscription->cancel();
 }
 
-void NullSubscriber::onNext(Payload /*element*/) {}
+void NullSubscriber::onNext(Payload /*element*/) noexcept {}
 
-void NullSubscriber::onComplete() {}
+void NullSubscriber::onComplete() noexcept {}
 
-void NullSubscriber::onError(folly::exception_wrapper /*ex*/) {}
+void NullSubscriber::onError(folly::exception_wrapper /*ex*/) noexcept {}
 
-void NullSubscription::request(size_t /*n*/){};
+void NullSubscription::request(size_t /*n*/) noexcept {};
 
-void NullSubscription::cancel() {}
+void NullSubscription::cancel() noexcept {}
 
 std::shared_ptr<Subscriber<Payload>> NullRequestHandler::handleRequestChannel(
     Payload /*request*/,
     StreamId /*streamId*/,
-    const std::shared_ptr<Subscriber<Payload>>& response) {
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
   // TODO(lehecka): get rid of onSubscribe call
   response->onSubscribe(std::make_shared<NullSubscription>());
   response->onError(std::runtime_error("NullRequestHandler"));
@@ -34,7 +35,7 @@ std::shared_ptr<Subscriber<Payload>> NullRequestHandler::handleRequestChannel(
 void NullRequestHandler::handleRequestStream(
     Payload /*request*/,
     StreamId /*streamId*/,
-    const std::shared_ptr<Subscriber<Payload>>& response) {
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
   // TODO(lehecka): get rid of onSubscribe call
   response->onSubscribe(std::make_shared<NullSubscription>());
   response->onError(std::runtime_error("NullRequestHandler"));
@@ -43,7 +44,7 @@ void NullRequestHandler::handleRequestStream(
 void NullRequestHandler::handleRequestSubscription(
     Payload /*request*/,
     StreamId /*streamId*/,
-    const std::shared_ptr<Subscriber<Payload>>& response) {
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
   // TODO(lehecka): get rid of onSubscribe call
   response->onSubscribe(std::make_shared<NullSubscription>());
   response->onError(std::runtime_error("NullRequestHandler"));
@@ -52,28 +53,28 @@ void NullRequestHandler::handleRequestSubscription(
 void NullRequestHandler::handleRequestResponse(
     Payload /*request*/,
     StreamId /*streamId*/,
-    const std::shared_ptr<Subscriber<Payload>>& response) {
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
   response->onSubscribe(std::make_shared<NullSubscription>());
   response->onError(std::runtime_error("NullRequestHandler"));
 }
 
 void NullRequestHandler::handleFireAndForgetRequest(
     Payload /*request*/,
-    StreamId /*streamId*/) {}
+    StreamId /*streamId*/) noexcept {}
 
 void NullRequestHandler::handleMetadataPush(
-    std::unique_ptr<folly::IOBuf> /*request*/) {}
+    std::unique_ptr<folly::IOBuf> /*request*/) noexcept {}
 
 std::shared_ptr<StreamState> NullRequestHandler::handleSetupPayload(
     ReactiveSocket& socket,
-    ConnectionSetupPayload /*request*/) {
+    ConnectionSetupPayload /*request*/) noexcept {
   return std::make_shared<StreamState>(Stats::noop());
 }
 
 bool NullRequestHandler::handleResume(
     ReactiveSocket& socket,
     const ResumeIdentificationToken& /*token*/,
-    ResumePosition /*position*/) {
+    ResumePosition /*position*/) noexcept {
   return false;
 }
 

--- a/src/NullRequestHandler.h
+++ b/src/NullRequestHandler.h
@@ -10,17 +10,18 @@ namespace reactivesocket {
 class NullSubscriber : public Subscriber<Payload> {
  public:
   // Subscriber methods
-  void onSubscribe(std::shared_ptr<Subscription> subscription) override;
-  void onNext(Payload element) override;
-  void onComplete() override;
-  void onError(folly::exception_wrapper ex) override;
+  void onSubscribe(
+      std::shared_ptr<Subscription> subscription) noexcept override;
+  void onNext(Payload element) noexcept override;
+  void onComplete() noexcept override;
+  void onError(folly::exception_wrapper ex) noexcept override;
 };
 
 class NullSubscription : public Subscription {
  public:
   // Subscription methods
-  void request(size_t n) override;
-  void cancel() override;
+  void request(size_t n) noexcept override;
+  void cancel() noexcept override;
 };
 
 class NullRequestHandler : public RequestHandler {
@@ -28,35 +29,38 @@ class NullRequestHandler : public RequestHandler {
   std::shared_ptr<Subscriber<Payload>> handleRequestChannel(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
 
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
 
   void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
 
   void handleRequestResponse(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
 
-  void handleFireAndForgetRequest(Payload request, StreamId streamId) override;
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override;
 
-  void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override;
+  void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept override;
 
   std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket& socket,
-      ConnectionSetupPayload request) override;
+      ConnectionSetupPayload request) noexcept override;
 
   bool handleResume(
       ReactiveSocket& socket,
       const ResumeIdentificationToken& token,
-      ResumePosition position) override;
+      ResumePosition position) noexcept override;
 
   void handleCleanResume(
       std::shared_ptr<Subscription> response) noexcept override;

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -20,46 +20,47 @@ class RequestHandler {
   virtual std::shared_ptr<Subscriber<Payload>> handleRequestChannel(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) = 0;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept = 0;
 
   /// Handles a new Stream requested by the other end.
   virtual void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) = 0;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept = 0;
 
   /// Handles a new inbound Subscription requested by the other end.
   virtual void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) = 0;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept = 0;
 
   /// Handles a new inbound RequestResponse requested by the other end.
   virtual void handleRequestResponse(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) = 0;
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept = 0;
 
   /// Handles a new fire-and-forget request sent by the other end.
   virtual void handleFireAndForgetRequest(
       Payload request,
-      StreamId streamId) = 0;
+      StreamId streamId) noexcept = 0;
 
   /// Handles a new metadata-push sent by the other end.
-  virtual void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) = 0;
+  virtual void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept = 0;
 
   /// Temporary home - this should eventually be an input to asking for a
   /// RequestHandler so negotiation is possible
   virtual std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket& socket,
-      ConnectionSetupPayload request) = 0;
+      ConnectionSetupPayload request) noexcept = 0;
 
   /// Temporary home - this should accompany handleSetupPayload
   /// Return stream state for the given token. Return nullptr to disable resume
   virtual bool handleResume(
       ReactiveSocket& socket,
       const ResumeIdentificationToken& token,
-      ResumePosition position) = 0;
+      ResumePosition position) noexcept = 0;
 
   // Handle a stream that can resume in a "clean" state. Client and Server are
   // up-to-date.

--- a/src/SubscriptionBase.h
+++ b/src/SubscriptionBase.h
@@ -11,8 +11,8 @@ namespace reactivesocket {
 class SubscriptionBase : public Subscription,
                          public EnableSharedFromThisBase<SubscriptionBase>,
                          public virtual ExecutorBase {
-  virtual void requestImpl(size_t n) = 0;
-  virtual void cancelImpl() = 0;
+  virtual void requestImpl(size_t n) noexcept = 0;
+  virtual void cancelImpl() noexcept = 0;
 
  public:
   using ExecutorBase::ExecutorBase;
@@ -22,7 +22,7 @@ class SubscriptionBase : public Subscription,
   explicit SubscriptionBase(folly::Executor& executor = defaultExecutor())
       : ExecutorBase(executor) {}
 
-  void request(size_t n) override final {
+  void request(size_t n) noexcept override final {
     auto thisPtr = this->shared_from_this();
     runInExecutor([thisPtr, n]() {
       VLOG(1) << (ExecutorBase*)thisPtr.get() << " request";
@@ -30,7 +30,7 @@ class SubscriptionBase : public Subscription,
     });
   }
 
-  void cancel() override final {
+  void cancel() noexcept override final {
     auto thisPtr = this->shared_from_this();
     runInExecutor([thisPtr]() {
       VLOG(1) << (ExecutorBase*)thisPtr.get() << " cancel";

--- a/src/automata/ChannelRequester.cpp
+++ b/src/automata/ChannelRequester.cpp
@@ -5,14 +5,14 @@
 namespace reactivesocket {
 
 void ChannelRequester::onSubscribeImpl(
-    std::shared_ptr<Subscription> subscription) {
+    std::shared_ptr<Subscription> subscription) noexcept {
   CHECK(State::NEW == state_);
   Base::onSubscribe(subscription);
   // Request the first payload immediately.
   subscription->request(1);
 }
 
-void ChannelRequester::onNextImpl(Payload request) {
+void ChannelRequester::onNextImpl(Payload request) noexcept {
   switch (state_) {
     case State::NEW: {
       state_ = State::REQUESTED;
@@ -49,7 +49,7 @@ void ChannelRequester::onNextImpl(Payload request) {
 }
 
 // TODO: consolidate code in onCompleteImpl, onErrorImpl, cancelImpl
-void ChannelRequester::onCompleteImpl() {
+void ChannelRequester::onCompleteImpl() noexcept {
   switch (state_) {
     case State::NEW:
       state_ = State::CLOSED;
@@ -67,7 +67,7 @@ void ChannelRequester::onCompleteImpl() {
   }
 }
 
-void ChannelRequester::onErrorImpl(folly::exception_wrapper ex) {
+void ChannelRequester::onErrorImpl(folly::exception_wrapper ex) noexcept {
   switch (state_) {
     case State::NEW:
       state_ = State::CLOSED;
@@ -83,7 +83,7 @@ void ChannelRequester::onErrorImpl(folly::exception_wrapper ex) {
   }
 }
 
-void ChannelRequester::requestImpl(size_t n) {
+void ChannelRequester::requestImpl(size_t n) noexcept {
   switch (state_) {
     case State::NEW:
       // The initial request has not been sent out yet, hence we must accumulate
@@ -100,7 +100,7 @@ void ChannelRequester::requestImpl(size_t n) {
   }
 }
 
-void ChannelRequester::cancelImpl() {
+void ChannelRequester::cancelImpl() noexcept {
   switch (state_) {
     case State::NEW:
       state_ = State::CLOSED;

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -33,15 +33,15 @@ class ChannelRequester : public PublisherMixin<
 
  private:
   /// @{
-  void onSubscribeImpl(std::shared_ptr<Subscription>) override;
-  void onNextImpl(Payload) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper) override;
+  void onSubscribeImpl(std::shared_ptr<Subscription>) noexcept override;
+  void onNextImpl(Payload) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper) noexcept override;
   /// @}
 
   // implementation from ConsumerMixin::SubscriptionBase
-  void requestImpl(size_t) override;
-  void cancelImpl() override;
+  void requestImpl(size_t) noexcept override;
+  void cancelImpl() noexcept override;
 
   using Base::onNextFrame;
   void onNextFrame(Frame_RESPONSE&&) override;

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -5,11 +5,11 @@
 namespace reactivesocket {
 
 void ChannelResponder::onSubscribeImpl(
-    std::shared_ptr<Subscription> subscription) {
+    std::shared_ptr<Subscription> subscription) noexcept {
   Base::onSubscribe(subscription);
 }
 
-void ChannelResponder::onNextImpl(Payload response) {
+void ChannelResponder::onNextImpl(Payload response) noexcept {
   switch (state_) {
     case State::RESPONDING:
       Base::onNext(std::move(response));
@@ -19,7 +19,7 @@ void ChannelResponder::onNextImpl(Payload response) {
   }
 }
 
-void ChannelResponder::onCompleteImpl() {
+void ChannelResponder::onCompleteImpl() noexcept {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
@@ -32,7 +32,7 @@ void ChannelResponder::onCompleteImpl() {
   }
 }
 
-void ChannelResponder::onErrorImpl(folly::exception_wrapper ex) {
+void ChannelResponder::onErrorImpl(folly::exception_wrapper ex) noexcept {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
@@ -46,7 +46,7 @@ void ChannelResponder::onErrorImpl(folly::exception_wrapper ex) {
   }
 }
 
-void ChannelResponder::requestImpl(size_t n) {
+void ChannelResponder::requestImpl(size_t n) noexcept {
   switch (state_) {
     case State::RESPONDING:
       Base::generateRequest(n);
@@ -55,7 +55,7 @@ void ChannelResponder::requestImpl(size_t n) {
   }
 }
 
-void ChannelResponder::cancelImpl() {
+void ChannelResponder::cancelImpl() noexcept {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -29,14 +29,14 @@ class ChannelResponder : public PublisherMixin<
   std::ostream& logPrefix(std::ostream& os);
 
  private:
-  void onSubscribeImpl(std::shared_ptr<Subscription>) override;
-  void onNextImpl(Payload) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper) override;
+  void onSubscribeImpl(std::shared_ptr<Subscription>) noexcept override;
+  void onNextImpl(Payload) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper) noexcept override;
 
   // implementation from ConsumerMixin::SubscriptionBase
-  void requestImpl(size_t n) override;
-  void cancelImpl() override;
+  void requestImpl(size_t n) noexcept override;
+  void cancelImpl() noexcept override;
 
   using Base::onNextFrame;
   void onNextFrame(Frame_REQUEST_CHANNEL&&) override;

--- a/src/automata/RequestResponseRequester.cpp
+++ b/src/automata/RequestResponseRequester.cpp
@@ -35,7 +35,7 @@ void RequestResponseRequester::processInitialPayload(Payload request) {
   }
 }
 
-void RequestResponseRequester::requestImpl(size_t n) {
+void RequestResponseRequester::requestImpl(size_t n) noexcept {
   if (n == 0) {
     return;
   }
@@ -49,7 +49,7 @@ void RequestResponseRequester::requestImpl(size_t n) {
   }
 }
 
-void RequestResponseRequester::cancelImpl() {
+void RequestResponseRequester::cancelImpl() noexcept {
   switch (state_) {
     case State::NEW:
       state_ = State::CLOSED;

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -35,8 +35,8 @@ class RequestResponseRequester : public StreamAutomatonBase,
   std::ostream& logPrefix(std::ostream& os);
 
  private:
-  void requestImpl(size_t) override;
-  void cancelImpl() override;
+  void requestImpl(size_t) noexcept override;
+  void cancelImpl() noexcept override;
 
   using Base::onNextFrame;
   void onNextFrame(Frame_RESPONSE&&) override;

--- a/src/automata/RequestResponseResponder.cpp
+++ b/src/automata/RequestResponseResponder.cpp
@@ -5,11 +5,11 @@
 namespace reactivesocket {
 
 void RequestResponseResponder::onSubscribeImpl(
-    std::shared_ptr<Subscription> subscription) {
+    std::shared_ptr<Subscription> subscription) noexcept {
   Base::onSubscribe(subscription);
 }
 
-void RequestResponseResponder::onNextImpl(Payload response) {
+void RequestResponseResponder::onNextImpl(Payload response) noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING: {
@@ -23,7 +23,7 @@ void RequestResponseResponder::onNextImpl(Payload response) {
   }
 }
 
-void RequestResponseResponder::onCompleteImpl() {
+void RequestResponseResponder::onCompleteImpl() noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING: {
@@ -37,7 +37,8 @@ void RequestResponseResponder::onCompleteImpl() {
   }
 }
 
-void RequestResponseResponder::onErrorImpl(folly::exception_wrapper ex) {
+void RequestResponseResponder::onErrorImpl(
+    folly::exception_wrapper ex) noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING: {

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -36,10 +36,10 @@ class RequestResponseResponder
 
  private:
   /// @{
-  void onSubscribeImpl(std::shared_ptr<Subscription>) override;
-  void onNextImpl(Payload) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper) override;
+  void onSubscribeImpl(std::shared_ptr<Subscription>) noexcept override;
+  void onNextImpl(Payload) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper) noexcept override;
   /// @}
 
   using Base::onNextFrame;

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -36,7 +36,7 @@ void StreamSubscriptionRequesterBase::processInitialPayload(Payload request) {
   }
 }
 
-void StreamSubscriptionRequesterBase::requestImpl(size_t n) {
+void StreamSubscriptionRequesterBase::requestImpl(size_t n) noexcept {
   switch (state_) {
     case State::NEW:
       // The initial request has not been sent out yet, hence we must accumulate
@@ -53,7 +53,7 @@ void StreamSubscriptionRequesterBase::requestImpl(size_t n) {
   }
 }
 
-void StreamSubscriptionRequesterBase::cancelImpl() {
+void StreamSubscriptionRequesterBase::cancelImpl() noexcept {
   switch (state_) {
     case State::NEW:
       state_ = State::CLOSED;

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -25,8 +25,8 @@ class StreamSubscriptionRequesterBase : public ConsumerMixin<Frame_RESPONSE> {
   virtual void sendRequestFrame(FrameFlags, size_t, Payload&&) = 0;
 
   // implementation from ConsumerMixin::SubscriptionBase
-  void requestImpl(size_t) override;
-  void cancelImpl() override;
+  void requestImpl(size_t) noexcept override;
+  void cancelImpl() noexcept override;
 
   using Base::onNextFrame;
   void onNextFrame(Frame_RESPONSE&&) override;

--- a/src/automata/StreamSubscriptionResponderBase.cpp
+++ b/src/automata/StreamSubscriptionResponderBase.cpp
@@ -5,11 +5,11 @@
 namespace reactivesocket {
 
 void StreamSubscriptionResponderBase::onSubscribeImpl(
-    std::shared_ptr<Subscription> subscription) {
+    std::shared_ptr<Subscription> subscription) noexcept {
   Base::onSubscribe(subscription);
 }
 
-void StreamSubscriptionResponderBase::onNextImpl(Payload response) {
+void StreamSubscriptionResponderBase::onNextImpl(Payload response) noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING:
@@ -20,7 +20,7 @@ void StreamSubscriptionResponderBase::onNextImpl(Payload response) {
   }
 }
 
-void StreamSubscriptionResponderBase::onCompleteImpl() {
+void StreamSubscriptionResponderBase::onCompleteImpl() noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING: {
@@ -34,7 +34,8 @@ void StreamSubscriptionResponderBase::onCompleteImpl() {
   }
 }
 
-void StreamSubscriptionResponderBase::onErrorImpl(folly::exception_wrapper ex) {
+void StreamSubscriptionResponderBase::onErrorImpl(
+    folly::exception_wrapper ex) noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
     case State::RESPONDING: {

--- a/src/automata/StreamSubscriptionResponderBase.h
+++ b/src/automata/StreamSubscriptionResponderBase.h
@@ -36,10 +36,10 @@ class StreamSubscriptionResponderBase
   void onNextFrame(Frame_CANCEL&&) override;
 
  private:
-  void onSubscribeImpl(std::shared_ptr<Subscription>) override;
-  void onNextImpl(Payload) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper) override;
+  void onSubscribeImpl(std::shared_ptr<Subscription>) noexcept override;
+  void onNextImpl(Payload) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper) noexcept override;
 
   void endStream(StreamCompletionSignal) override;
 

--- a/src/automata/SubscriptionResponder.cpp
+++ b/src/automata/SubscriptionResponder.cpp
@@ -5,7 +5,7 @@
 
 namespace reactivesocket {
 
-void SubscriptionResponder::onCompleteImpl() {
+void SubscriptionResponder::onCompleteImpl() noexcept {
   LOG(FATAL) << "onComplete is not allowed on Subscription iteraction.";
 }
 

--- a/src/automata/SubscriptionResponder.h
+++ b/src/automata/SubscriptionResponder.h
@@ -20,7 +20,7 @@ class SubscriptionResponder : public StreamSubscriptionResponderBase {
   std::ostream& logPrefix(std::ostream& os);
 
  private:
-  void onCompleteImpl() override;
+  void onCompleteImpl() noexcept override;
 };
 
 } // reactivesocket

--- a/src/framed/FramedReader.cpp
+++ b/src/framed/FramedReader.cpp
@@ -5,13 +5,14 @@
 
 namespace reactivesocket {
 
-void FramedReader::onSubscribeImpl(std::shared_ptr<Subscription> subscription) {
+void FramedReader::onSubscribeImpl(
+    std::shared_ptr<Subscription> subscription) noexcept {
   CHECK(!streamSubscription_);
   streamSubscription_.reset(std::move(subscription));
   frames_.onSubscribe(shared_from_this());
 }
 
-void FramedReader::onNextImpl(std::unique_ptr<folly::IOBuf> payload) {
+void FramedReader::onNextImpl(std::unique_ptr<folly::IOBuf> payload) noexcept {
   streamRequested_ = false;
 
   if (payload) {
@@ -57,19 +58,19 @@ void FramedReader::parseFrames() {
   dispatchingFrames_ = false;
 }
 
-void FramedReader::onCompleteImpl() {
+void FramedReader::onCompleteImpl() noexcept {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   frames_.onComplete();
   streamSubscription_.cancel();
 }
 
-void FramedReader::onErrorImpl(folly::exception_wrapper ex) {
+void FramedReader::onErrorImpl(folly::exception_wrapper ex) noexcept {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   frames_.onError(std::move(ex));
   streamSubscription_.cancel();
 }
 
-void FramedReader::requestImpl(size_t n) {
+void FramedReader::requestImpl(size_t n) noexcept {
   allowance_.release(n);
   parseFrames();
   requestStream();
@@ -82,7 +83,7 @@ void FramedReader::requestStream() {
   }
 }
 
-void FramedReader::cancelImpl() {
+void FramedReader::cancelImpl() noexcept {
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   streamSubscription_.cancel();
   frames_.onComplete();

--- a/src/framed/FramedReader.h
+++ b/src/framed/FramedReader.h
@@ -25,14 +25,15 @@ class FramedReader : public SubscriberBaseT<std::unique_ptr<folly::IOBuf>>,
 
  private:
   // Subscriber methods
-  void onSubscribeImpl(std::shared_ptr<Subscription> subscription) override;
-  void onNextImpl(std::unique_ptr<folly::IOBuf> element) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper ex) override;
+  void onSubscribeImpl(
+      std::shared_ptr<Subscription> subscription) noexcept override;
+  void onNextImpl(std::unique_ptr<folly::IOBuf> element) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper ex) noexcept override;
 
   // Subscription methods
-  void requestImpl(size_t n) override;
-  void cancelImpl() override;
+  void requestImpl(size_t n) noexcept override;
+  void cancelImpl() noexcept override;
 
   void parseFrames();
   void requestStream();

--- a/src/framed/FramedWriter.cpp
+++ b/src/framed/FramedWriter.cpp
@@ -5,7 +5,8 @@
 
 namespace reactivesocket {
 
-void FramedWriter::onSubscribeImpl(std::shared_ptr<Subscription> subscription) {
+void FramedWriter::onSubscribeImpl(
+    std::shared_ptr<Subscription> subscription) noexcept {
   CHECK(!writerSubscription_);
   writerSubscription_.reset(std::move(subscription));
   stream_.onSubscribe(shared_from_this());
@@ -36,7 +37,7 @@ static std::unique_ptr<folly::IOBuf> appendSize(
   }
 }
 
-void FramedWriter::onNextImpl(std::unique_ptr<folly::IOBuf> payload) {
+void FramedWriter::onNextImpl(std::unique_ptr<folly::IOBuf> payload) noexcept {
   auto sizedPayload = appendSize(std::move(payload));
   if (!sizedPayload) {
     VLOG(1) << "payload too big";
@@ -62,17 +63,17 @@ void FramedWriter::onNextMultiple(
   stream_.onNext(payloadQueue.move());
 }
 
-void FramedWriter::onCompleteImpl() {
+void FramedWriter::onCompleteImpl() noexcept {
   stream_.onComplete();
   writerSubscription_.cancel();
 }
 
-void FramedWriter::onErrorImpl(folly::exception_wrapper ex) {
+void FramedWriter::onErrorImpl(folly::exception_wrapper ex) noexcept {
   stream_.onError(std::move(ex));
   writerSubscription_.cancel();
 }
 
-void FramedWriter::requestImpl(size_t n) {
+void FramedWriter::requestImpl(size_t n) noexcept {
   // it is possible to receive requestImpl after on{Complete,Error}
   // because it is a different interface and can be hooked up somewhere else
   if (writerSubscription_) {
@@ -80,7 +81,7 @@ void FramedWriter::requestImpl(size_t n) {
   }
 }
 
-void FramedWriter::cancelImpl() {
+void FramedWriter::cancelImpl() noexcept {
   writerSubscription_.cancel();
   stream_.onComplete();
 }

--- a/src/framed/FramedWriter.h
+++ b/src/framed/FramedWriter.h
@@ -28,15 +28,15 @@ class FramedWriter : public SubscriberBaseT<std::unique_ptr<folly::IOBuf>>,
 
  private:
   // Subscriber methods
-  void onSubscribeImpl(
-      std::shared_ptr<reactivesocket::Subscription> subscription) override;
-  void onNextImpl(std::unique_ptr<folly::IOBuf> element) override;
-  void onCompleteImpl() override;
-  void onErrorImpl(folly::exception_wrapper ex) override;
+  void onSubscribeImpl(std::shared_ptr<reactivesocket::Subscription>
+                           subscription) noexcept override;
+  void onNextImpl(std::unique_ptr<folly::IOBuf> element) noexcept override;
+  void onCompleteImpl() noexcept override;
+  void onErrorImpl(folly::exception_wrapper ex) noexcept override;
 
   // Subscription methods
-  void requestImpl(size_t n) override;
-  void cancelImpl() override;
+  void requestImpl(size_t n) noexcept override;
+  void cancelImpl() noexcept override;
 
   using EnableSharedFromThisBase<FramedWriter>::shared_from_this;
 

--- a/src/tcp/TcpDuplexConnection.cpp
+++ b/src/tcp/TcpDuplexConnection.cpp
@@ -36,28 +36,29 @@ class TcpReaderWriter : public ::folly::AsyncTransportWrapper::WriteCallback,
   }
 
  private:
-  void onSubscribeImpl(std::shared_ptr<Subscription> subscription) override {
+  void onSubscribeImpl(
+      std::shared_ptr<Subscription> subscription) noexcept override {
     // no flow control at tcp level, since we can't know the size of messages
     subscription->request(std::numeric_limits<size_t>::max());
   }
 
-  void onNextImpl(std::unique_ptr<folly::IOBuf> element) override {
+  void onNextImpl(std::unique_ptr<folly::IOBuf> element) noexcept override {
     send(std::move(element));
   }
 
-  void onCompleteImpl() override {
+  void onCompleteImpl() noexcept override {
     closeFromWriter();
   }
 
-  void onErrorImpl(folly::exception_wrapper ex) override {
+  void onErrorImpl(folly::exception_wrapper ex) noexcept override {
     closeFromWriter();
   }
 
-  void requestImpl(size_t n) override {
+  void requestImpl(size_t n) noexcept override {
     // ignored for now, currently flow control is only at higher layers
   }
 
-  void cancelImpl() override {
+  void cancelImpl() noexcept override {
     closeFromReader();
   }
 

--- a/tck-test/TestSubscriber.cpp
+++ b/tck-test/TestSubscriber.cpp
@@ -120,7 +120,8 @@ void TestSubscriber::assertTerminated() {
   }
 }
 
-void TestSubscriber::onSubscribe(std::shared_ptr<Subscription> subscription) {
+void TestSubscriber::onSubscribe(
+    std::shared_ptr<Subscription> subscription) noexcept {
   subscription_.reset(std::move(subscription));
 
   //  actual.onSubscribe(s);
@@ -139,7 +140,7 @@ void TestSubscriber::onSubscribe(std::shared_ptr<Subscription> subscription) {
   //  }
 }
 
-void TestSubscriber::onNext(Payload element) {
+void TestSubscriber::onNext(Payload element) noexcept {
   LOG(INFO) << "ON NEXT: " << element;
 
   //  if (isEcho) {
@@ -168,7 +169,7 @@ void TestSubscriber::onNext(Payload element) {
   //  actual.onNext(new PayloadImpl(tup.getK(), tup.getV()));
 }
 
-void TestSubscriber::onComplete() {
+void TestSubscriber::onComplete() noexcept {
   LOG(INFO) << "onComplete";
   //  isComplete = true;
   //  if (!checkSubscriptionOnce) {
@@ -195,7 +196,7 @@ void TestSubscriber::onComplete() {
   terminatedCV_.notify_one();
 }
 
-void TestSubscriber::onError(folly::exception_wrapper ex) {
+void TestSubscriber::onError(folly::exception_wrapper ex) noexcept {
   LOG(INFO) << "onError";
   //  if (!checkSubscriptionOnce) {
   //    checkSubscriptionOnce = true;

--- a/tck-test/TestSubscriber.h
+++ b/tck-test/TestSubscriber.h
@@ -34,10 +34,11 @@ class TestSubscriber : public reactivesocket::Subscriber<Payload> {
   void assertCanceled();
 
  protected:
-  void onSubscribe(std::shared_ptr<Subscription> subscription) override;
-  void onNext(Payload element) override;
-  void onComplete() override;
-  void onError(folly::exception_wrapper ex) override;
+  void onSubscribe(
+      std::shared_ptr<Subscription> subscription) noexcept override;
+  void onNext(Payload element) noexcept override;
+  void onComplete() noexcept override;
+  void onError(folly::exception_wrapper ex) noexcept override;
 
  private:
   void assertTerminated();

--- a/test/MockRequestHandler.h
+++ b/test/MockRequestHandler.h
@@ -58,49 +58,52 @@ class MockRequestHandler : public RequestHandler {
   std::shared_ptr<Subscriber<Payload>> handleRequestChannel(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     return handleRequestChannel_(request, streamId, response);
   }
 
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     handleRequestStream_(request, streamId, response);
   }
 
   void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     handleRequestSubscription_(request, streamId, response);
   }
 
   void handleRequestResponse(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     handleRequestResponse_(request, streamId, response);
   }
 
-  void handleFireAndForgetRequest(Payload request, StreamId streamId) override {
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override {
     handleFireAndForgetRequest_(request, streamId);
   }
 
-  void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override {
+  void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept override {
     handleMetadataPush_(request);
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket& socket,
-      ConnectionSetupPayload request) override {
+      ConnectionSetupPayload request) noexcept override {
     return handleSetupPayload_(socket, request);
   }
 
   bool handleResume(
       ReactiveSocket& socket,
       const ResumeIdentificationToken& token,
-      ResumePosition position) override {
+      ResumePosition position) noexcept override {
     return handleResume_(socket, token, position);
   }
 

--- a/test/SubscriberBaseTest.cpp
+++ b/test/SubscriberBaseTest.cpp
@@ -23,19 +23,19 @@ class SubscriberBaseMock : public SubscriberBaseT<int> {
 
  private:
   void onSubscribeImpl(
-      std::shared_ptr<Subscription> subscription) override final {
+      std::shared_ptr<Subscription> subscription) noexcept override final {
     onSubscribeImpl_(subscription);
   }
 
-  void onNextImpl(int value) override final {
+  void onNextImpl(int value) noexcept override final {
     onNextImpl_(value);
   }
 
-  void onCompleteImpl() override final {
+  void onCompleteImpl() noexcept override final {
     onCompleteImpl_();
   }
 
-  void onErrorImpl(folly::exception_wrapper ex) override final {
+  void onErrorImpl(folly::exception_wrapper ex) noexcept override final {
     onErrorImpl_(std::move(ex));
   }
 };

--- a/test/resume/TcpResumeClient.cpp
+++ b/test/resume/TcpResumeClient.cpp
@@ -34,19 +34,19 @@ class Callback : public AsyncSocket::ConnectCallback {
 };
 
 class ResumeCallback : public ClientResumeStatusCallback {
-  void onResumeOk() override {
+  void onResumeOk() noexcept override {
     LOG(INFO) << "resumeOk";
   }
 
   // Called when an ERROR frame with CONNECTION_ERROR is received during
   // resuming operation
-  void onResumeError(folly::exception_wrapper ex) override {
+  void onResumeError(folly::exception_wrapper ex) noexcept override {
     LOG(INFO) << "resumeError: " << ex.what();
   }
 
   // Called when the resume operation was interrupted due to network
   // the application code may try to resume again.
-  void onConnectionError(folly::exception_wrapper ex) override {
+  void onConnectionError(folly::exception_wrapper ex) noexcept override {
     LOG(INFO) << "connectionError: " << ex.what();
   }
 };

--- a/test/resume/TcpResumeServer.cpp
+++ b/test/resume/TcpResumeServer.cpp
@@ -35,7 +35,7 @@ class ServerSubscription : public SubscriptionBase {
   }
 
   // Subscription methods
-  void requestImpl(size_t n) override {
+  void requestImpl(size_t n) noexcept override {
     LOG(INFO) << "request " << this;
     response_.onNext(Payload("from server"));
     response_.onNext(Payload("from server2"));
@@ -44,7 +44,7 @@ class ServerSubscription : public SubscriptionBase {
     //    response_.onError(std::runtime_error("XXX"));
   }
 
-  void cancelImpl() override {
+  void cancelImpl() noexcept override {
     LOG(INFO) << "cancel " << this;
   }
 
@@ -61,7 +61,7 @@ class ServerRequestHandler : public DefaultRequestHandler {
   void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestSubscription " << request;
     response->onSubscribe(std::make_shared<ServerSubscription>(response));
   }
@@ -70,25 +70,28 @@ class ServerRequestHandler : public DefaultRequestHandler {
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestStream " << request;
 
     response->onSubscribe(std::make_shared<ServerSubscription>(response));
   }
 
-  void handleFireAndForgetRequest(Payload request, StreamId streamId) override {
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleFireAndForgetRequest " << request
               << "\n";
   }
 
-  void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override {
+  void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleMetadataPush "
               << request->moveToFbString() << "\n";
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket& socket,
-      ConnectionSetupPayload request) override {
+      ConnectionSetupPayload request) noexcept override {
     std::stringstream str;
 
     str << "ServerRequestHandler.handleSetupPayload " << request
@@ -108,7 +111,7 @@ class ServerRequestHandler : public DefaultRequestHandler {
   bool handleResume(
       ReactiveSocket& socket,
       const ResumeIdentificationToken& token,
-      ResumePosition position) override {
+      ResumePosition position) noexcept override {
     std::stringstream str;
 
     str << "ServerRequestHandler.handleResume resume token <";

--- a/test/simple/PrintSubscriber.cpp
+++ b/test/simple/PrintSubscriber.cpp
@@ -11,20 +11,21 @@ PrintSubscriber::~PrintSubscriber() {
   LOG(INFO) << "~PrintSubscriber " << this;
 }
 
-void PrintSubscriber::onSubscribe(std::shared_ptr<Subscription> subscription) {
+void PrintSubscriber::onSubscribe(
+    std::shared_ptr<Subscription> subscription) noexcept {
   LOG(INFO) << "PrintSubscriber " << this << " onSubscribe";
   subscription->request(std::numeric_limits<int32_t>::max());
 }
 
-void PrintSubscriber::onNext(Payload element) {
+void PrintSubscriber::onNext(Payload element) noexcept {
   LOG(INFO) << "PrintSubscriber " << this << " onNext " << element;
 }
 
-void PrintSubscriber::onComplete() {
+void PrintSubscriber::onComplete() noexcept {
   LOG(INFO) << "PrintSubscriber " << this << " onComplete";
 }
 
-void PrintSubscriber::onError(folly::exception_wrapper ex) {
+void PrintSubscriber::onError(folly::exception_wrapper ex) noexcept {
   LOG(INFO) << "PrintSubscriber " << this << " onError " << ex.what();
 }
 }

--- a/test/simple/PrintSubscriber.h
+++ b/test/simple/PrintSubscriber.h
@@ -11,12 +11,10 @@ class PrintSubscriber : public Subscriber<Payload> {
  public:
   ~PrintSubscriber();
 
-  void onSubscribe(std::shared_ptr<Subscription> subscription) override;
-
-  void onNext(Payload element) override;
-
-  void onComplete() override;
-
-  void onError(folly::exception_wrapper ex) override;
+  void onSubscribe(
+      std::shared_ptr<Subscription> subscription) noexcept override;
+  void onNext(Payload element) noexcept override;
+  void onComplete() noexcept override;
+  void onError(folly::exception_wrapper ex) noexcept override;
 };
 }

--- a/test/streams/Mocks.h
+++ b/test/streams/Mocks.h
@@ -28,7 +28,8 @@ class MockPublisher : public Publisher<T, E> {
       subscribe_,
       void(std::shared_ptr<Subscriber<T, E>> subscriber));
 
-  void subscribe(std::shared_ptr<Subscriber<T, E>> subscriber) override {
+  void subscribe(
+      std::shared_ptr<Subscriber<T, E>> subscriber) noexcept override {
     subscribe_(std::move(subscriber));
   }
 };
@@ -55,11 +56,11 @@ class MockSubscriber : public Subscriber<T, E> {
       VLOG(2) << "dtor SubscriptionShim " << this;
     }
 
-    void request(size_t n) override final {
+    void request(size_t n) noexcept override final {
       originalSubscription_->request(n);
     }
 
-    void cancel() override final {
+    void cancel() noexcept override final {
       checkpoint_->Call();
       originalSubscription_->cancel();
     }
@@ -82,7 +83,8 @@ class MockSubscriber : public Subscriber<T, E> {
   MOCK_METHOD0(onComplete_, void());
   MOCK_METHOD1_T(onError_, void(E ex));
 
-  void onSubscribe(std::shared_ptr<Subscription> subscription) override {
+  void onSubscribe(
+      std::shared_ptr<Subscription> subscription) noexcept override {
     subscription_ = std::make_shared<SubscriptionShim>(
         std::move(subscription), checkpoint_);
     // We allow registering the same subscriber with multiple Publishers.
@@ -90,17 +92,17 @@ class MockSubscriber : public Subscriber<T, E> {
     onSubscribe_(subscription_);
   }
 
-  void onNext(T element) override {
+  void onNext(T element) noexcept override {
     onNext_(element);
   }
 
-  void onComplete() override {
+  void onComplete() noexcept override {
     checkpoint_->Call();
     onComplete_();
     subscription_ = nullptr;
   }
 
-  void onError(E ex) override {
+  void onError(E ex) noexcept override {
     checkpoint_->Call();
     onError_(ex);
     subscription_ = nullptr;
@@ -130,11 +132,11 @@ class MockSubscription : public Subscription {
   MOCK_METHOD1(request_, void(size_t n));
   MOCK_METHOD0(cancel_, void());
 
-  void request(size_t n) override {
+  void request(size_t n) noexcept override {
     request_(n);
   }
 
-  void cancel() override {
+  void cancel() noexcept override {
     cancel_();
   }
 };

--- a/test/tcp/TcpClient.cpp
+++ b/test/tcp/TcpClient.cpp
@@ -44,7 +44,7 @@ class ClientSubscription : public SubscriptionBase {
 
  private:
   // Subscription methods
-  void requestImpl(size_t n) override {
+  void requestImpl(size_t n) noexcept override {
     for (size_t i = 0; i < numElems_; i++) {
       response_.onNext(Payload("from server " + std::to_string(i)));
     }
@@ -52,7 +52,7 @@ class ClientSubscription : public SubscriptionBase {
     response_.onError(std::runtime_error("XXX"));
   }
 
-  void cancelImpl() override {}
+  void cancelImpl() noexcept override {}
 
   SubscriberPtr<Subscriber<Payload>> response_;
   size_t numElems_;
@@ -65,7 +65,7 @@ class ClientRequestHandler : public DefaultRequestHandler {
   void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestSubscription " << request;
 
     response->onSubscribe(std::make_shared<ClientSubscription>(response));
@@ -75,7 +75,7 @@ class ClientRequestHandler : public DefaultRequestHandler {
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestStream " << request;
 
     response->onSubscribe(std::make_shared<ClientSubscription>(response));
@@ -84,24 +84,27 @@ class ClientRequestHandler : public DefaultRequestHandler {
   void handleRequestResponse(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestResponse " << request;
 
     response->onSubscribe(std::make_shared<ClientSubscription>(response, 1));
   }
 
-  void handleFireAndForgetRequest(Payload request, StreamId streamId) override {
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleFireAndForgetRequest " << request;
   }
 
-  void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override {
+  void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleMetadataPush "
               << request->moveToFbString();
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket&,
-      ConnectionSetupPayload request) override {
+      ConnectionSetupPayload request) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleSetupPayload " << request;
     return std::make_shared<StreamState>(Stats::noop());
   }

--- a/test/tcp/TcpServer.cpp
+++ b/test/tcp/TcpServer.cpp
@@ -30,7 +30,7 @@ class ServerSubscription : public SubscriptionBase {
 
  private:
   // Subscription methods
-  void requestImpl(size_t n) override {
+  void requestImpl(size_t n) noexcept override {
     for (size_t i = 0; i < numElems_; i++) {
       response_.onNext(Payload("from server " + std::to_string(i)));
     }
@@ -38,7 +38,7 @@ class ServerSubscription : public SubscriptionBase {
     //    response_.onError(std::runtime_error("XXX"));
   }
 
-  void cancelImpl() override {}
+  void cancelImpl() noexcept override {}
 
   SubscriberPtr<Subscriber<Payload>> response_;
   size_t numElems_;
@@ -50,7 +50,7 @@ class ServerRequestHandler : public DefaultRequestHandler {
   void handleRequestSubscription(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestSubscription " << request;
 
     response->onSubscribe(std::make_shared<ServerSubscription>(response));
@@ -60,7 +60,7 @@ class ServerRequestHandler : public DefaultRequestHandler {
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestStream " << request;
 
     response->onSubscribe(std::make_shared<ServerSubscription>(response));
@@ -69,24 +69,27 @@ class ServerRequestHandler : public DefaultRequestHandler {
   void handleRequestResponse(
       Payload request,
       StreamId streamId,
-      const std::shared_ptr<Subscriber<Payload>>& response) override {
+      const std::shared_ptr<Subscriber<Payload>>& response) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleRequestResponse " << request;
 
     response->onSubscribe(std::make_shared<ServerSubscription>(response, 1));
   }
 
-  void handleFireAndForgetRequest(Payload request, StreamId streamId) override {
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleFireAndForgetRequest " << request;
   }
 
-  void handleMetadataPush(std::unique_ptr<folly::IOBuf> request) override {
+  void handleMetadataPush(
+      std::unique_ptr<folly::IOBuf> request) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleMetadataPush "
               << request->moveToFbString();
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
       ReactiveSocket&,
-      ConnectionSetupPayload request) override {
+      ConnectionSetupPayload request) noexcept override {
     LOG(INFO) << "ServerRequestHandler.handleSetupPayload " << request;
     return std::make_shared<StreamState>(Stats::noop());
   }


### PR DESCRIPTION
both stream state machines and global (connection level) state machines are implemented such that they don't provide any exception guarantees or safety. To ensure correctness and for the following reasons we will terminate the program for an unhandled exception:
* ReactiveSocket will live on its own executor (EventBase) so exception will always bubble up to the Executor root. Unhandled exceptions will tare down the program anyways.
* Debugging is hard when we let the exceptions bubble up the stack too far.

If the application code wants to make sure the exceptions aren't going to terminate the program, it should use try {} catch(...) {} in each callback. 