### PR TITLE
Ignore unexpected frames instead of dying

### DIFF
--- a/src/automata/StreamAutomatonBase.cpp
+++ b/src/automata/StreamAutomatonBase.cpp
@@ -6,49 +6,53 @@
 
 namespace reactivesocket {
 
+namespace {
+
+template<typename T>
+void onUnexpectedFrame(const T& frame) {
+  VLOG(4) << "Unexpected frame, ignoring: " << frame;
+}
+
+}
+
 void StreamAutomatonBase::endStream(StreamCompletionSignal) {
   isTerminated_ = true;
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_STREAM&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_REQUEST_STREAM&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_SUB&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_REQUEST_SUB&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_CHANNEL&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_REQUEST_CHANNEL&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_RESPONSE&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_REQUEST_RESPONSE&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_N&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_REQUEST_N&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_CANCEL&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_CANCEL&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_RESPONSE&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_RESPONSE&& f) {
+  onUnexpectedFrame(f);
 }
 
-void StreamAutomatonBase::onNextFrame(Frame_ERROR&&) {
-  onUnexpectedFrame();
+void StreamAutomatonBase::onNextFrame(Frame_ERROR&& f) {
+  onUnexpectedFrame(f);
 }
 
 void StreamAutomatonBase::onBadFrame() {
   connection_->closeWithError(Frame_ERROR::invalid(streamId_, "bad frame"));
-}
-
-void StreamAutomatonBase::onUnexpectedFrame() {
-  DCHECK(false) << "onUnexpectedFrame";
-  connection_->closeWithError(Frame_ERROR::unexpectedFrame());
 }
 
 void StreamAutomatonBase::onUnknownFrame() {

--- a/src/automata/StreamAutomatonBase.h
+++ b/src/automata/StreamAutomatonBase.h
@@ -65,9 +65,6 @@ class StreamAutomatonBase : public AbstractStreamAutomaton {
   void onBadFrame() override;
   void onUnknownFrame() override;
 
- private:
-  void onUnexpectedFrame();
-
  protected:
   /// A partially-owning pointer to the connection, the stream runs on.
   const std::shared_ptr<ConnectionAutomaton> connection_;


### PR DESCRIPTION
Following the spec we should ignore things we don't expect/understand instead of failing hard. This commit also makes the logging better in these cases.

This is needed as reactivesocket-java in fact sends a RESPONSE(complete) after each subscription frame, see https://github.com/ReactiveSocket/reactivesocket-java/issues/226.