### PR TITLE
Add hack ifdef to assume assumption

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -86,7 +86,10 @@ cpp_library(
         '@/folly:exception_wrapper',
         '@/lithium/reactivesocket-utils:reactivesocket-external-utils',
     ],
-    compiler_flags=['-DREACTIVE_SOCKET_EXTERNAL_STACK_TRACE_UTILS'],
+    compiler_flags=[
+        '-DREACTIVE_SOCKET_EXTERNAL_STACK_TRACE_UTILS',
+        '-DHACK_ASSUME_RESUMPTION=1',
+    ],
 )
 
 cpp_library(

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -465,6 +465,12 @@ bool Frame_SETUP::deserializeFrom(std::unique_ptr<folly::IOBuf> in) {
 
     // TODO: Remove hack:
     // https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243
+#ifdef HACK_ASSUME_RESUMPTION
+    // Old clients didn't properly set the RESUME_ENABLE flag
+    if (version_ == 0) {
+      header_.flags_ |= FrameFlags_RESUME_ENABLE;
+    }
+#endif
     if (header_.flags_ & FrameFlags_RESUME_ENABLE) {
       ResumeIdentificationToken::Data data;
       cur.pull(data.data(), data.size());

--- a/src/StandardReactiveSocket.cpp
+++ b/src/StandardReactiveSocket.cpp
@@ -407,7 +407,7 @@ void StandardReactiveSocket::clientConnect(
   // TODO set correct version
   Frame_SETUP frame(
       setupPayload.resumable ? FrameFlags_RESUME_ENABLE : FrameFlags_EMPTY,
-      /*version=*/0,
+      /*version=*/1,
       connection_->getKeepaliveTime(),
       std::numeric_limits<uint32_t>::max(),
       setupPayload.token,

--- a/test/FrameTest.cpp
+++ b/test/FrameTest.cpp
@@ -137,7 +137,7 @@ TEST(FrameTest, Frame_KEEPALIVE) {
 
 TEST(FrameTest, Frame_SETUP) {
   FrameFlags flags = FrameFlags_EMPTY;
-  uint32_t version = 0;
+  uint32_t version = 1;
   uint32_t keepaliveTime = std::numeric_limits<uint32_t>::max();
   uint32_t maxLifetime = std::numeric_limits<uint32_t>::max();
   ResumeIdentificationToken::Data tokenData;

--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -555,7 +555,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
     testConnection->getOutput()->onNext(
         Frame_SETUP(
             FrameFlags_EMPTY,
-            0,
+            1,
             0,
             0,
             ResumeIdentificationToken::generateNew(),


### PR DESCRIPTION
This is needed for now to handle old clients as they incorrectly didn't set the header but assumed resumption.