### PR TITLE
Fix memory leak between ConnectionAutomaton and FollyKeepaliveTimer

### DIFF
--- a/src/folly/FollyKeepaliveTimer.cpp
+++ b/src/folly/FollyKeepaliveTimer.cpp
@@ -33,9 +33,9 @@ void FollyKeepaliveTimer::schedule() {
 
 void FollyKeepaliveTimer::sendKeepalive() {
   if (pending_) {
-    stop();
     connection_->closeWithError(
         Frame_ERROR::connectionError("no response to keepalive"));
+    stop();
   } else {
     connection_->sendKeepalive();
     pending_ = true;
@@ -46,6 +46,7 @@ void FollyKeepaliveTimer::sendKeepalive() {
 void FollyKeepaliveTimer::stop() {
   *running_ = false;
   pending_ = false;
+  connection_ = nullptr;
 }
 
 // must be called from the same thread as stop


### PR DESCRIPTION
There's a shared_ptr cycle made between ConnectionAutomaton and
FollyKeepaliveTimer on FollyKeepaliveTimer::start().  Currently, we don't break
it on FollyKeepaliveTimer::stop() so we leak both of them.

Fix it by explicitly setting FollyKeepaliveTimer::connection_ to null in
::stop(), and fix ::sendKeepalive() to call ::stop() after sending an error
frame to ::connection_.