### PR TITLE
Remove user-triggerable assert

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -415,7 +415,10 @@ bool Frame_KEEPALIVE::deserializeFrom(
   folly::io::Cursor cur(in.get());
   try {
     header_.deserializeFrom(cur);
-    assert((header_.flags_ & FrameFlags_METADATA) == 0);
+    if (header_.flags_ & FrameFlags_METADATA) {
+      return false;
+    }
+
     // TODO: Remove hack:
     // https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243
     if (resumeable) {


### PR DESCRIPTION
Keepalive frames should never have the metadata flag set.  Return an error if
they do, rather than asserting they don't.