### PR TITLE
Throw instead of asserting on invalid metadata sizes

### DIFF
--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -1,12 +1,13 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "Payload.h"
+
 #include <folly/String.h>
 #include <folly/io/Cursor.h>
 
 namespace reactivesocket {
 
-constexpr static auto kMaxMetadataLength = std::numeric_limits<int32_t>::max();
+constexpr auto kMaxMetadataLength = std::numeric_limits<int32_t>::max();
 
 Payload::Payload(
     std::unique_ptr<folly::IOBuf> _data,
@@ -14,8 +15,12 @@ Payload::Payload(
     : data(std::move(_data)), metadata(std::move(_metadata)) {}
 
 Payload::Payload(const std::string& _data, const std::string& _metadata)
-    : data(folly::IOBuf::copyBuffer(_data)),
-      metadata(folly::IOBuf::copyBuffer(_metadata)) {}
+  : data(folly::IOBuf::copyBuffer(_data)) {
+  if (!_metadata.empty()) {
+    metadata = folly::IOBuf::copyBuffer(_metadata);
+  }
+}
+
 
 void Payload::checkFlags(FrameFlags flags) const {
   assert(bool(flags & FrameFlags_METADATA) == bool(metadata));
@@ -24,15 +29,18 @@ void Payload::checkFlags(FrameFlags flags) const {
 void Payload::serializeMetadataInto(
     folly::io::QueueAppender& appender,
     std::unique_ptr<folly::IOBuf> metadata) {
-  if (metadata != nullptr) {
-    // use signed int because the first bit in metadata length is reserved
-    assert(metadata->length() + sizeof(uint32_t) < kMaxMetadataLength);
-    (void)kMaxMetadataLength;
-
-    appender.writeBE<uint32_t>(
-        static_cast<uint32_t>(metadata->length()) + sizeof(uint32_t));
-    appender.insert(std::move(metadata));
+  if (metadata == nullptr) {
+    return;
   }
+
+  // Use signed int because the first bit in metadata length is reserved.
+  if (metadata->length() >= kMaxMetadataLength - sizeof(uint32_t)) {
+    throw std::runtime_error("Metadata is too big to serialize");
+  }
+
+  appender.writeBE<uint32_t>(
+    static_cast<uint32_t>(metadata->length() + sizeof(uint32_t)));
+  appender.insert(std::move(metadata));
 }
 
 void Payload::serializeInto(folly::io::QueueAppender& appender) {
@@ -45,20 +53,28 @@ void Payload::serializeInto(folly::io::QueueAppender& appender) {
 std::unique_ptr<folly::IOBuf> Payload::deserializeMetadataFrom(
     folly::io::Cursor& cur,
     FrameFlags flags) {
-  std::unique_ptr<folly::IOBuf> metadata;
-
-  if (flags & FrameFlags_METADATA) {
-    const auto length = cur.readBE<uint32_t>();
-
-    assert(length < kMaxMetadataLength);
-    (void)kMaxMetadataLength;
-
-    const auto metadataPayloadLength = length - sizeof(uint32_t);
-
-    if (metadataPayloadLength > 0) {
-      cur.clone(metadata, metadataPayloadLength);
-    }
+  if ((flags & FrameFlags_METADATA) == 0) {
+    return nullptr;
   }
+
+  const auto length = cur.readBE<uint32_t>();
+
+  if (length >= kMaxMetadataLength) {
+    throw std::runtime_error("Metadata is too big to deserialize");
+  }
+
+  if (length <= sizeof(uint32_t)) {
+    throw std::runtime_error("Metadata is too small to encode its size");
+  }
+
+  const auto metadataPayloadLength =
+    length - static_cast<uint32_t>(sizeof(uint32_t));
+
+  // TODO: Check if metadataPayloadLength exceeds frame length minus frame
+  // header size.
+
+  std::unique_ptr<folly::IOBuf> metadata;
+  cur.clone(metadata, metadataPayloadLength);
   return metadata;
 }
 

--- a/test/PayloadTest.cpp
+++ b/test/PayloadTest.cpp
@@ -1,10 +1,20 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <gtest/gtest.h>
+
+#include <folly/io/Cursor.h>
+#include <folly/io/IOBuf.h>
+
 #include "src/Payload.h"
 
 using namespace ::testing;
 using namespace ::reactivesocket;
+
+TEST(PayloadTest, EmptyMetadata) {
+  Payload p("some error message");
+  EXPECT_NE(p.data, nullptr);
+  EXPECT_EQ(p.metadata, nullptr);
+}
 
 TEST(PayloadTest, Clear) {
   Payload p("hello");
@@ -12,4 +22,15 @@ TEST(PayloadTest, Clear) {
 
   p.clear();
   ASSERT_FALSE(p);
+}
+
+TEST(PayloadTest, GiantMetadata) {
+  constexpr auto metadataSize = std::numeric_limits<uint32_t>::max();
+
+  auto metadata = folly::IOBuf::wrapBuffer(&metadataSize, sizeof(metadataSize));
+  folly::io::Cursor cur(metadata.get());
+
+  EXPECT_THROW(
+    Payload::deserializeMetadataFrom(cur, FrameFlags_METADATA),
+    std::runtime_error);
 }


### PR DESCRIPTION
Also fix a bug in Payload's string ctor where it will always make a metadata
IOBuf, regardless if the metadata string is empty or not.