### PR TITLE
Remove ProducedFrame template param from ProducerMixin class

### DIFF
--- a/src/automata/ChannelRequester.cpp
+++ b/src/automata/ChannelRequester.cpp
@@ -43,11 +43,8 @@ void ChannelRequester::onNextImpl(Payload request) noexcept {
     case State::REQUESTED: {
       debugCheckOnNextOnCompleteOnError();
       Frame_REQUEST_CHANNEL frame(
-          ConsumerMixin<Frame_RESPONSE>::streamId_,
-          FrameFlags_EMPTY,
-          std::move(request));
-      ConsumerMixin<Frame_RESPONSE>::connection_->outputFrameOrEnqueue(
-          frame.serializeOut());
+          streamId_, FrameFlags_EMPTY, std::move(request));
+      connection_->outputFrameOrEnqueue(frame.serializeOut());
       break;
     }
     case State::CLOSED:

--- a/src/automata/ChannelRequester.cpp
+++ b/src/automata/ChannelRequester.cpp
@@ -40,9 +40,16 @@ void ChannelRequester::onNextImpl(Payload request) noexcept {
         Base::generateRequest(remainingN);
       }
     } break;
-    case State::REQUESTED:
-      Base::onNext(std::move(request));
+    case State::REQUESTED: {
+      debugCheckOnNextOnCompleteOnError();
+      Frame_REQUEST_CHANNEL frame(
+          ConsumerMixin<Frame_RESPONSE>::streamId_,
+          FrameFlags_EMPTY,
+          std::move(request));
+      ConsumerMixin<Frame_RESPONSE>::connection_->outputFrameOrEnqueue(
+          frame.serializeOut());
       break;
+    }
     case State::CLOSED:
       break;
   }

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -18,12 +18,9 @@ class exception_wrapper;
 namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a Channel requester.
-class ChannelRequester : public PublisherMixin<
-                             Frame_REQUEST_CHANNEL,
-                             ConsumerMixin<Frame_RESPONSE>>,
+class ChannelRequester : public PublisherMixin<ConsumerMixin<Frame_RESPONSE>>,
                          public SubscriberBase {
-  using Base =
-      PublisherMixin<Frame_REQUEST_CHANNEL, ConsumerMixin<Frame_RESPONSE>>;
+  using Base = PublisherMixin<ConsumerMixin<Frame_RESPONSE>>;
 
  public:
   explicit ChannelRequester(const Base::Parameters& params)

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -13,12 +13,8 @@ void ChannelResponder::onNextImpl(Payload response) noexcept {
   switch (state_) {
     case State::RESPONDING: {
       debugCheckOnNextOnCompleteOnError();
-      Frame_RESPONSE frame(
-          ConsumerMixin<Frame_REQUEST_CHANNEL>::streamId_,
-          FrameFlags_EMPTY,
-          std::move(response));
-      ConsumerMixin<Frame_REQUEST_CHANNEL>::connection_->outputFrameOrEnqueue(
-          frame.serializeOut());
+      Frame_RESPONSE frame(streamId_, FrameFlags_EMPTY, std::move(response));
+      connection_->outputFrameOrEnqueue(frame.serializeOut());
       break;
     }
     case State::CLOSED:

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -11,9 +11,16 @@ void ChannelResponder::onSubscribeImpl(
 
 void ChannelResponder::onNextImpl(Payload response) noexcept {
   switch (state_) {
-    case State::RESPONDING:
-      Base::onNext(std::move(response));
+    case State::RESPONDING: {
+      debugCheckOnNextOnCompleteOnError();
+      Frame_RESPONSE frame(
+          ConsumerMixin<Frame_REQUEST_CHANNEL>::streamId_,
+          FrameFlags_EMPTY,
+          std::move(response));
+      ConsumerMixin<Frame_REQUEST_CHANNEL>::connection_->outputFrameOrEnqueue(
+          frame.serializeOut());
       break;
+    }
     case State::CLOSED:
       break;
   }

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -13,12 +13,10 @@
 namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a Channel responder.
-class ChannelResponder : public PublisherMixin<
-                             Frame_RESPONSE,
-                             ConsumerMixin<Frame_REQUEST_CHANNEL>>,
-                         public SubscriberBase {
-  using Base =
-      PublisherMixin<Frame_RESPONSE, ConsumerMixin<Frame_REQUEST_CHANNEL>>;
+class ChannelResponder
+    : public PublisherMixin<ConsumerMixin<Frame_REQUEST_CHANNEL>>,
+      public SubscriberBase {
+  using Base = PublisherMixin<ConsumerMixin<Frame_REQUEST_CHANNEL>>;
 
  public:
   explicit ChannelResponder(

--- a/src/automata/RequestResponseResponder.cpp
+++ b/src/automata/RequestResponseResponder.cpp
@@ -14,7 +14,13 @@ void RequestResponseResponder::onNextImpl(Payload response) noexcept {
   switch (state_) {
     case State::RESPONDING: {
       state_ = State::CLOSED;
-      Base::onNext(std::move(response), FrameFlags_COMPLETE);
+      debugCheckOnNextOnCompleteOnError();
+      Frame_RESPONSE frame(
+          StreamAutomatonBase::streamId_,
+          FrameFlags_EMPTY,
+          std::move(response));
+      StreamAutomatonBase::connection_->outputFrameOrEnqueue(
+          frame.serializeOut());
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
       break;
     }

--- a/src/automata/RequestResponseResponder.cpp
+++ b/src/automata/RequestResponseResponder.cpp
@@ -16,11 +16,10 @@ void RequestResponseResponder::onNextImpl(Payload response) noexcept {
       state_ = State::CLOSED;
       debugCheckOnNextOnCompleteOnError();
       Frame_RESPONSE frame(
-          StreamAutomatonBase::streamId_,
+          streamId_,
           FrameFlags_EMPTY,
           std::move(response));
-      StreamAutomatonBase::connection_->outputFrameOrEnqueue(
-          frame.serializeOut());
+      connection_->outputFrameOrEnqueue(frame.serializeOut());
       connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);
       break;
     }

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -13,10 +13,9 @@ namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a RequestResponse
 /// responder
-class RequestResponseResponder
-    : public PublisherMixin<Frame_RESPONSE, StreamAutomatonBase>,
-      public SubscriberBase {
-  using Base = PublisherMixin<Frame_RESPONSE, StreamAutomatonBase>;
+class RequestResponseResponder : public PublisherMixin<StreamAutomatonBase>,
+                                 public SubscriberBase {
+  using Base = PublisherMixin<StreamAutomatonBase>;
 
  public:
   struct Parameters : Base::Parameters {

--- a/src/automata/StreamSubscriptionResponderBase.cpp
+++ b/src/automata/StreamSubscriptionResponderBase.cpp
@@ -14,12 +14,8 @@ void StreamSubscriptionResponderBase::onNextImpl(Payload response) noexcept {
   switch (state_) {
     case State::RESPONDING: {
       debugCheckOnNextOnCompleteOnError();
-      Frame_RESPONSE frame(
-          StreamAutomatonBase::streamId_,
-          FrameFlags_EMPTY,
-          std::move(response));
-      StreamAutomatonBase::connection_->outputFrameOrEnqueue(
-          frame.serializeOut());
+      Frame_RESPONSE frame(streamId_, FrameFlags_EMPTY, std::move(response));
+      connection_->outputFrameOrEnqueue(frame.serializeOut());
       break;
     }
     case State::CLOSED:

--- a/src/automata/StreamSubscriptionResponderBase.cpp
+++ b/src/automata/StreamSubscriptionResponderBase.cpp
@@ -12,9 +12,16 @@ void StreamSubscriptionResponderBase::onSubscribeImpl(
 void StreamSubscriptionResponderBase::onNextImpl(Payload response) noexcept {
   debugCheckOnNextOnCompleteOnError();
   switch (state_) {
-    case State::RESPONDING:
-      Base::onNext(std::move(response));
+    case State::RESPONDING: {
+      debugCheckOnNextOnCompleteOnError();
+      Frame_RESPONSE frame(
+          StreamAutomatonBase::streamId_,
+          FrameFlags_EMPTY,
+          std::move(response));
+      StreamAutomatonBase::connection_->outputFrameOrEnqueue(
+          frame.serializeOut());
       break;
+    }
     case State::CLOSED:
       break;
   }

--- a/src/automata/StreamSubscriptionResponderBase.h
+++ b/src/automata/StreamSubscriptionResponderBase.h
@@ -15,9 +15,9 @@ namespace reactivesocket {
 /// Implementation of stream automaton that represents a Stream/Subscription
 /// responder.
 class StreamSubscriptionResponderBase
-    : public PublisherMixin<Frame_RESPONSE, StreamAutomatonBase>,
+    : public PublisherMixin<StreamAutomatonBase>,
       public SubscriberBase {
-  using Base = PublisherMixin<Frame_RESPONSE, StreamAutomatonBase>;
+  using Base = PublisherMixin<StreamAutomatonBase>;
 
  public:
   struct Parameters : Base::Parameters {

--- a/src/mixins/PublisherMixin.h
+++ b/src/mixins/PublisherMixin.h
@@ -19,7 +19,7 @@ namespace reactivesocket {
 enum class StreamCompletionSignal;
 
 /// A mixin that represents a flow-control-aware producer of data.
-template <typename ProducedFrame, typename Base>
+template <typename Base>
 class PublisherMixin : public Base {
  public:
   explicit PublisherMixin(
@@ -49,11 +49,6 @@ class PublisherMixin : public Base {
     }
   }
 
-  void onNext(Payload payload, FrameFlags flags = FrameFlags_EMPTY) {
-    debugCheckOnNextOnCompleteOnError();
-    ProducedFrame frame(Base::streamId_, flags, std::move(payload));
-    Base::connection_->outputFrameOrEnqueue(frame.serializeOut());
-  }
   /// @}
 
   std::shared_ptr<Subscription> subscription() {


### PR DESCRIPTION
This is part of the effort to get rid of mixins/ProducerMixin and
mixins/ConsumerMixin classes and replacing them with regular base
classes instead.

Ran clang-format and devtools/format_all.sh for the affected files.

Tested by running all the unittests.