### PR TITLE
Remove Frame template param from ConsumerMixin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ add_library(
   src/FrameProcessor.h
   src/FrameTransport.cpp
   src/FrameTransport.h
-  src/mixins/ConsumerMixin-inl.h
+  src/mixins/ConsumerMixin.cpp
   src/mixins/ConsumerMixin.h
   src/mixins/PublisherMixin.h
   src/NullRequestHandler.cpp

--- a/src/automata/ChannelRequester.cpp
+++ b/src/automata/ChannelRequester.cpp
@@ -151,7 +151,7 @@ void ChannelRequester::onNextFrame(Frame_RESPONSE&& frame) {
       break;
   }
 
-  processPayload(std::move(frame));
+  processPayload(std::move(frame.payload_));
 
   if (end) {
     connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -18,9 +18,9 @@ class exception_wrapper;
 namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a Channel requester.
-class ChannelRequester : public PublisherMixin<ConsumerMixin<Frame_RESPONSE>>,
+class ChannelRequester : public PublisherMixin<ConsumerMixin>,
                          public SubscriberBase {
-  using Base = PublisherMixin<ConsumerMixin<Frame_RESPONSE>>;
+  using Base = PublisherMixin<ConsumerMixin>;
 
  public:
   explicit ChannelRequester(const Base::Parameters& params)

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -103,7 +103,7 @@ void ChannelResponder::onNextFrame(Frame_REQUEST_CHANNEL&& frame) {
   }
 
   processRequestN(frame.requestN_);
-  processPayload(std::move(frame));
+  processPayload(std::move(frame.payload_));
 
   if (end) {
     connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -13,10 +13,9 @@
 namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a Channel responder.
-class ChannelResponder
-    : public PublisherMixin<ConsumerMixin<Frame_REQUEST_CHANNEL>>,
-      public SubscriberBase {
-  using Base = PublisherMixin<ConsumerMixin<Frame_REQUEST_CHANNEL>>;
+class ChannelResponder : public PublisherMixin<ConsumerMixin>,
+                         public SubscriberBase {
+  using Base = PublisherMixin<ConsumerMixin>;
 
  public:
   explicit ChannelResponder(

--- a/src/automata/StreamSubscriptionRequesterBase.cpp
+++ b/src/automata/StreamSubscriptionRequesterBase.cpp
@@ -92,7 +92,7 @@ void StreamSubscriptionRequesterBase::onNextFrame(Frame_RESPONSE&& frame) {
       break;
   }
 
-  processPayload(std::move(frame));
+  processPayload(std::move(frame.payload_));
 
   if (end) {
     connection_->endStream(streamId_, StreamCompletionSignal::GRACEFUL);

--- a/src/automata/StreamSubscriptionRequesterBase.h
+++ b/src/automata/StreamSubscriptionRequesterBase.h
@@ -11,8 +11,8 @@
 namespace reactivesocket {
 
 /// Implementation of stream automaton that represents a Subscription requester.
-class StreamSubscriptionRequesterBase : public ConsumerMixin<Frame_RESPONSE> {
-  using Base = ConsumerMixin<Frame_RESPONSE>;
+class StreamSubscriptionRequesterBase : public ConsumerMixin {
+  using Base = ConsumerMixin;
 
  public:
   // initialization of the ExecutorBase will be ignored for any of the

--- a/src/mixins/ConsumerMixin.h
+++ b/src/mixins/ConsumerMixin.h
@@ -7,10 +7,12 @@
 #include <iostream>
 #include "src/AllowanceSemaphore.h"
 #include "src/Common.h"
+#include "src/ConnectionAutomaton.h"
 #include "src/NullRequestHandler.h"
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
 #include "src/SmartPointers.h"
+#include "src/SubscriptionBase.h"
 #include "src/automata/StreamAutomatonBase.h"
 
 namespace reactivesocket {
@@ -18,7 +20,6 @@ namespace reactivesocket {
 enum class StreamCompletionSignal;
 
 /// A mixin that represents a flow-control-aware consumer of data.
-template <typename Frame>
 class ConsumerMixin : public StreamAutomatonBase, public SubscriptionBase {
   using Base = StreamAutomatonBase;
 
@@ -86,7 +87,7 @@ class ConsumerMixin : public StreamAutomatonBase, public SubscriptionBase {
     }
   }
 
-  void processPayload(Frame&&);
+  void processPayload(Payload&&);
 
   void onError(folly::exception_wrapper ex);
   /// @}
@@ -115,5 +116,3 @@ class ConsumerMixin : public StreamAutomatonBase, public SubscriptionBase {
   AllowanceSemaphore pendingAllowance_;
 };
 }
-
-#include "src/mixins/ConsumerMixin-inl.h"


### PR DESCRIPTION
This is part of an effort to get rid of mixins/ConsumerMixin and
mixins/ProducerMixin and replace them with regular base classes instead.