### PR TITLE
Fix a data race in ClientSideConcurrencyTest

### DIFF
--- a/test/ReactiveSocketConcurrencyTest.cpp
+++ b/test/ReactiveSocketConcurrencyTest.cpp
@@ -24,11 +24,11 @@ using namespace ::reactivesocket;
 class ClientSideConcurrencyTest : public testing::Test {
  public:
   ClientSideConcurrencyTest() {
-    auto clientConn = std::make_unique<InlineConnection>();
     auto serverConn = std::make_unique<InlineConnection>();
-    clientConn->connectTo(*serverConn);
 
     thread2.getEventBase()->runImmediatelyOrRunInEventBaseThreadAndWait([&] {
+      auto clientConn = std::make_unique<InlineConnection>();
+      clientConn->connectTo(*serverConn);
       clientSock = StandardReactiveSocket::fromClientConnection(
           *thread2.getEventBase(),
           std::move(clientConn),


### PR DESCRIPTION
This simple fix brings down the number of Thread Sanitizer warnings from 54 to 43.

One of the warning:

```
==================
WARNING: ThreadSanitizer: data race (pid=82713)
  Read of size 8 at 0x7fff59f0f7f8 by thread T2:
    #0 ClientSideConcurrencyTest::ClientSideConcurrencyTest()::'lambda'()::operator()() const memory:2714 (tests+0x00010013088a)
    #1 _ZN5folly6detail8function14FunctionTraitsIFvvEE9callSmallIZN25ClientSideConcurrencyTestC1EvEUlvE_EEvRNS1_4DataE Function.h:289 (tests+0x000100130638)
    #2 void folly::detail::function::FunctionTraits<void ()>::callSmall<folly::EventBase::runInEventBaseThreadAndWait(folly::Function<void ()>)::$_3>(folly::detail::function::Data&) <null>:42 (libfolly.57.dylib+0x000000091d4d)

  Previous write of size 8 at 0x7fff59f0f7f8 by main thread:
    #0 ClientSideConcurrencyTest::ClientSideConcurrencyTest() memory:2232 (tests+0x00010011f24a)
    #1 ClientSideConcurrencyTest_RequestStreamTest_Test::ClientSideConcurrencyTest_RequestStreamTest_Test() ReactiveSocketConcurrencyTest.cpp:206 (tests+0x0001001418a2)
    #2 ClientSideConcurrencyTest_RequestStreamTest_Test::ClientSideConcurrencyTest_RequestStreamTest_Test() ReactiveSocketConcurrencyTest.cpp:206 (tests+0x000100141858)
    #3 testing::internal::TestFactoryImpl<ClientSideConcurrencyTest_RequestStreamTest_Test>::CreateTest() gtest-internal.h:484 (tests+0x0001001417f1)
    #4 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) <null>:81 (tests+0x000100380f69)
    #5 main Test.cpp:14 (tests+0x000100239187)

  Location is stack of main thread.

  Thread T2 (tid=715057, running) created by main thread at:
    #0 pthread_create <null>:144 (libclang_rt.tsan_osx_dynamic.dylib+0x000000024410)
    #1 std::__1::thread::thread<void (&)(folly::EventBaseManager*, folly::EventBase*), folly::EventBaseManager*&, folly::EventBase*, void>(void (&&&)(folly::EventBaseManager*, folly::EventBase*), folly::EventBaseManager*&&&, folly::EventBase*&&) <null>:42 (libfolly.57.dylib+0x00000009b387)
    #2 ClientSideConcurrencyTest_RequestStreamTest_Test::ClientSideConcurrencyTest_RequestStreamTest_Test() ReactiveSocketConcurrencyTest.cpp:206 (tests+0x0001001418a2)
    #3 ClientSideConcurrencyTest_RequestStreamTest_Test::ClientSideConcurrencyTest_RequestStreamTest_Test() ReactiveSocketConcurrencyTest.cpp:206 (tests+0x000100141858)
    #4 testing::internal::TestFactoryImpl<ClientSideConcurrencyTest_RequestStreamTest_Test>::CreateTest() gtest-internal.h:484 (tests+0x0001001417f1)
    #5 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) <null>:81 (tests+0x000100380f69)
    #6 main Test.cpp:14 (tests+0x000100239187)

SUMMARY: ThreadSanitizer: data race memory:2714 in ClientSideConcurrencyTest::ClientSideConcurrencyTest()::'lambda'()::operator()() const
==================

```