### PR TITLE
Add missing files to CMakeLists.txt that were causing test failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ add_library(
   src/automata/RequestResponseRequester.h
   src/automata/RequestResponseResponder.cpp
   src/automata/RequestResponseResponder.h
+  src/automata/StreamAutomatonBase.cpp
+  src/automata/StreamAutomatonBase.h
   src/automata/StreamRequester.cpp
   src/automata/StreamRequester.h
   src/automata/StreamResponder.h
@@ -127,6 +129,7 @@ add_library(
   src/automata/StreamSubscriptionResponderBase.h
   src/automata/SubscriptionRequester.cpp
   src/automata/SubscriptionRequester.h
+  src/automata/SubscriptionResponder.cpp
   src/automata/SubscriptionResponder.h
   src/Common.cpp
   src/Common.h
@@ -144,6 +147,12 @@ add_library(
   src/folly/FollyKeepaliveTimer.h
   src/Frame.cpp
   src/Frame.h
+  src/FrameProcessor.h
+  src/FrameSerializer.h
+  src/FrameSerializer.cpp
+  src/FrameSerializer.h
+  src/FrameTransport.cpp
+  src/FrameTransport.h
   src/framed/FramedDuplexConnection.cpp
   src/framed/FramedDuplexConnection.h
   src/framed/FramedReader.cpp
@@ -168,6 +177,8 @@ add_library(
   src/Stats.cpp
   src/Stats.h
   src/StreamState.h
+  src/StreamsFactory.h
+  src/StreamsFactory.cpp
   src/SubscriberBase.h
   src/SubscriptionBase.h
   src/tcp/TcpDuplexConnection.cpp


### PR DESCRIPTION
Not sure if my setup of auto-syncing broke this, or if it was already broken, but in any case this looks like the correct fix.