### PR TITLE
Migration of existing yarpl experiments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,4 +344,6 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
+add_subdirectory(experimental/yarpl)
+
 # EOF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,6 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
-add_subdirectory(experimental/yarpl)
+#add_subdirectory(experimental/yarpl)
 
 # EOF

--- a/experimental/yarpl/CMakeLists.txt
+++ b/experimental/yarpl/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required (VERSION 3.4)
+project (yarpl)
+
+# CMake Config
+
+add_definitions(-std=c++14)
+
+# Generate compilation database
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+
+# Common configuration for all build modes.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -momit-leaf-frame-pointer")
+
+# Configuration for Debug build mode.
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+include_directories(${CMAKE_SOURCE_DIR})
+
+# library source
+add_library(
+        yarpl
+        include/yarpl/Observable.h
+        include/yarpl/Observable_Observer.h
+        include/yarpl/Observable_Subscription.h
+        src/Observable_Subscription.cpp
+        include/yarpl/Flowable.h
+        include/yarpl/Flowable_Subscriber.h
+        include/yarpl/Flowable_Subscription.h
+        src/Flowable_Subscription.cpp
+)
+
+target_include_directories(
+        yarpl
+        PUBLIC "${PROJECT_SOURCE_DIR}/include" # allow include paths such as "yarpl/observable.h" can be used
+)
+
+
+# Executable for Experimenting
+add_executable(
+        yarpl-playground
+        examples/yarpl-playground.cpp
+        examples/ObservableExamples.h
+)
+
+target_link_libraries(
+        yarpl-playground
+        yarpl)
+
+# unit tests
+add_executable(
+        yarpl-tests
+        test/yarpl-tests.cpp
+        test/Observable_test.cpp
+        test/Flowable_test.cpp
+        test/Subscription_test.cpp
+)
+
+target_link_libraries(
+        yarpl-tests
+        yarpl
+        ${GMOCK_LIBS} # inherited from reactivesocket-cpp CMake
+)
+
+## perf tests
+#add_executable(
+#        yarpl-perf
+#        perf/yarpl-perf.cpp
+#        perf/Observable_perf.cpp
+#        perf/Function_perf.cpp
+#)
+#
+#target_link_libraries(
+#        yarpl-perf
+#        yarpl
+#        benchmark
+#)

--- a/experimental/yarpl/README.md
+++ b/experimental/yarpl/README.md
@@ -1,0 +1,57 @@
+# yarpl: Yet Another Reactive Programming Library
+
+C++ implementation of reactive functional programming including both `Observable` and `Flowable` types.
+
+NOTE: This is a work in progress. It is not feature complete.
+
+# Build Status
+
+no automated builds yet
+
+# Dependencies
+
+Install `reactive-streams/ReactiveStreams.h`: https://github.com/ReactiveSocket/reactive-streams-cpp#build--install
+
+After first checkout, initialize and update submodules:
+
+```
+# inside root ./yarpl
+git submodule init
+git submodule update --recursive
+```
+
+# Building and running tests
+
+After installing dependencies as above, you can build and run tests with:
+
+```
+# inside root ./yarpl
+mkdir -p build
+cd build
+cmake ../ -DCMAKE_BUILD_TYPE=DEBUG
+make -j
+./yarpl-tests
+```
+
+# Related Projects
+
+- ReactiveX: http://reactivex.io
+- RxJava 2.0: https://github.com/ReactiveX/RxJava/blob/2.x/DESIGN.md
+- RxCpp: https://github.com/Reactive-Extensions/RxCpp
+- Reactive Streams: http://www.reactive-streams.org
+- Reactive Streams C++: https://github.com/ReactiveSocket/reactive-streams-cpp
+
+# Why?
+
+- Need an implementation of Reactive Streams `Publisher` (the `Flowable` type in this library) which does not exist anywhere that I'm aware of in C++
+- Prefer having `Flowable`, `Observable`, `Single`, and `Completable` in a single interoperable library.
+
+# What's with the name?
+
+I don't enjoy naming project. Please suggest a better name. Until then I just want to code.
+
+Also ...
+
+- RxCpp already exists.
+- RsCpp (ReactiveStreamsCpp) doesn't make sense as this isn't just about Reactive Streams, and the point of Reactive Streams is to have many implementations.
+- I'm tired of projects starting with or containing "react", "reactive", "reactor", "rx", etc.

--- a/experimental/yarpl/examples/FlowableExamples.h
+++ b/experimental/yarpl/examples/FlowableExamples.h
@@ -1,0 +1,130 @@
+#include <iostream>
+#include <string>
+
+//#include <yarpl/Flowable.h>
+
+// using namespace yarpl::flowable;
+
+class FlowableExamples {
+public:
+  static void run();
+};
+
+/*********************** ASubscription **************/
+
+class ASubscription {
+public:
+  virtual ~ASubscription(){};
+  virtual void cancel() = 0;
+  virtual void request(uint64_t n) = 0;
+};
+
+/*********************** ASubscriber ****************/
+
+template <typename T> class ASubscriber {
+public:
+  virtual ~ASubscriber(){};
+  virtual void onNext(const T &value) = 0;
+  virtual void onError(const std::exception &e) = 0;
+  virtual void onComplete() = 0;
+  virtual void onSubscribe(std::unique_ptr<ASubscription>) = 0;
+};
+
+/*********************** AFlowable ******************/
+
+template <typename T> class AFlowable {
+  std::function<void(std::unique_ptr<ASubscriber<T>>)> onSubscribe;
+
+public:
+  ~AFlowable();
+  AFlowable(std::function<void(std::unique_ptr<ASubscriber<T>>)> onSubscribe);
+  static std::unique_ptr<AFlowable<T>>
+  create(std::function<void(std::unique_ptr<ASubscriber<T>>)> onSubscribe);
+  void subscribe(std::unique_ptr<ASubscriber<T>>);
+};
+
+template <typename T> AFlowable<T>::~AFlowable() {
+  std::cout << "AFlowable DESTROYED" << std::endl;
+}
+
+template <typename T>
+AFlowable<T>::AFlowable(std::function<void(std::unique_ptr<ASubscriber<T>>)> os)
+    : onSubscribe(os) {
+  std::cout << "AFlowable CREATED" << std::endl;
+};
+
+template <typename T>
+std::unique_ptr<AFlowable<T>> AFlowable<T>::create(
+    std::function<void(std::unique_ptr<ASubscriber<T>>)> onSubscribe) {
+  return std::make_unique<AFlowable>(onSubscribe);
+}
+
+template <typename T>
+void AFlowable<T>::subscribe(std::unique_ptr<ASubscriber<T>> o) {
+  // when subscribed to, invoke the `onSubscribe` function
+  onSubscribe(std::move(o));
+}
+
+/*********************** Experimenting **************/
+
+void FlowableExamples::run() {
+  std::cout << "---------------FlowableExamples::run-----------------"
+            << std::endl;
+
+  class MySubscriber : public ASubscriber<int> {
+    std::unique_ptr<ASubscription> theSubscription;
+
+  public:
+    MySubscriber() { std::cout << "MySubscriber CREATED" << std::endl; }
+    ~MySubscriber() { std::cout << "MySubscriber DESTROYED" << std::endl; }
+    void onNext(const int &value) {
+      std::cout << "  onNext received " << value << std::endl;
+    }
+    void onError(const std::exception &e) {}
+    void onComplete() {}
+    void onSubscribe(std::unique_ptr<ASubscription> s) {
+      theSubscription = std::move(s);
+      theSubscription->request(10);
+    }
+  };
+
+  class MySubscription : public ASubscription {
+    std::weak_ptr<ASubscriber<int>> s;
+
+  public:
+    ~MySubscription() { std::cout << "MySubscription DESTROYED" << std::endl; }
+    MySubscription(std::weak_ptr<ASubscriber<int>> _s) : s(std::move(_s)) {
+      std::cout << "MySubscription CREATED" << std::endl;
+    };
+    void cancel() {}
+    void request(uint64_t n) {
+      auto sp = s.lock();
+      if (sp) {
+        // do stuff
+        sp->onNext(1);
+      }
+    }
+  };
+
+  {
+    std::cout << "--------- MySubscriber? " << std::endl;
+    auto b = std::make_unique<MySubscriber>();
+    b->onComplete();
+  }
+  std::cout << "--------- MySubscriber? " << std::endl;
+
+  {
+    AFlowable<int>::create([](std::unique_ptr<ASubscriber<int>> s) {
+      std::cout << "AFlowable onSubscribe START" << std::endl;
+      std::shared_ptr<ASubscriber<int>> sharedSubscriber = std::move(s);
+      std::weak_ptr<ASubscriber<int>> wp = sharedSubscriber;
+      sharedSubscriber->onSubscribe(
+          std::make_unique<MySubscription>(std::move(wp)));
+      std::cout << "AFlowable onSubscribe END" << std::endl;
+    })->subscribe(std::make_unique<MySubscriber>());
+  }
+  std::cout << "--------- All destroyed? " << std::endl;
+
+  std::cout << "---------------FlowableExamples::run-----------------"
+            << std::endl;
+}

--- a/experimental/yarpl/examples/ObservableExamples.h
+++ b/experimental/yarpl/examples/ObservableExamples.h
@@ -1,0 +1,82 @@
+#include <iostream>
+#include <string>
+
+#include <yarpl/Observable.h>
+
+using namespace yarpl::observable;
+
+class ObservableExamples {
+public:
+  static void run();
+};
+
+void ObservableExamples::run() {
+  std::cout << "---------------ObservableExamples::run-----------------"
+            << std::endl;
+  // subscription
+  std::unique_ptr<Subscription> s =
+      Subscription::create([]() { std::cout << "cancel" << std::endl; });
+  std::cout << "Subscription cancelled: " << s->isCanceled() << std::endl;
+  s->cancel();
+  std::cout << "Subscription cancelled: " << s->isCanceled() << std::endl;
+
+  // observer with next callback
+  auto o = Observer<int>::create(
+      [](auto v) { std::cout << "received value " << v << std::endl; });
+  o->onNext(5);
+
+  // observer with all 3 callbacks
+  auto o2 = Observer<int>::create(
+      [](auto v) { std::cout << "received value " << v << std::endl; },
+      [](auto e) { std::cout << "received error " << e.what() << std::endl; },
+      []() { std::cout << "completed" << std::endl; });
+  o2->onNext(42);
+  o2->onComplete();
+
+  // inline class with custom Observer implementation
+  class MyObserver : Observer<std::string> {
+    std::unique_ptr<Subscription> subscription;
+    int count;
+
+  public:
+    void onNext(const std::string &value) {
+      count++;
+      std::cout << "MyObserver::onNext " << value
+                << "  subscription: " << subscription->isCanceled()
+                << std::endl;
+      if (count >= 2) {
+        subscription->cancel();
+      }
+    }
+
+    void onError(const std::exception &exception) {}
+
+    void onComplete() { std::cout << "MyObserver::onComplete" << std::endl; }
+
+    void onSubscribe(std::unique_ptr<Subscription> ptr) {
+      std::cout << "MyObserver::onSubscribe" << std::endl;
+      subscription = std::move(ptr);
+    }
+  } myObserver;
+
+  myObserver.onSubscribe(Subscription::create());
+  myObserver.onNext("hello");
+  myObserver.onNext("world");
+  myObserver.onNext("!");
+  myObserver.onComplete();
+
+  // create an Observable
+
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    obs->onSubscribe(Subscription::create([]() { std::cout << "cancelled!"; }));
+    obs->onNext(1);
+    obs->onNext(2);
+    obs->onComplete();
+  });
+
+  a->subscribe(Observer<int>::create(
+      [](auto value) { std::cout << "Observed => " << value << std::endl; }));
+
+  std::cout << "---------------ObservableExamples::run-----------------"
+            << std::endl;
+}

--- a/experimental/yarpl/examples/yarpl-playground.cpp
+++ b/experimental/yarpl/examples/yarpl-playground.cpp
@@ -1,0 +1,7 @@
+#include "ObservableExamples.h"
+#include "FlowableExamples.h"
+
+int main() {
+    ObservableExamples::run();
+    FlowableExamples::run();
+}

--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <yarpl/Flowable_Subscriber.h>
+
+namespace yarpl {
+namespace flowable {
+
+template <typename T> class Flowable {
+  std::function<void(std::unique_ptr<Subscriber<T>>)> onSubscribe;
+
+public:
+  Flowable(std::function<void(std::unique_ptr<Subscriber<T>>)> onSubscribe);
+  static std::unique_ptr<Flowable<T>>
+  create(std::function<void(std::unique_ptr<Subscriber<T>>)> onSubscribe);
+  void subscribe(std::unique_ptr<Subscriber<T>>);
+};
+
+/* ****************************************** */
+/* implementation here because of templates */
+/* https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl */
+/* ****************************************** */
+
+template <typename T>
+Flowable<T>::Flowable(std::function<void(std::unique_ptr<Subscriber<T>>)> os)
+    : onSubscribe(os){};
+
+template <typename T>
+std::unique_ptr<Flowable<T>> Flowable<T>::create(
+    std::function<void(std::unique_ptr<Subscriber<T>>)> onSubscribe) {
+  return std::make_unique<Flowable>(onSubscribe);
+}
+
+template <typename T>
+void Flowable<T>::subscribe(std::unique_ptr<Subscriber<T>> o) {
+  // when subscribed to, invoke the `onSubscribe` function
+  onSubscribe(std::move(o));
+}
+
+} // flowable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Flowable_Subscriber.h
+++ b/experimental/yarpl/include/yarpl/Flowable_Subscriber.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <yarpl/Flowable_Subscription.h>
+
+namespace yarpl {
+namespace flowable {
+
+/**
+ *
+ */
+template <typename T> class Subscriber {
+public:
+  virtual ~Subscriber(){};
+
+  static std::unique_ptr<Subscriber<T>>
+  create(std::function<void(const T &)> onNext);
+
+  static std::unique_ptr<Subscriber<T>>
+  create(std::function<void(const T &)> onNext,
+         std::function<void(const std::exception &)> onError);
+
+  static std::unique_ptr<Subscriber<T>>
+  create(std::function<void(const T &)> onNext,
+         std::function<void(const std::exception &)> onError,
+         std::function<void()> onComplete);
+
+  virtual void onNext(const T &value) = 0;
+  virtual void onError(const std::exception &e) = 0;
+  virtual void onComplete() = 0;
+  virtual void onSubscribe(std::unique_ptr<Subscription>) = 0;
+};
+
+/* ****************************************** */
+/* implementation here because of templates */
+/* https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl */
+/* ****************************************** */
+
+static const std::function<void(const std::exception &)> DEFAULT_ERROR =
+    [](const std::exception &) {};
+static const std::function<void()> DEFAULT_COMPLETE = []() {};
+
+template <typename T> class ObserverImpl : public Subscriber<T> {
+  std::function<void(const T &)> next;
+  std::function<void(const std::exception &)> error;
+  std::function<void()> complete;
+
+public:
+  ObserverImpl(std::function<void(const T &)> n)
+      : next(n), error(DEFAULT_ERROR), complete(DEFAULT_COMPLETE){};
+  ObserverImpl(std::function<void(const T &)> n,
+               std::function<void(const std::exception &)> e)
+      : next(n), error(e), complete(DEFAULT_COMPLETE){};
+  ObserverImpl(std::function<void(const T &)> n,
+               std::function<void(const std::exception &)> e,
+               std::function<void()> c)
+      : next(n), error(e), complete(c){};
+
+  void onNext(const T &value) { next.operator()(value); }
+
+  void onError(const std::exception &e) { error.operator()(e); }
+
+  void onComplete() { complete.operator()(); }
+
+  void onSubscribe(std::unique_ptr<Subscription> s) {
+    // default to requesting max() (infinite)
+    // which means this Subscriber is synchronous and needs no flow control
+    s->request(std::numeric_limits<uint64_t>::max());
+  }
+};
+
+template <typename T>
+std::unique_ptr<Subscriber<T>>
+Subscriber<T>::create(std::function<void(const T &)> onNext) {
+  return std::unique_ptr<Subscriber<T>>(new ObserverImpl<T>(onNext));
+}
+
+template <typename T>
+std::unique_ptr<Subscriber<T>>
+Subscriber<T>::create(std::function<void(const T &)> onNext,
+                      std::function<void(const std::exception &)> onError) {
+  return std::unique_ptr<Subscriber<T>>(new ObserverImpl<T>(onNext, onError));
+}
+
+template <typename T>
+std::unique_ptr<Subscriber<T>>
+Subscriber<T>::create(std::function<void(const T &)> onNext,
+                      std::function<void(const std::exception &)> onError,
+                      std::function<void()> onComplete) {
+  return std::unique_ptr<Subscriber<T>>(
+      new ObserverImpl<T>(onNext, onError, onComplete));
+}
+
+} // observable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Flowable_Subscription.h
+++ b/experimental/yarpl/include/yarpl/Flowable_Subscription.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace yarpl {
+namespace flowable {
+
+class Subscription {
+public:
+  virtual ~Subscription(){};
+  virtual void cancel() = 0;
+  virtual void request(uint64_t n) = 0;
+};
+
+} // observable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Observable.h
+++ b/experimental/yarpl/include/yarpl/Observable.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <yarpl/Observable_Observer.h>
+
+namespace yarpl {
+namespace observable {
+
+template <typename T> class Observable {
+  std::function<void(std::unique_ptr<Observer<T>>)> onSubscribe;
+
+public:
+  Observable(std::function<void(std::unique_ptr<Observer<T>>)> onSubscribe);
+  static std::unique_ptr<Observable<T>>
+  create(std::function<void(std::unique_ptr<Observer<T>>)> onSubscribe);
+  void subscribe(std::unique_ptr<Observer<T>>);
+};
+
+/* ****************************************** */
+/* implementation here because of templates */
+/* https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl */
+/* ****************************************** */
+
+template <typename T>
+Observable<T>::Observable(std::function<void(std::unique_ptr<Observer<T>>)> os)
+    : onSubscribe(os){};
+
+template <typename T>
+std::unique_ptr<Observable<T>> Observable<T>::create(
+    std::function<void(std::unique_ptr<Observer<T>>)> onSubscribe) {
+  return std::make_unique<Observable>(onSubscribe);
+}
+
+template <typename T>
+void Observable<T>::subscribe(std::unique_ptr<Observer<T>> o) {
+  // when subscribed to, invoke the `onSubscribe` function
+  onSubscribe(std::move(o));
+}
+
+} // observable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Observable_Observer.h
+++ b/experimental/yarpl/include/yarpl/Observable_Observer.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <yarpl/Observable_Subscription.h>
+
+namespace yarpl {
+namespace observable {
+
+/**
+ *
+ */
+template <typename T> class Observer {
+public:
+  static std::unique_ptr<Observer<T>>
+  create(std::function<void(const T &)> onNext);
+
+  static std::unique_ptr<Observer<T>>
+  create(std::function<void(const T &)> onNext,
+         std::function<void(const std::exception &)> onError);
+
+  static std::unique_ptr<Observer<T>>
+  create(std::function<void(const T &)> onNext,
+         std::function<void(const std::exception &)> onError,
+         std::function<void()> onComplete);
+
+  virtual void onNext(const T &value) = 0;
+  virtual void onError(const std::exception &e) = 0;
+  virtual void onComplete() = 0;
+  virtual void onSubscribe(std::unique_ptr<Subscription>) = 0;
+};
+
+/* ****************************************** */
+/* implementation here because of templates */
+/* https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl */
+/* ****************************************** */
+
+static const std::function<void(const std::exception &)> DEFAULT_ERROR =
+    [](const std::exception &) {};
+static const std::function<void()> DEFAULT_COMPLETE = []() {};
+
+template <typename T> class ObserverImpl : public Observer<T> {
+  std::function<void(const T &)> next;
+  std::function<void(const std::exception &)> error;
+  std::function<void()> complete;
+
+public:
+  ObserverImpl(std::function<void(const T &)> n)
+      : next(n), error(DEFAULT_ERROR), complete(DEFAULT_COMPLETE){};
+  ObserverImpl(std::function<void(const T &)> n,
+               std::function<void(const std::exception &)> e)
+      : next(n), error(e), complete(DEFAULT_COMPLETE){};
+  ObserverImpl(std::function<void(const T &)> n,
+               std::function<void(const std::exception &)> e,
+               std::function<void()> c)
+      : next(n), error(e), complete(c){};
+
+  void onNext(const T &value) { next.operator()(value); }
+
+  void onError(const std::exception &e) { error.operator()(e); }
+
+  void onComplete() { complete.operator()(); }
+
+  void onSubscribe(std::unique_ptr<Subscription> s) {
+    // do nothing with onSubscribe when lambdas used
+    // cancellation is not supported in that case
+  }
+};
+
+template <typename T>
+std::unique_ptr<Observer<T>>
+Observer<T>::create(std::function<void(const T &)> onNext) {
+  return std::unique_ptr<Observer<T>>(new ObserverImpl<T>(onNext));
+}
+
+template <typename T>
+std::unique_ptr<Observer<T>>
+Observer<T>::create(std::function<void(const T &)> onNext,
+                    std::function<void(const std::exception &)> onError) {
+  return std::unique_ptr<Observer<T>>(new ObserverImpl<T>(onNext, onError));
+}
+
+template <typename T>
+std::unique_ptr<Observer<T>>
+Observer<T>::create(std::function<void(const T &)> onNext,
+                    std::function<void(const std::exception &)> onError,
+                    std::function<void()> onComplete) {
+  return std::unique_ptr<Observer<T>>(
+      new ObserverImpl<T>(onNext, onError, onComplete));
+}
+
+} // observable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Observable_Subscription.h
+++ b/experimental/yarpl/include/yarpl/Observable_Subscription.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace yarpl {
+namespace observable {
+
+class Subscription {
+  std::atomic_bool cancelled{false};
+  std::function<void()> onCancel;
+
+private:
+  Subscription(std::function<void()> onCancel) : onCancel(onCancel){};
+
+public:
+  static std::unique_ptr<Subscription> create(std::function<void()> onCancel);
+  static std::unique_ptr<Subscription> create(std::atomic_bool &cancelled);
+  static std::unique_ptr<Subscription> create();
+  void cancel();
+  bool isCanceled();
+};
+
+} // observable namespace
+} // yarpl namespace

--- a/experimental/yarpl/include/yarpl/Observable_Subscription.h
+++ b/experimental/yarpl/include/yarpl/Observable_Subscription.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 

--- a/experimental/yarpl/perf/Function_perf.cpp
+++ b/experimental/yarpl/perf/Function_perf.cpp
@@ -1,0 +1,69 @@
+#include <benchmark/benchmark.h>
+#include <iostream>
+
+/*
+ * Seeking to understand cost of different method signatures
+ * when passing an object through levels of functions.
+ *
+ * function_nested_copy                       93 ns         78 ns    9909119
+ * function_nested_move                       71 ns         66 ns   11116405
+ * function_nested_ref                        84 ns         74 ns   11032483
+ * function_nested_unique_ptr                364 ns        344 ns    1934567
+ */
+
+struct Tuple {
+  Tuple(int xx, int yy) : x(xx), y(yy) {}
+  const int x;
+  const int y;
+
+  void doSomething() {}
+};
+
+void functionByCopyAgain(Tuple a) { a.doSomething(); };
+
+void functionByCopy(Tuple a) { functionByCopyAgain(a); };
+
+static void function_nested_copy(benchmark::State &state) {
+  while (state.KeepRunning()) {
+    Tuple a(1, 2);
+    functionByCopy(a);
+  }
+}
+BENCHMARK(function_nested_copy);
+
+void functionByMoveAgain(Tuple a) { a.doSomething(); };
+
+void functionByMove(Tuple a) { functionByMoveAgain(std::move(a)); };
+
+static void function_nested_move(benchmark::State &state) {
+  while (state.KeepRunning()) {
+    Tuple a(1, 2);
+    functionByCopy(std::move(a));
+  }
+}
+BENCHMARK(function_nested_move);
+
+void functionByRefAgain(Tuple &a) { a.doSomething(); };
+
+void functionByRef(Tuple &a) { functionByRefAgain(a); };
+
+static void function_nested_ref(benchmark::State &state) {
+  while (state.KeepRunning()) {
+    Tuple a(1, 2);
+    functionByCopy(a);
+  }
+}
+BENCHMARK(function_nested_ref);
+
+void functionByUniquePtrAgain(std::unique_ptr<Tuple> a) { a->doSomething(); };
+
+void functionByUniquePtr(std::unique_ptr<Tuple> a) {
+  functionByUniquePtrAgain(std::move(a));
+};
+
+static void function_nested_unique_ptr(benchmark::State &state) {
+  while (state.KeepRunning()) {
+    functionByUniquePtr(std::make_unique<Tuple>(1, 2));
+  }
+}
+BENCHMARK(function_nested_unique_ptr);

--- a/experimental/yarpl/perf/Observable_perf.cpp
+++ b/experimental/yarpl/perf/Observable_perf.cpp
@@ -1,0 +1,44 @@
+#include <benchmark/benchmark.h>
+#include <yarpl/Observable.h>
+#include <iostream>
+
+using namespace yarpl::observable;
+
+static void Observable_OnNextOne_ConstructOnly(benchmark::State &state) {
+  while (state.KeepRunning()) {
+    auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+      obs->onSubscribe(Subscription::create());
+      obs->onNext(1);
+      obs->onComplete();
+    });
+  }
+}
+BENCHMARK(Observable_OnNextOne_ConstructOnly);
+
+static void Observable_OnNextOne_SubscribeOnly(benchmark::State &state) {
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    obs->onSubscribe(Subscription::create());
+    obs->onNext(1);
+    obs->onComplete();
+  });
+  while (state.KeepRunning()) {
+    a->subscribe(Observer<int>::create([](int value) { /* do nothing */ }));
+  }
+}
+BENCHMARK(Observable_OnNextOne_SubscribeOnly);
+
+static void Observable_OnNextN(benchmark::State &state) {
+  auto a = Observable<int>::create([&state](std::unique_ptr<Observer<int>> obs) {
+    obs->onSubscribe(Subscription::create());
+    for (int i = 0; i < state.range_x(); i++) {
+      obs->onNext(i);
+    }
+    obs->onComplete();
+  });
+  while (state.KeepRunning()) {
+    a->subscribe(Observer<int>::create([](int value) { /* do nothing */ }));
+  }
+}
+
+// Register the function as a benchmark
+BENCHMARK(Observable_OnNextN)->Arg(100)->Arg(10000)->Arg(1000000);

--- a/experimental/yarpl/perf/yarpl-perf.cpp
+++ b/experimental/yarpl/perf/yarpl-perf.cpp
@@ -1,0 +1,4 @@
+#include <benchmark/benchmark.h>
+
+// main method for all perf tests in other files
+BENCHMARK_MAIN();

--- a/experimental/yarpl/src/Flowable_Subscription.cpp
+++ b/experimental/yarpl/src/Flowable_Subscription.cpp
@@ -1,0 +1,7 @@
+#include "yarpl/Flowable_Subscription.h"
+
+namespace yarpl {
+namespace flowable {
+
+}
+}

--- a/experimental/yarpl/src/Observable_Subscription.cpp
+++ b/experimental/yarpl/src/Observable_Subscription.cpp
@@ -1,0 +1,29 @@
+#include "yarpl/Observable_Subscription.h"
+
+namespace yarpl {
+namespace observable {
+
+std::unique_ptr<Subscription>
+Subscription::create(std::function<void()> onCancel) {
+  return std::unique_ptr<Subscription>(new Subscription(onCancel));
+}
+std::unique_ptr<Subscription>
+Subscription::create(std::atomic_bool &cancelled) {
+    return create([&cancelled]() { cancelled = true; });
+}
+
+std::unique_ptr<Subscription> Subscription::create() {
+  return create([]() {});
+}
+
+void Subscription::cancel() {
+  bool expected = false;
+  // mark cancelled 'true' and only if successful invoke 'onCancel()'
+  if (cancelled.compare_exchange_strong(expected, true)) {
+    onCancel();
+  }
+}
+
+bool Subscription::isCanceled() { return cancelled; }
+}
+}

--- a/experimental/yarpl/test/Flowable_test.cpp
+++ b/experimental/yarpl/test/Flowable_test.cpp
@@ -1,0 +1,429 @@
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+#include <yarpl/Flowable.h>
+
+using namespace yarpl::flowable;
+
+/*
+ * Verbose usage of interfaces with inline class implementations.
+ *
+ * - Demonstrating subscribe, onSubscribe, request, onNext, cancel.
+ * - Shows use of unique_ptr and std::move to pass around the Subscriber and
+ * Subscription.
+ */
+TEST(Flowable, SubscribeRequestAndCancel) {
+
+  // Subscription that emits integers forever as long as requested
+  class InfiniteIntegersSource : public Subscription {
+    std::unique_ptr<Subscriber<int>> subscriber;
+    std::atomic_bool isCancelled{false};
+
+  public:
+    InfiniteIntegersSource(std::unique_ptr<Subscriber<int>> subscriber)
+        : subscriber(std::move(subscriber)) {}
+
+    void cancel() override { isCancelled = true; }
+    void request(uint64_t n) override {
+      for (u_long i = 0; i < n; i++) {
+        if (isCancelled) {
+          return;
+        }
+        subscriber->onNext(i);
+      }
+    }
+  };
+
+  // Subscriber that requests 10 items, then cancels after receiving 6
+  class MySubscriber : public Subscriber<int> {
+    std::unique_ptr<Subscription> subscription;
+
+  public:
+    void onNext(const int &value) override {
+      std::cout << "received " << value << std::endl;
+      if (value == 6) {
+        subscription->cancel();
+      }
+    }
+    void onError(const std::exception &e) override {}
+    void onComplete() override {}
+    void onSubscribe(std::unique_ptr<Subscription> s) override {
+      subscription = std::move(s);
+      subscription->request((u_long)10);
+    }
+  };
+
+  // create Flowable around InfiniteIntegersSource
+  auto a =
+      Flowable<int>::create([](std::unique_ptr<Subscriber<int>> subscriber) {
+        /*
+         * This usage works, and looks to be supported by rule 14 of:
+         * http://en.cppreference.com/w/cpp/language/eval_order
+         *
+         * This rule is added for C++17, but talking with Lee Howes on the C++
+         * committee
+         * suggests this is codifying behavior that already is supported by
+         * compilers.
+         *
+         * One remaining concern though is that this following line is basically
+         * the only
+         * way to code it, as the std:move could not be done on a line
+         * preceeding onSubscribe.
+         *
+         * Another option is to make the Subscription and move Subscriber into
+         * it, then
+         * have an accessor on Subscription to allow something like:
+         *
+         * subscription->getSubscriber()->onSubscribe(subscription).
+         *
+         * But that's awkward too.
+         *
+         * Another option is to make the Subscription call onSubscribe once
+         * the Subscriber is moved into it.
+         *
+         * Or we just accept that this line is how it's done. In practice
+         * very few engineers will ever need to write this code because
+         * implementations
+         * will typically provide factory methods anyways, since it's hard to
+         * create
+         * proper Flowable/Publishers without them.
+         */
+        subscriber->onSubscribe(
+            std::make_unique<InfiniteIntegersSource>(std::move(subscriber)));
+      });
+
+  a->subscribe(std::make_unique<MySubscriber>());
+  std::cout << "-----------------------------" << std::endl;
+}
+
+TEST(Flowable, OnError) {
+
+  // Subscription that fails
+  class Source : public Subscription {
+    std::unique_ptr<Subscriber<int>> subscriber;
+    std::atomic_bool isCancelled{false};
+
+  public:
+    Source(std::unique_ptr<Subscriber<int>> subscriber)
+        : subscriber(std::move(subscriber)) {}
+
+    void cancel() override { isCancelled = true; }
+    void request(uint64_t n) override {
+      try {
+        throw std::runtime_error("something broke!");
+      } catch (const std::exception &e) {
+        subscriber->onError(e);
+      }
+    }
+  };
+
+  // create Flowable around Source
+  auto a = Flowable<int>::create([](
+      std::unique_ptr<Subscriber<int>> subscriber) {
+    subscriber->onSubscribe(std::make_unique<Source>(std::move(subscriber)));
+  });
+
+  std::string errorMessage("DEFAULT->No Error Message");
+  a->subscribe(
+      Subscriber<int>::create([](int value) { /* do nothing */ },
+                              [&errorMessage](const std::exception &e) {
+                                errorMessage = std::string(e.what());
+                              }));
+
+  EXPECT_EQ("something broke!", errorMessage);
+  std::cout << "-----------------------------" << std::endl;
+}
+
+/**
+ * Assert that all items passed through the Flowable get destroyed
+ */
+TEST(Flowable, ItemsCollectedSynchronously) {
+
+  static std::atomic<int> instanceCount;
+
+  struct Tuple {
+    const int a;
+    const int b;
+
+    Tuple(const int a, const int b) : a(a), b(b) {
+      std::cout << "Tuple created!!" << std::endl;
+      instanceCount++;
+    }
+    Tuple(const Tuple &t) : a(t.a), b(t.b) {
+      std::cout << "Tuple copy constructed!!" << std::endl;
+      instanceCount++;
+    }
+    ~Tuple() {
+      std::cout << "Tuple destroyed!!" << std::endl;
+      instanceCount--;
+    }
+  };
+
+  class Source : public Subscription {
+    std::unique_ptr<Subscriber<Tuple>> subscriber;
+    std::atomic_bool isCancelled{false};
+
+  public:
+    Source(std::unique_ptr<Subscriber<Tuple>> subscriber)
+        : subscriber(std::move(subscriber)) {}
+
+    void cancel() override { isCancelled = true; }
+    void request(uint64_t n) override {
+      // ignoring n for tests ... DO NOT DO THIS FOR REAL
+      subscriber->onNext(Tuple{1, 2});
+      subscriber->onNext(Tuple{2, 3});
+      subscriber->onNext(Tuple{3, 4});
+      subscriber->onComplete();
+    }
+  };
+
+  // create Flowable around Source
+  auto a = Flowable<Tuple>::create([](
+      std::unique_ptr<Subscriber<Tuple>> subscriber) {
+    subscriber->onSubscribe(std::make_unique<Source>(std::move(subscriber)));
+  });
+
+  a->subscribe(Subscriber<Tuple>::create([](const Tuple &value) {
+    std::cout << "received value " << value.a << std::endl;
+  }));
+
+  std::cout << "Finished ... remaining instances == " << instanceCount
+            << std::endl;
+
+  EXPECT_EQ(0, instanceCount);
+  std::cout << "-----------------------------" << std::endl;
+}
+
+/*
+ * Assert that all items passed through the Flowable get
+ * copied and destroyed correctly over async boundaries.
+ *
+ * This is simulating "async" by having an Observer store the items
+ * in a Vector which could then be consumed on another thread.
+ */
+TEST(Flowable, ItemsCollectedAsynchronously) {
+
+  static std::atomic<int> createdCount;
+  static std::atomic<int> destroyedCount;
+
+  struct Tuple {
+    const int a;
+    const int b;
+
+    Tuple(const int a, const int b) : a(a), b(b) {
+      std::cout << "Tuple " << a << " created!!" << std::endl;
+      createdCount++;
+    }
+    Tuple(const Tuple &t) : a(t.a), b(t.b) {
+      std::cout << "Tuple " << a << " copy constructed!!" << std::endl;
+      createdCount++;
+    }
+    ~Tuple() {
+      std::cout << "Tuple " << a << " destroyed!!" << std::endl;
+      destroyedCount++;
+    }
+  };
+
+  // scope this so we can check destruction of Vector after this block
+  {
+
+    // Subscription that fails
+    class Source : public Subscription {
+      std::unique_ptr<Subscriber<Tuple>> subscriber;
+      std::atomic_bool isCancelled{false};
+
+    public:
+      Source(std::unique_ptr<Subscriber<Tuple>> subscriber)
+          : subscriber(std::move(subscriber)) {}
+
+      void cancel() override { isCancelled = true; }
+      void request(uint64_t n) override {
+        // ignoring n for tests ... DO NOT DO THIS FOR REAL
+        std::cout << "-----------------------------" << std::endl;
+        subscriber->onNext(Tuple{1, 2});
+        std::cout << "-----------------------------" << std::endl;
+        subscriber->onNext(Tuple{2, 3});
+        std::cout << "-----------------------------" << std::endl;
+        subscriber->onNext(Tuple{3, 4});
+        std::cout << "-----------------------------" << std::endl;
+        subscriber->onComplete();
+      }
+    };
+
+    // create Flowable around Source
+    auto a = Flowable<Tuple>::create([](
+        std::unique_ptr<Subscriber<Tuple>> subscriber) {
+      subscriber->onSubscribe(std::make_unique<Source>(std::move(subscriber)));
+    });
+
+    std::vector<Tuple> v;
+    v.reserve(10); // otherwise it resizes and copies on each push_back
+    a->subscribe(Subscriber<Tuple>::create([&v](const Tuple &value) {
+      std::cout << "received value " << value.a << std::endl;
+      // copy into vector
+      v.push_back(value);
+      std::cout << "done pushing into vector" << std::endl;
+    }));
+
+    // expect that 3 instances were originally created, then 3 more when copying
+    EXPECT_EQ(6, createdCount);
+    // expect that 3 instances still exist in the vector, so only 3 destroyed so
+    // far
+    EXPECT_EQ(3, destroyedCount);
+
+    std::cout << "Leaving block now so Vector should release Tuples..."
+              << std::endl;
+  }
+
+  EXPECT_EQ(0, (createdCount - destroyedCount));
+  std::cout << "-----------------------------" << std::endl;
+}
+
+/**
+ * Assert that memory is not retained when a single Flowable
+ * is subscribed to multiple times.
+ */
+TEST(Flowable, TestRetainOnStaticAsyncFlowableWithMultipleSubscribers) {
+
+  static std::atomic<int> tupleInstanceCount;
+  static std::atomic<int> subscriptionInstanceCount;
+  static std::atomic<int> subscriberInstanceCount;
+
+  struct Tuple {
+    const int a;
+    const int b;
+
+    Tuple(const int a, const int b) : a(a), b(b) {
+      std::cout << "   Tuple created!!" << std::endl;
+      tupleInstanceCount++;
+    }
+    Tuple(const Tuple &t) : a(t.a), b(t.b) {
+      std::cout << "   Tuple copy constructed!!" << std::endl;
+      tupleInstanceCount++;
+    }
+    ~Tuple() {
+      std::cout << "   Tuple destroyed!!" << std::endl;
+      tupleInstanceCount--;
+    }
+  };
+
+  class MySubscriber : public Subscriber<Tuple> {
+    std::unique_ptr<Subscription> subscription;
+
+  public:
+    MySubscriber() {
+      std::cout << "   Subscriber created!!" << std::endl;
+      subscriberInstanceCount++;
+    }
+    ~MySubscriber() {
+      std::cout << "   Subscriber destroyed!!" << std::endl;
+      subscriberInstanceCount--;
+    }
+
+    void onNext(const Tuple &value) override {
+      std::cout << "   Subscriber received value " << value.a << " on thread "
+                << std::this_thread::get_id() << std::endl;
+    }
+    void onError(const std::exception &e) override {}
+    void onComplete() override {}
+    void onSubscribe(std::unique_ptr<Subscription> s) override {
+      subscription = std::move(s);
+      subscription->request((u_long)10);
+    }
+  };
+
+  class Source : public Subscription {
+    std::weak_ptr<Subscriber<Tuple>> subscriber;
+    std::atomic_bool isCancelled{false};
+
+  public:
+    Source(std::weak_ptr<Subscriber<Tuple>> subscriber)
+        : subscriber(std::move(subscriber)) {
+      std::cout << "   Subscription created!!" << std::endl;
+      subscriptionInstanceCount++;
+    }
+    ~Source() {
+      std::cout << "   Subscription destroyed!!" << std::endl;
+      subscriptionInstanceCount--;
+    }
+
+    void cancel() override { isCancelled = true; }
+    void request(uint64_t n) override {
+      // ignoring n for tests ... DO NOT DO THIS FOR REAL
+      auto ss = subscriber.lock();
+      if (ss) {
+        ss->onNext(Tuple{1, 2});
+        ss->onNext(Tuple{2, 3});
+        ss->onNext(Tuple{3, 4});
+        ss->onComplete();
+      } else {
+        std::cout << "!!!!!!!!!!! Subscriber already destroyed when REQUEST_N "
+                     "received."
+                  << std::endl;
+      }
+    }
+  };
+
+  {
+    static std::atomic_int counter{2};
+    // create Flowable around Source
+    auto a = Flowable<Tuple>::create([](
+        std::unique_ptr<Subscriber<Tuple>> subscriber) {
+      std::cout << "Flowable subscribed to ... starting new thread ..."
+                << std::endl;
+      try {
+        std::thread([s = std::move(subscriber)]() mutable {
+          try {
+            std::cout << "*** Running in another thread!!!!!" << std::endl;
+            // force artificial delay
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            // now do work
+            std::shared_ptr<Subscriber<Tuple>> sharedSubscriber = std::move(s);
+            std::weak_ptr<Subscriber<Tuple>> wp = sharedSubscriber;
+            sharedSubscriber->onSubscribe(
+                std::make_unique<Source>(std::move(wp)));
+            counter--; // assuming pipeline is synchronous, which it is in this
+                       // test
+            std::cout << "Done thread" << std::endl;
+          } catch (std::exception &e) {
+            std::cout << e.what() << std::endl;
+          }
+        }).detach();
+
+      } catch (std::exception &e) {
+        std::cout << e.what() << std::endl;
+      }
+    });
+
+    EXPECT_EQ(0, subscriptionInstanceCount);
+
+    std::cout << "Thread counter: " << counter << std::endl;
+    std::cout << "About to subscribe (1) ..." << std::endl;
+
+    { a->subscribe(std::make_unique<MySubscriber>()); }
+    while (counter > 1) {
+      std::cout << "waiting for completion" << std::endl;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    // ensure Subscriber and Subscription are destroyed
+    EXPECT_EQ(0, subscriptionInstanceCount);
+
+    std::cout << "About to subscribe (2) ..." << std::endl;
+
+    { a->subscribe(std::make_unique<MySubscriber>()); }
+    while (counter > 0) {
+      std::cout << "waiting for completion" << std::endl;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    // ensure Subscriber and Subscription are destroyed
+    EXPECT_EQ(0, subscriptionInstanceCount);
+
+    std::cout << "Finished ... remaining instances == " << tupleInstanceCount
+              << std::endl;
+  }
+  std::cout << "... after block" << std::endl;
+  EXPECT_EQ(0, tupleInstanceCount);
+  EXPECT_EQ(0, subscriptionInstanceCount);
+  EXPECT_EQ(0, subscriberInstanceCount);
+  std::cout << "-----------------------------" << std::endl;
+}

--- a/experimental/yarpl/test/Observable_test.cpp
+++ b/experimental/yarpl/test/Observable_test.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+#include <yarpl/Observable.h>
+
+using namespace yarpl::observable;
+
+TEST(Observable, SingleOnNext) {
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    obs->onSubscribe(Subscription::create());
+    obs->onNext(1);
+    obs->onComplete();
+  });
+
+  std::vector<int> v;
+  a->subscribe(Observer<int>::create([&v](int value) { v.push_back(value); }));
+
+  EXPECT_EQ(v.at(0), 1);
+}
+
+TEST(Observable, MultiOnNext) {
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    obs->onSubscribe(Subscription::create());
+    obs->onNext(1);
+    obs->onNext(2);
+    obs->onNext(3);
+    obs->onComplete();
+  });
+
+  std::vector<int> v;
+  a->subscribe(Observer<int>::create([&v](int value) { v.push_back(value); }));
+
+  EXPECT_EQ(v.at(0), 1);
+  EXPECT_EQ(v.at(1), 2);
+  EXPECT_EQ(v.at(2), 3);
+}
+
+TEST(Observable, OnError) {
+  std::string errorMessage("DEFAULT->No Error Message");
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    try {
+      throw std::runtime_error("something broke!");
+    } catch (const std::exception &e) {
+      obs->onError(e);
+    }
+  });
+
+  a->subscribe(Observer<int>::create([](int value) { /* do nothing */ },
+                                     [&errorMessage](const std::exception &e) {
+                                       errorMessage = std::string(e.what());
+                                     }));
+
+  EXPECT_EQ("something broke!", errorMessage);
+}
+
+/**
+ * Assert that all items passed through the Observable get destroyed
+ */
+TEST(Observable, ItemsCollectedSynchronously) {
+
+  static std::atomic<int> instanceCount;
+
+  struct Tuple {
+    const int a;
+    const int b;
+
+    Tuple(const int a, const int b) : a(a), b(b) {
+      std::cout << "Tuple created!!" << std::endl;
+      instanceCount++;
+    }
+    Tuple(const Tuple &t) : a(t.a), b(t.b) {
+      std::cout << "Tuple copy constructed!!" << std::endl;
+      instanceCount++;
+    }
+    ~Tuple() {
+      std::cout << "Tuple destroyed!!" << std::endl;
+      instanceCount--;
+    }
+  };
+
+  auto a = Observable<Tuple>::create([](std::unique_ptr<Observer<Tuple>> obs) {
+    obs->onSubscribe(Subscription::create());
+    obs->onNext(Tuple{1, 2});
+    obs->onNext(Tuple{2, 3});
+    obs->onNext(Tuple{3, 4});
+    obs->onComplete();
+  });
+
+  // TODO how can it be made so 'auto' correctly works without doing copying?
+  // a->subscribe(Observer<Tuple>::create(
+  //    [](auto value) { std::cout << "received value " << value.a << "\n"; }));
+  a->subscribe(Observer<Tuple>::create([](const Tuple &value) {
+    std::cout << "received value " << value.a << std::endl;
+  }));
+
+  std::cout << "Finished ... remaining instances == " << instanceCount
+            << std::endl;
+
+  EXPECT_EQ(0, instanceCount);
+  std::cout << "-----------------------------" << std::endl;
+}
+
+/*
+ * Assert that all items passed through the Flowable get
+ * copied and destroyed correctly over async boundaries.
+ *
+ * This is simulating "async" by having an Observer store the items
+ * in a Vector which could then be consumed on another thread.
+ */
+TEST(Observable, ItemsCollectedAsynchronously) {
+
+  static std::atomic<int> createdCount;
+  static std::atomic<int> destroyedCount;
+
+  struct Tuple {
+    const int a;
+    const int b;
+
+    Tuple(const int a, const int b) : a(a), b(b) {
+      std::cout << "Tuple " << a << " created!!" << std::endl;
+      createdCount++;
+    }
+    Tuple(const Tuple &t) : a(t.a), b(t.b) {
+      std::cout << "Tuple " << a << " copy constructed!!" << std::endl;
+      createdCount++;
+    }
+    ~Tuple() {
+      std::cout << "Tuple " << a << " destroyed!!" << std::endl;
+      destroyedCount++;
+    }
+  };
+
+  // scope this so we can check destruction of Vector after this block
+  {
+    auto a =
+        Observable<Tuple>::create([](std::unique_ptr<Observer<Tuple>> obs) {
+          obs->onSubscribe(Subscription::create());
+          std::cout << "-----------------------------" << std::endl;
+          obs->onNext(Tuple{1, 2});
+          std::cout << "-----------------------------" << std::endl;
+          obs->onNext(Tuple{2, 3});
+          std::cout << "-----------------------------" << std::endl;
+          obs->onNext(Tuple{3, 4});
+          std::cout << "-----------------------------" << std::endl;
+          obs->onComplete();
+        });
+
+    std::vector<Tuple> v;
+    v.reserve(10); // otherwise it resizes and copies on each push_back
+    a->subscribe(Observer<Tuple>::create([&v](const Tuple &value) {
+      std::cout << "received value " << value.a << std::endl;
+      // copy into vector
+      v.push_back(value);
+      std::cout << "done pushing into vector" << std::endl;
+    }));
+
+    // expect that 3 instances were originally created, then 3 more when copying
+    EXPECT_EQ(6, createdCount);
+    // expect that 3 instances still exist in the vector, so only 3 destroyed so
+    // far
+    EXPECT_EQ(3, destroyedCount);
+
+    std::cout << "Leaving block now so Vector should release Tuples..."
+              << std::endl;
+  }
+
+  EXPECT_EQ(0, (createdCount - destroyedCount));
+  std::cout << "-----------------------------" << std::endl;
+}
+
+class TakeObserver : public Observer<int> {
+
+private:
+  const int limit;
+  int count = 0;
+  std::unique_ptr<Subscription> subscription;
+  std::vector<int> &v;
+
+public:
+  TakeObserver(int limit, std::vector<int> &v) : limit(limit), v(v) {
+    v.reserve(5);
+  }
+
+  void onSubscribe(std::unique_ptr<Subscription> s) override {
+    subscription = std::move(s);
+  }
+  void onNext(const int &value) override {
+    v.push_back(value);
+    if (++count >= limit) {
+      //      std::cout << "Cancelling subscription after receiving " << count
+      //                << " items." << std::endl;
+      subscription->cancel();
+    }
+  }
+  void onError(const std::exception &e) override {}
+  void onComplete() override {}
+};
+
+// assert behavior of onComplete after subscription.cancel
+TEST(Observable, SubscriptionCancellation) {
+  static std::atomic_int emitted{0};
+  auto a = Observable<int>::create([](std::unique_ptr<Observer<int>> obs) {
+    std::atomic_bool isUnsubscribed{false};
+    obs->onSubscribe(Subscription::create(isUnsubscribed));
+    int i = 0;
+    while (!isUnsubscribed && i <= 10) {
+      emitted++;
+      obs->onNext(i++);
+    }
+    if (!isUnsubscribed) {
+      obs->onComplete();
+    }
+  });
+
+  std::vector<int> v;
+  a->subscribe(std::make_unique<TakeObserver>(2, v));
+  EXPECT_EQ((unsigned long)2, v.size());
+  EXPECT_EQ(2, emitted);
+}

--- a/experimental/yarpl/test/Subscription_test.cpp
+++ b/experimental/yarpl/test/Subscription_test.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <yarpl/Observable.h>
+
+using namespace yarpl::observable;
+
+TEST(Subscription, SubscriptionOnCancelInvocation) {
+  bool onCancelInvoked = false;
+  auto s = Subscription::create([&onCancelInvoked]() {
+    std::cout << "onCancel function invoked" << std::endl;
+    onCancelInvoked = true;
+  });
+  EXPECT_EQ(false, s->isCanceled());
+  EXPECT_EQ(false, onCancelInvoked);
+  s->cancel();
+  // onCancel should have been invoked
+  EXPECT_EQ(true, s->isCanceled());
+  EXPECT_EQ(true, onCancelInvoked);
+  // reset
+  onCancelInvoked = false;
+  // try canceling again
+  s->cancel();
+  // the onCancel function should not have been invoked again
+  EXPECT_EQ(false, onCancelInvoked);
+}

--- a/experimental/yarpl/test/yarpl-tests.cpp
+++ b/experimental/yarpl/test/yarpl-tests.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Bootstrap the development of Observable and Flowable types for use with ReactiveSocket. Currently placed in /experimental/yarpl. 

- We want to change some of the signatures before proceeding any further @vjn and I are going to followup with changes soon
- benchmark code is left in place, but building is disabled for now
- name can change from yarpl at some point ... just needed a name (Yet Another Reactive Programming Library)
- will eventually move from this experimental home if it proves useful