### PR TITLE
RSocket API and Examples v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,8 @@ add_library(
         experimental/rsocket-src/RSocketServer.cpp
         experimental/rsocket/RSocketClient.h
         experimental/rsocket-src/RSocketClient.cpp
+        experimental/rsocket/RSocketRequester.h
+        experimental/rsocket-src/RSocketRequester.cpp
         experimental/rsocket/RSocketErrors.h
         experimental/rsocket/ConnectionAcceptor.h
         experimental/rsocket/ConnectionFactory.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,4 +346,128 @@ add_dependencies(tcpresumeserver gmock)
 
 #add_subdirectory(experimental/yarpl)
 
+########################################
+# Examples
+########################################
+
+add_library(
+        reactivesocket_examples_util
+        examples/util/ExampleSubscriber.cpp
+        examples/util/ExampleSubscriber.h
+)
+
+add_library(
+        rsocket_experimental
+        experimental/rsocket/RSocket.h
+        experimental/rsocket-src/RSocket.cpp
+        experimental/rsocket/RSocketServer.h
+        experimental/rsocket-src/RSocketServer.cpp
+        experimental/rsocket/RSocketClient.h
+        experimental/rsocket-src/RSocketClient.cpp
+        experimental/rsocket/RSocketErrors.h
+        experimental/rsocket/ConnectionAcceptor.h
+        experimental/rsocket/ConnectionFactory.h
+        experimental/rsocket/ConnectionSetupRequest.h
+        experimental/rsocket-src/ConnectionSetupRequest.cpp
+        experimental/rsocket/ConnectionResumeRequest.h
+        experimental/rsocket-src/ConnectionResumeRequest.cpp
+        experimental/rsocket/transports/TcpConnectionAcceptor.h
+        experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
+        experimental/rsocket/transports/TcpConnectionFactory.h
+        experimental/rsocket-src/transports/TcpConnectionFactory.cpp
+        )
+
+add_dependencies(rsocket_experimental ReactiveStreams)
+
+# include the experimental includes for usage
+ target_include_directories(rsocket_experimental PUBLIC "${PROJECT_SOURCE_DIR}/experimental")
+#include_directories(${CMAKE_CURRENT_BINARY_DIR}/experimental)
+
+
+target_link_libraries(
+        reactivesocket_examples_util
+        rsocket_experimental
+        ReactiveSocket
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# stream-hello-world
+
+add_executable(
+        example_stream-hello-world-server
+        examples/stream-hello-world/StreamHelloWorld_Server.cpp
+        examples/stream-hello-world/HelloStreamSubscription.cpp
+        examples/stream-hello-world/HelloStreamSubscription.h
+        examples/stream-hello-world/HelloStreamRequestHandler.cpp
+        examples/stream-hello-world/HelloStreamRequestHandler.h)
+
+target_link_libraries(
+        example_stream-hello-world-server
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(
+        example_stream-hello-world-client
+        examples/stream-hello-world/StreamHelloWorld_Client.cpp
+)
+
+target_link_libraries(
+        example_stream-hello-world-client
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+# conditional-request-handling
+
+add_executable(
+        example_conditional-request-handling-server
+        examples/conditional-request-handling/ConditionalRequestHandling_Server.cpp
+        examples/conditional-request-handling/TextRequestHandler.h
+        examples/conditional-request-handling/TextRequestHandler.cpp
+        examples/conditional-request-handling/ConditionalRequestSubscription.h
+        examples/conditional-request-handling/ConditionalRequestSubscription.cpp
+        examples/conditional-request-handling/JsonRequestHandler.cpp examples/conditional-request-handling/JsonRequestHandler.h)
+
+target_link_libraries(
+        example_conditional-request-handling-server
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(
+        example_conditional-request-handling-client
+        examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+)
+
+target_link_libraries(
+        example_conditional-request-handling-client
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+
+########################################
+# End Examples
+########################################
+
 # EOF

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+Folder containing example usage of reactivesocket-cpp
+
+Currently being used to explore API design as well while building the various examples.

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -21,22 +21,19 @@ int main(int argc, char* argv[]) {
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 
-  auto s = std::make_shared<ExampleSubscriber>(5, 6);
   auto rsf = RSocket::createClient(
       TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
+  auto rs = rsf->connect().get();
 
-  rsf->connect().then([s](std::shared_ptr<StandardReactiveSocket> rs) {
-      // TODO create the RSocket APIs instead of StandardReactiveSocket
-    rs->requestStream(Payload("Bob"), s);
-  });
-  s->awaitTerminalEvent();
+  LOG(INFO) << "------------------ Hello Bob!";
+  auto s1 = std::make_shared<ExampleSubscriber>(5, 6);
+  rs->requestStream(Payload("Bob"), s1);
+  s1->awaitTerminalEvent();
 
-  //  auto rs = rsf->connect().get();
-  //  rs->requestStream(Payload("Bob"), s);
-  //  s->awaitTerminalEvent();
-
-  //  std::string name;
-  //  std::getline(std::cin, name);
+  LOG(INFO) << "------------------ Hello Jane!";
+  auto s2 = std::make_shared<ExampleSubscriber>(5, 6);
+  rs->requestStream(Payload("Jane"), s2);
+  s2->awaitTerminalEvent();
 
   return 0;
 }

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -1,0 +1,42 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <iostream>
+#include "examples/util/ExampleSubscriber.h"
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionFactory.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+using namespace ::rsocket_example;
+using namespace ::rsocket;
+
+DEFINE_string(host, "localhost", "host to connect to");
+DEFINE_int32(port, 9898, "host:port to connect to");
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  auto s = std::make_shared<ExampleSubscriber>(5, 6);
+  auto rsf = RSocket::createClient(
+      TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
+
+  rsf->connect().then([s](std::shared_ptr<StandardReactiveSocket> rs) {
+      // TODO create the RSocket APIs instead of StandardReactiveSocket
+    rs->requestStream(Payload("Bob"), s);
+  });
+  s->awaitTerminalEvent();
+
+  //  auto rs = rsf->connect().get();
+  //  rs->requestStream(Payload("Bob"), s);
+  //  s->awaitTerminalEvent();
+
+  //  std::string name;
+  //  std::getline(std::cin, name);
+
+  return 0;
+}

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -35,5 +35,7 @@ int main(int argc, char* argv[]) {
   rs->requestStream(Payload("Jane"), s2);
   s2->awaitTerminalEvent();
 
+  // TODO on shutdown the destruction of
+  // ScopedEventBaseThread spits out a stacktrace
   return 0;
 }

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Server.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Server.cpp
@@ -1,0 +1,45 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include "JsonRequestHandler.h"
+#include "TextRequestHandler.h"
+#include "rsocket/RSocket.h"
+#include "rsocket/RSocketErrors.h"
+#include "rsocket/transports/TcpConnectionAcceptor.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+using namespace ::rsocket;
+
+DEFINE_int32(port, 9898, "port to connect to");
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(TcpConnectionAcceptor::create(FLAGS_port));
+  // global request handlers
+  auto textHandler = std::make_shared<TextRequestHandler>();
+  auto jsonHandler = std::make_shared<JsonRequestHandler>();
+  // start accepting connections
+  rs->startAndPark(
+      [textHandler, jsonHandler](std::unique_ptr<ConnectionSetupRequest> r)
+          -> std::shared_ptr<RequestHandler> {
+            if (r->getDataMimeType() == "text/plain") {
+              LOG(INFO) << "Connection Request => text/plain MimeType";
+              return textHandler;
+            } else if (r->getDataMimeType() == "application/json") {
+              LOG(INFO) << "Connection Request => application/json MimeType";
+              return jsonHandler;
+            } else {
+              LOG(INFO) << "Connection Request => Unsupported MimeType"
+                        << r->getDataMimeType();
+              throw UnsupportedSetupError("Unknown MimeType");
+            }
+          });
+}

--- a/examples/conditional-request-handling/ConditionalRequestSubscription.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestSubscription.cpp
@@ -1,0 +1,47 @@
+
+#include "ConditionalRequestSubscription.h"
+#include <string>
+
+namespace reactivesocket {
+
+// Emit a stream of ints starting at 0 until number of ints
+// emitted matches 'numberToEmit' at which point onComplete()
+// will be emitted.
+//
+// On each invocation will restrict emission to number of requested.
+//
+// This method has no concurrency since SubscriptionBase
+// schedules this on an Executor sequentially
+void ConditionalRequestSubscription::requestImpl(size_t n) noexcept {
+  LOG(INFO) << "requested=" << n << " currentElem=" << currentElem_
+            << " numberToEmit=" << numberToEmit_;
+
+  if (numberToEmit_ == 0) {
+    subscriber_->onComplete();
+    return;
+  }
+  for (size_t i = 0; i < n; i++) {
+    if (cancelled_) {
+      LOG(INFO) << "emission stopped by cancellation";
+      return;
+    }
+    std::stringstream ss;
+    ss << "Hello " << name_ << " " << currentElem_ << "!";
+    std::string s = ss.str();
+    subscriber_->onNext(Payload(s));
+    // currentElem is used to track progress across requestImpl invocations
+    currentElem_++;
+    // break the loop and complete the stream if numberToEmit_ is matched
+    if (currentElem_ == numberToEmit_) {
+      subscriber_->onComplete();
+      return;
+    }
+  }
+}
+
+void ConditionalRequestSubscription::cancelImpl() noexcept {
+  LOG(INFO) << "cancellation received";
+  // simple cancellation token (nothing to shut down, just stop next loop)
+  cancelled_ = true;
+}
+}

--- a/examples/conditional-request-handling/ConditionalRequestSubscription.h
+++ b/examples/conditional-request-handling/ConditionalRequestSubscription.h
@@ -1,0 +1,36 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+#include "src/DuplexConnection.h"
+#include "src/Payload.h"
+#include "src/SubscriptionBase.h"
+
+namespace reactivesocket {
+
+/// Emits a stream of ints
+class ConditionalRequestSubscription : public SubscriptionBase {
+ public:
+  explicit ConditionalRequestSubscription(
+      std::shared_ptr<Subscriber<Payload>> subscriber,
+      std::string name,
+      size_t numberToEmit = 2)
+      : ExecutorBase(defaultExecutor()),
+        subscriber_(std::move(subscriber)),
+        name_(std::move(name)),
+        numberToEmit_(numberToEmit),
+        cancelled_(false) {}
+
+ private:
+  // Subscription methods
+  void requestImpl(size_t n) noexcept override;
+  void cancelImpl() noexcept override;
+
+  std::shared_ptr<Subscriber<Payload>> subscriber_;
+  std::string name_;
+  size_t numberToEmit_;
+  size_t currentElem_ = 0;
+  std::atomic_bool cancelled_;
+};
+}

--- a/examples/conditional-request-handling/JsonRequestHandler.cpp
+++ b/examples/conditional-request-handling/JsonRequestHandler.cpp
@@ -1,0 +1,30 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "JsonRequestHandler.h"
+#include <string>
+#include "ConditionalRequestSubscription.h"
+
+using namespace ::reactivesocket;
+
+/// Handles a new inbound Stream requested by the other end.
+void JsonRequestHandler::handleRequestStream(
+    Payload request,
+    StreamId streamId,
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
+  LOG(INFO) << "JsonRequestHandler.handleRequestStream " << request;
+
+  // string from payload data
+  const char* p = reinterpret_cast<const char*>(request.data->data());
+  auto requestString = std::string(p, request.data->length());
+
+  response->onSubscribe(std::make_shared<ConditionalRequestSubscription>(
+      response, requestString, 10));
+}
+
+std::shared_ptr<StreamState> JsonRequestHandler::handleSetupPayload(
+    ReactiveSocket& socket,
+    ConnectionSetupPayload request) noexcept {
+  LOG(INFO) << "JsonRequestHandler.handleSetupPayload " << request;
+  // TODO what should this do?
+  return nullptr;
+}

--- a/examples/conditional-request-handling/JsonRequestHandler.h
+++ b/examples/conditional-request-handling/JsonRequestHandler.h
@@ -1,0 +1,25 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/ExceptionWrapper.h>
+#include "src/StandardReactiveSocket.h"
+#include "src/SubscriptionBase.h"
+#include "src/NullRequestHandler.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+
+using namespace ::reactivesocket;
+
+class JsonRequestHandler : public DefaultRequestHandler {
+public:
+    /// Handles a new inbound Stream requested by the other end.
+    void handleRequestStream(
+            Payload request,
+            StreamId streamId,
+            const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
+
+    std::shared_ptr<StreamState> handleSetupPayload(
+            ReactiveSocket&,
+            ConnectionSetupPayload request) noexcept override;
+};

--- a/examples/conditional-request-handling/README.md
+++ b/examples/conditional-request-handling/README.md
@@ -1,0 +1,26 @@
+# Example: conditional-request-subscription
+
+A basic TCP client/server relationship that streams a sequence of strings using ReactiveSocket `requestStream`.
+
+CMake targets:
+
+- Server: example_conditional-request-handling-server
+- Client: example_conditional-request-handling-client
+
+Server:
+
+```cpp
+
+```
+
+Client:
+
+```cpp
+
+```
+
+Output:
+
+```
+
+```

--- a/examples/conditional-request-handling/README.md
+++ b/examples/conditional-request-handling/README.md
@@ -1,6 +1,6 @@
 # Example: conditional-request-subscription
 
-A basic TCP client/server relationship that streams a sequence of strings using ReactiveSocket `requestStream`.
+Example server that uses the connection SETUP data (MimeType in this example) to determine which request handler to use. 
 
 CMake targets:
 
@@ -10,17 +10,27 @@ CMake targets:
 Server:
 
 ```cpp
-
+// RSocket server accepting on TCP
+auto rs = RSocket::createServer(TcpConnectionAcceptor::create(FLAGS_port));
+// global request handlers
+auto textHandler = std::make_shared<TextRequestHandler>();
+auto jsonHandler = std::make_shared<JsonRequestHandler>();
+// start accepting connections
+rs->startAndPark(
+  [textHandler, jsonHandler](std::unique_ptr<ConnectionSetupRequest> r)
+      -> std::shared_ptr<RequestHandler> {
+        if (r->getDataMimeType() == "text/plain") {
+          return textHandler;
+        } else if (r->getDataMimeType() == "application/json") {
+          return jsonHandler;
+        } else {
+          throw UnsupportedSetupError("Unknown MimeType");
+        }
+      });
 ```
 
 Client:
 
 ```cpp
-
-```
-
-Output:
-
-```
-
+// TODO not yet passing in MimeType
 ```

--- a/examples/conditional-request-handling/TextRequestHandler.cpp
+++ b/examples/conditional-request-handling/TextRequestHandler.cpp
@@ -1,0 +1,30 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "TextRequestHandler.h"
+#include <string>
+#include "ConditionalRequestSubscription.h"
+
+using namespace ::reactivesocket;
+
+/// Handles a new inbound Stream requested by the other end.
+void TextRequestHandler::handleRequestStream(
+    Payload request,
+    StreamId streamId,
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
+  LOG(INFO) << "TextRequestHandler.handleRequestStream " << request;
+
+  // string from payload data
+  const char* p = reinterpret_cast<const char*>(request.data->data());
+  auto requestString = std::string(p, request.data->length());
+
+  response->onSubscribe(
+      std::make_shared<ConditionalRequestSubscription>(response, requestString, 10));
+}
+
+std::shared_ptr<StreamState> TextRequestHandler::handleSetupPayload(
+    ReactiveSocket& socket,
+    ConnectionSetupPayload request) noexcept {
+  LOG(INFO) << "TextRequestHandler.handleSetupPayload " << request;
+  // TODO what should this do?
+  return nullptr;
+}

--- a/examples/conditional-request-handling/TextRequestHandler.h
+++ b/examples/conditional-request-handling/TextRequestHandler.h
@@ -1,0 +1,25 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/ExceptionWrapper.h>
+#include "src/StandardReactiveSocket.h"
+#include "src/SubscriptionBase.h"
+#include "src/NullRequestHandler.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+
+using namespace ::reactivesocket;
+
+class TextRequestHandler : public DefaultRequestHandler {
+public:
+    /// Handles a new inbound Stream requested by the other end.
+    void handleRequestStream(
+            Payload request,
+            StreamId streamId,
+            const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
+
+    std::shared_ptr<StreamState> handleSetupPayload(
+            ReactiveSocket&,
+            ConnectionSetupPayload request) noexcept override;
+};

--- a/examples/stream-hello-world/HelloStreamRequestHandler.cpp
+++ b/examples/stream-hello-world/HelloStreamRequestHandler.cpp
@@ -1,0 +1,30 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "HelloStreamRequestHandler.h"
+#include <string>
+#include "HelloStreamSubscription.h"
+
+using namespace ::reactivesocket;
+
+/// Handles a new inbound Stream requested by the other end.
+void HelloStreamRequestHandler::handleRequestStream(
+    Payload request,
+    StreamId streamId,
+    const std::shared_ptr<Subscriber<Payload>>& response) noexcept {
+  LOG(INFO) << "HelloStreamRequestHandler.handleRequestStream " << request;
+
+  // string from payload data
+  const char* p = reinterpret_cast<const char*>(request.data->data());
+  auto requestString = std::string(p, request.data->length());
+
+  response->onSubscribe(
+      std::make_shared<HelloStreamSubscription>(response, requestString, 10));
+}
+
+std::shared_ptr<StreamState> HelloStreamRequestHandler::handleSetupPayload(
+    ReactiveSocket& socket,
+    ConnectionSetupPayload request) noexcept {
+  LOG(INFO) << "HelloStreamRequestHandler.handleSetupPayload " << request;
+  // TODO what should this do?
+  return nullptr;
+}

--- a/examples/stream-hello-world/HelloStreamRequestHandler.h
+++ b/examples/stream-hello-world/HelloStreamRequestHandler.h
@@ -1,0 +1,25 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/ExceptionWrapper.h>
+#include "src/StandardReactiveSocket.h"
+#include "src/SubscriptionBase.h"
+#include "src/NullRequestHandler.h"
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+
+using namespace ::reactivesocket;
+
+class HelloStreamRequestHandler : public DefaultRequestHandler {
+public:
+    /// Handles a new inbound Stream requested by the other end.
+    void handleRequestStream(
+            Payload request,
+            StreamId streamId,
+            const std::shared_ptr<Subscriber<Payload>>& response) noexcept override;
+
+    std::shared_ptr<StreamState> handleSetupPayload(
+            ReactiveSocket&,
+            ConnectionSetupPayload request) noexcept override;
+};

--- a/examples/stream-hello-world/HelloStreamSubscription.cpp
+++ b/examples/stream-hello-world/HelloStreamSubscription.cpp
@@ -1,0 +1,47 @@
+
+#include "HelloStreamSubscription.h"
+#include <string>
+
+namespace reactivesocket {
+
+// Emit a stream of ints starting at 0 until number of ints
+// emitted matches 'numberToEmit' at which point onComplete()
+// will be emitted.
+//
+// On each invocation will restrict emission to number of requested.
+//
+// This method has no concurrency since SubscriptionBase
+// schedules this on an Executor sequentially
+void HelloStreamSubscription::requestImpl(size_t n) noexcept {
+  LOG(INFO) << "requested=" << n << " currentElem=" << currentElem_
+            << " numberToEmit=" << numberToEmit_;
+
+  if (numberToEmit_ == 0) {
+    subscriber_->onComplete();
+    return;
+  }
+  for (size_t i = 0; i < n; i++) {
+    if (cancelled_) {
+      LOG(INFO) << "emission stopped by cancellation";
+      return;
+    }
+    std::stringstream ss;
+    ss << "Hello " << name_ << " " << currentElem_ << "!";
+    std::string s = ss.str();
+    subscriber_->onNext(Payload(s));
+    // currentElem is used to track progress across requestImpl invocations
+    currentElem_++;
+    // break the loop and complete the stream if numberToEmit_ is matched
+    if (currentElem_ == numberToEmit_) {
+      subscriber_->onComplete();
+      return;
+    }
+  }
+}
+
+void HelloStreamSubscription::cancelImpl() noexcept {
+  LOG(INFO) << "cancellation received";
+  // simple cancellation token (nothing to shut down, just stop next loop)
+  cancelled_ = true;
+}
+}

--- a/examples/stream-hello-world/HelloStreamSubscription.h
+++ b/examples/stream-hello-world/HelloStreamSubscription.h
@@ -1,0 +1,36 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+#include "src/DuplexConnection.h"
+#include "src/Payload.h"
+#include "src/SubscriptionBase.h"
+
+namespace reactivesocket {
+
+/// Emits a stream of ints
+class HelloStreamSubscription : public SubscriptionBase {
+ public:
+  explicit HelloStreamSubscription(
+      std::shared_ptr<Subscriber<Payload>> subscriber,
+      std::string name,
+      size_t numberToEmit = 2)
+      : ExecutorBase(defaultExecutor()),
+        subscriber_(std::move(subscriber)),
+        name_(std::move(name)),
+        numberToEmit_(numberToEmit),
+        cancelled_(false) {}
+
+ private:
+  // Subscription methods
+  void requestImpl(size_t n) noexcept override;
+  void cancelImpl() noexcept override;
+
+  std::shared_ptr<Subscriber<Payload>> subscriber_;
+  std::string name_;
+  size_t numberToEmit_;
+  size_t currentElem_ = 0;
+  std::atomic_bool cancelled_;
+};
+}

--- a/examples/stream-hello-world/README.md
+++ b/examples/stream-hello-world/README.md
@@ -15,45 +15,14 @@ Server:
   // global request handler
   auto handler = std::make_shared<HelloStreamRequestHandler>();
   // start accepting connections
-  rs->start([handler](auto connectionRequest) { return handler; });
+  rs->startAndPark([handler](auto r) { return handler; });
 ```
 
 Client:
 
 ```cpp
-  ScopedEventBaseThread eventBaseThread;
-  auto rsf = RSocket::createClient(
-      TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
-  rsf->connect(eventBaseThread)
-      .then([](std::shared_ptr<StandardReactiveSocket> rs) {
-        rs->requestStream(
-            Payload("args-here"), std::make_shared<ExampleSubscriber>(5, 6));
-      });
-```
-
-Output:
-
-```
-TcpConnectionFactory.cpp:56] ConnectionFactory creation => host: localhost port: 9898
-RSocketClient.cpp:13] RSocketClient => created
-RSocketClient.cpp:18] RSocketClient => start connection with Future
-TcpConnectionFactory.cpp:22] ConnectionFactory => starting socket
-TcpConnectionFactory.cpp:25] ConnectionFactory => attempting connection to [::1]:9898
-TcpConnectionFactory.cpp:30] ConnectionFactory  => DONE connect
-TcpConnectionFactory.cpp:35] ConnectionFactory => socketCallback => Success
-RSocketClient.cpp:26] RSocketClient => onConnect received DuplexConnection
-ExampleSubscriber.cpp:18] ExampleSubscriber 0x7f9cd1f00eb8 created with =>   Initial Request: 5  Threshold for re-request: 3  Num to Take: 6
-ExampleSubscriber.cpp:26] ExampleSubscriber 0x7f9cd1f00eb8 onSubscribe
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 0!
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 1!
-ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 2!
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 3!
-ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 4!
-ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 5!
-ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
-ExampleSubscriber.cpp:44] ExampleSubscriber 0x7f9cd1f00eb8 cancelling after receiving 6 items.
-ExampleSubscriber.cpp:51] ExampleSubscriber 0x7f9cd1f00eb8 onComplete
-ExampleSubscriber.cpp:10] ExampleSubscriber destroy 0x7f9cd1f00eb8
+auto rsf = RSocket::createClient(TcpConnectionFactory::create(host, port));
+auto s = std::make_shared<ExampleSubscriber>(5, 6);
+auto rs = rsf->connect().get();
+rs->requestStream(Payload("Jane"), s);
 ```

--- a/examples/stream-hello-world/README.md
+++ b/examples/stream-hello-world/README.md
@@ -1,0 +1,59 @@
+# Example: stream-hello-world
+
+A basic TCP client/server relationship that streams a sequence of strings using ReactiveSocket `requestStream`.
+
+CMake targets:
+
+- Server: example_stream-hello-world-server
+- Client: example_stream-hello-world-client
+
+Server:
+
+```cpp
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(TcpConnectionAcceptor::create(FLAGS_port));
+  // global request handler
+  auto handler = std::make_shared<HelloStreamRequestHandler>();
+  // start accepting connections
+  rs->start([handler](auto connectionRequest) { return handler; });
+```
+
+Client:
+
+```cpp
+  ScopedEventBaseThread eventBaseThread;
+  auto rsf = RSocket::createClient(
+      TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
+  rsf->connect(eventBaseThread)
+      .then([](std::shared_ptr<StandardReactiveSocket> rs) {
+        rs->requestStream(
+            Payload("args-here"), std::make_shared<ExampleSubscriber>(5, 6));
+      });
+```
+
+Output:
+
+```
+TcpConnectionFactory.cpp:56] ConnectionFactory creation => host: localhost port: 9898
+RSocketClient.cpp:13] RSocketClient => created
+RSocketClient.cpp:18] RSocketClient => start connection with Future
+TcpConnectionFactory.cpp:22] ConnectionFactory => starting socket
+TcpConnectionFactory.cpp:25] ConnectionFactory => attempting connection to [::1]:9898
+TcpConnectionFactory.cpp:30] ConnectionFactory  => DONE connect
+TcpConnectionFactory.cpp:35] ConnectionFactory => socketCallback => Success
+RSocketClient.cpp:26] RSocketClient => onConnect received DuplexConnection
+ExampleSubscriber.cpp:18] ExampleSubscriber 0x7f9cd1f00eb8 created with =>   Initial Request: 5  Threshold for re-request: 3  Num to Take: 6
+ExampleSubscriber.cpp:26] ExampleSubscriber 0x7f9cd1f00eb8 onSubscribe
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 0!
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 1!
+ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 2!
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 3!
+ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 4!
+ExampleSubscriber.cpp:33] ExampleSubscriber 0x7f9cd1f00eb8 onNext as string: Hello Bob 5!
+ExampleSubscriber.cpp:38] ExampleSubscriber 0x7f9cd1f00eb8 requesting 2 more items
+ExampleSubscriber.cpp:44] ExampleSubscriber 0x7f9cd1f00eb8 cancelling after receiving 6 items.
+ExampleSubscriber.cpp:51] ExampleSubscriber 0x7f9cd1f00eb8 onComplete
+ExampleSubscriber.cpp:10] ExampleSubscriber destroy 0x7f9cd1f00eb8
+```

--- a/examples/stream-hello-world/StreamHelloWorld_Client.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Client.cpp
@@ -21,10 +21,12 @@ int main(int argc, char* argv[]) {
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 
+  // create a client which can then make connections below
   auto rsf = RSocket::createClient(
       TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
 
   {
+    // this example runs inside the Future.then lambda
     LOG(INFO) << "------------------ Run in future.then";
     auto s = std::make_shared<ExampleSubscriber>(5, 6);
     rsf->connect().then([s](std::shared_ptr<RSocketRequester> rs) {
@@ -34,6 +36,7 @@ int main(int argc, char* argv[]) {
   }
 
   {
+    // this example extracts from the Future.get and runs in the main thread
     LOG(INFO) << "------------------ Run after future.get";
     auto s = std::make_shared<ExampleSubscriber>(5, 6);
     auto rs = rsf->connect().get();
@@ -41,5 +44,8 @@ int main(int argc, char* argv[]) {
     s->awaitTerminalEvent();
   }
   LOG(INFO) << "------------- main() terminating -----------------";
+
+  // TODO on shutdown the destruction of
+  // ScopedEventBaseThread spits out a stacktrace
   return 0;
 }

--- a/examples/stream-hello-world/StreamHelloWorld_Client.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Client.cpp
@@ -1,0 +1,41 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <iostream>
+#include "examples/util/ExampleSubscriber.h"
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionFactory.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+using namespace ::rsocket_example;
+using namespace ::rsocket;
+
+DEFINE_string(host, "localhost", "host to connect to");
+DEFINE_int32(port, 9898, "host:port to connect to");
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  auto rsf = RSocket::createClient(
+      TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
+  rsf->connect().then([](std::shared_ptr<StandardReactiveSocket> rs) {
+    rs->requestStream(
+        Payload("Bob"), std::make_shared<ExampleSubscriber>(5, 6));
+  });
+
+  // TODO the following should work, but has eventbase issues (rs should use the
+  // correct one)
+  //  auto rs = rsf->connect().get();
+  //  rs->requestStream(
+  //      Payload("args-here"), std::make_shared<ExampleSubscriber>(5, 6));
+
+  std::string name;
+  std::getline(std::cin, name);
+
+  return 0;
+}

--- a/examples/stream-hello-world/StreamHelloWorld_Server.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Server.cpp
@@ -1,0 +1,28 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include "HelloStreamRequestHandler.h"
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionAcceptor.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+using namespace ::rsocket;
+
+DEFINE_int32(port, 9898, "port to connect to");
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(TcpConnectionAcceptor::create(FLAGS_port));
+  // global request handler
+  auto handler = std::make_shared<HelloStreamRequestHandler>();
+  // start accepting connections
+  rs->startAndPark([handler](auto r) { return handler; });
+}

--- a/examples/util/ExampleSubscriber.cpp
+++ b/examples/util/ExampleSubscriber.cpp
@@ -1,0 +1,68 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "examples/util/ExampleSubscriber.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket_example {
+
+ExampleSubscriber::~ExampleSubscriber() {
+  LOG(INFO) << "ExampleSubscriber destroy " << this;
+}
+
+ExampleSubscriber::ExampleSubscriber(int initialRequest, int numToTake)
+    : initialRequest(initialRequest),
+      thresholdForRequest(initialRequest * 0.75),
+      numToTake(numToTake),
+      received(0) {
+  LOG(INFO) << "ExampleSubscriber " << this << " created with => "
+            << "  Initial Request: " << initialRequest
+            << "  Threshold for re-request: " << thresholdForRequest
+            << "  Num to Take: " << numToTake;
+}
+
+void ExampleSubscriber::onSubscribe(
+    std::shared_ptr<Subscription> subscription) noexcept {
+  LOG(INFO) << "ExampleSubscriber " << this << " onSubscribe";
+  subscription_ = std::move(subscription);
+  requested = initialRequest;
+  subscription_->request(initialRequest);
+}
+
+void ExampleSubscriber::onNext(Payload element) noexcept {
+  LOG(INFO) << "ExampleSubscriber " << this
+            << " onNext as string: " << element.moveDataToString();
+  received++;
+  if (--requested == thresholdForRequest) {
+    int toRequest = (initialRequest - thresholdForRequest);
+    LOG(INFO) << "ExampleSubscriber " << this << " requesting " << toRequest
+              << " more items";
+    requested += toRequest;
+    subscription_->request(toRequest);
+  };
+  if (received == numToTake) {
+    LOG(INFO) << "ExampleSubscriber " << this << " cancelling after receiving "
+              << received << " items.";
+    subscription_->cancel();
+  }
+}
+
+void ExampleSubscriber::onComplete() noexcept {
+  LOG(INFO) << "ExampleSubscriber " << this << " onComplete";
+  terminated = true;
+  terminalEventCV_.notify_all();
+}
+
+void ExampleSubscriber::onError(folly::exception_wrapper ex) noexcept {
+  LOG(INFO) << "ExampleSubscriber " << this << " onError " << ex.what();
+  terminated = true;
+  terminalEventCV_.notify_all();
+}
+
+void ExampleSubscriber::awaitTerminalEvent() {
+  // now block this thread
+  std::unique_lock<std::mutex> lk(m);
+  // if shutdown gets implemented this would then be released by it
+  terminalEventCV_.wait(lk, [this] { return terminated; });
+}
+}

--- a/examples/util/ExampleSubscriber.cpp
+++ b/examples/util/ExampleSubscriber.cpp
@@ -60,9 +60,11 @@ void ExampleSubscriber::onError(folly::exception_wrapper ex) noexcept {
 }
 
 void ExampleSubscriber::awaitTerminalEvent() {
+  LOG(INFO) << "ExampleSubscriber " << this << " block thread";
   // now block this thread
   std::unique_lock<std::mutex> lk(m);
   // if shutdown gets implemented this would then be released by it
   terminalEventCV_.wait(lk, [this] { return terminated; });
+  LOG(INFO) << "ExampleSubscriber " << this << " unblocked";
 }
 }

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <mutex>
+#include <condition_variable>
 #include <folly/ExceptionWrapper.h>
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -1,0 +1,41 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <mutex>
+#include <folly/ExceptionWrapper.h>
+#include "src/Payload.h"
+#include "src/ReactiveStreamsCompat.h"
+
+using namespace ::reactivesocket;
+
+/**
+ * Subscriber that logs all events.
+ * Request 5 items to begin with, then 3 more after each receipt of 3.
+ */
+namespace rsocket_example {
+class ExampleSubscriber : public Subscriber<Payload> {
+ public:
+  ~ExampleSubscriber();
+  ExampleSubscriber(int initialRequest, int numToTake);
+
+  void onSubscribe(
+      std::shared_ptr<Subscription> subscription) noexcept override;
+  void onNext(Payload element) noexcept override;
+  void onComplete() noexcept override;
+  void onError(folly::exception_wrapper ex) noexcept override;
+
+  void awaitTerminalEvent();
+
+ private:
+  int initialRequest;
+  int thresholdForRequest;
+  int numToTake;
+  int requested;
+  int received;
+  std::shared_ptr<Subscription> subscription_;
+  bool terminated{false};
+  std::mutex m;
+  std::condition_variable terminalEventCV_;
+};
+}

--- a/examples/util/README.md
+++ b/examples/util/README.md
@@ -1,0 +1,3 @@
+Common files for the various examples.
+
+Right now also a location for experimental API design.

--- a/experimental/rsocket-src/ConnectionResumeRequest.cpp
+++ b/experimental/rsocket-src/ConnectionResumeRequest.cpp
@@ -1,0 +1,9 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "rsocket/ConnectionResumeRequest.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+}

--- a/experimental/rsocket-src/ConnectionSetupRequest.cpp
+++ b/experimental/rsocket-src/ConnectionSetupRequest.cpp
@@ -1,0 +1,33 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "rsocket/ConnectionSetupRequest.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+ConnectionSetupRequest::ConnectionSetupRequest(
+    ConnectionSetupPayload setupPayload)
+    : setupPayload_(std::move(setupPayload)) {}
+
+std::string& ConnectionSetupRequest::getMetadataMimeType() {
+  return setupPayload_.metadataMimeType;
+}
+std::string& ConnectionSetupRequest::getDataMimeType() {
+  return setupPayload_.dataMimeType;
+}
+Payload& ConnectionSetupRequest::getPayload() {
+  return setupPayload_.payload;
+}
+bool ConnectionSetupRequest::clientRequestsResumability() {
+  return setupPayload_.resumable;
+}
+ResumeIdentificationToken&
+ConnectionSetupRequest::getResumeIdentificationToken() {
+  return setupPayload_.token;
+}
+bool ConnectionSetupRequest::willHonorLease() {
+  // TODO not implemented yet in ConnectionSetupPayload
+  return false;
+}
+}

--- a/experimental/rsocket-src/RSocket.cpp
+++ b/experimental/rsocket-src/RSocket.cpp
@@ -1,0 +1,18 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "rsocket/RSocket.h"
+#include <src/NullRequestHandler.h>
+#include "src/folly/FollyKeepaliveTimer.h"
+
+namespace rsocket {
+
+std::unique_ptr<RSocketClient> RSocket::createClient(
+    std::unique_ptr<ConnectionFactory> connectionFactory) {
+  return std::make_unique<RSocketClient>(std::move(connectionFactory));
+}
+
+std::unique_ptr<RSocketServer> RSocket::createServer(
+    std::unique_ptr<ConnectionAcceptor> connectionAcceptor) {
+  return std::make_unique<RSocketServer>(std::move(connectionAcceptor));
+}
+}

--- a/experimental/rsocket-src/RSocketClient.cpp
+++ b/experimental/rsocket-src/RSocketClient.cpp
@@ -1,0 +1,49 @@
+#include "rsocket/RSocketClient.h"
+#include "src/NullRequestHandler.h"
+#include "src/StandardReactiveSocket.h"
+#include "src/folly/FollyKeepaliveTimer.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+RSocketClient::RSocketClient(std::unique_ptr<ConnectionFactory> connection)
+    : lazyConnection(std::move(connection)) {
+  LOG(INFO) << "RSocketClient => created";
+}
+// TODO make unique_ptr
+Future<std::shared_ptr<StandardReactiveSocket>> RSocketClient::connect() {
+  LOG(INFO) << "RSocketClient => start connection with Future";
+
+  auto promise =
+      std::make_shared<Promise<std::shared_ptr<StandardReactiveSocket>>>();
+
+  lazyConnection->connect([this, promise](
+      std::unique_ptr<DuplexConnection> framedConnection,
+      EventBase& eventBase) {
+    LOG(INFO) << "RSocketClient => onConnect received DuplexConnection";
+
+    rs = StandardReactiveSocket::fromClientConnection(
+        eventBase,
+        std::move(framedConnection),
+        // TODO need to optionally allow this being passed in for a duplex
+        // client
+        std::make_unique<NullRequestHandler>(),
+        // TODO need to allow this being passed in
+        ConnectionSetupPayload(
+            "text/plain", "text/plain", Payload("meta", "data")),
+        Stats::noop(),
+        // TODO need to optionally allow defining the keepalive timer
+        std::make_unique<FollyKeepaliveTimer>(
+            eventBase, std::chrono::milliseconds(5000)));
+
+    promise->setValue(rs);
+  });
+
+  return promise->getFuture();
+}
+
+RSocketClient::~RSocketClient() {
+  LOG(INFO) << "RSocketClient => destroy";
+}
+}

--- a/experimental/rsocket-src/RSocketRequester.cpp
+++ b/experimental/rsocket-src/RSocketRequester.cpp
@@ -1,0 +1,71 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "rsocket/RSocketRequester.h"
+
+using namespace folly;
+
+namespace rsocket {
+
+std::shared_ptr<RSocketRequester> RSocketRequester::create(
+    std::unique_ptr<StandardReactiveSocket> srs,
+    EventBase& eventBase) {
+  auto customDeleter = [&eventBase](RSocketRequester* pRequester) {
+    eventBase.runImmediatelyOrRunInEventBaseThreadAndWait([&pRequester] {
+      LOG(INFO) << "RSocketRequester => destroy on EventBase";
+      delete pRequester;
+    });
+  };
+
+  auto rsr = new RSocketRequester(std::move(srs), eventBase);
+  std::shared_ptr<RSocketRequester> sR(rsr, customDeleter);
+  return sR;
+}
+
+RSocketRequester::RSocketRequester(
+    std::unique_ptr<StandardReactiveSocket> srs,
+    EventBase& eventBase)
+    : standardReactiveSocket_(std::move(srs)), eventBase_(eventBase) {}
+
+RSocketRequester::~RSocketRequester() {
+  LOG(INFO) << "RSocketRequester => destroy";
+}
+
+std::shared_ptr<Subscriber<Payload>> RSocketRequester::requestChannel(
+    std::shared_ptr<Subscriber<Payload>> responseSink) {
+  return standardReactiveSocket_->requestChannel(std::move(responseSink));
+}
+
+void RSocketRequester::requestStream(
+    Payload request,
+    std::shared_ptr<Subscriber<Payload>> responseSink) {
+  eventBase_.runInEventBaseThread(
+      [ this, request = std::move(request), responseSink ]() mutable {
+        standardReactiveSocket_->requestStream(
+            std::move(request), std::move(responseSink));
+      });
+}
+
+void RSocketRequester::requestResponse(
+    Payload request,
+    std::shared_ptr<Subscriber<Payload>> responseSink) {
+  eventBase_.runInEventBaseThread(
+      [ this, request = std::move(request), responseSink ]() mutable {
+        standardReactiveSocket_->requestResponse(
+            std::move(request), std::move(responseSink));
+      });
+}
+
+void RSocketRequester::requestFireAndForget(Payload request) {
+  eventBase_.runInEventBaseThread(
+      [ this, request = std::move(request) ]() mutable {
+        standardReactiveSocket_->requestFireAndForget(std::move(request));
+      });
+}
+
+void RSocketRequester::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
+  eventBase_.runInEventBaseThread(
+      [ this, metadata = std::move(metadata) ]() mutable {
+        standardReactiveSocket_->metadataPush(std::move(metadata));
+      });
+}
+}

--- a/experimental/rsocket-src/RSocketServer.cpp
+++ b/experimental/rsocket-src/RSocketServer.cpp
@@ -1,0 +1,113 @@
+
+#include "rsocket/RSocketServer.h"
+#include <folly/ExceptionWrapper.h>
+#include <folly/io/async/EventBaseManager.h>
+#include "rsocket/RSocketErrors.h"
+#include "src/FrameTransport.h"
+
+namespace rsocket {
+
+class RSocketConnection : public reactivesocket::ServerConnectionAcceptor {
+ public:
+  RSocketConnection(OnSetupNewSocket onSetup) : onSetup_(std::move(onSetup)) {}
+  ~RSocketConnection() {
+    LOG(INFO) << "RSocketServer => destroy the connection acceptor";
+  }
+
+  void setupNewSocket(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ConnectionSetupPayload setupPayload,
+      Executor& executor) {
+    onSetup_(std::move(frameTransport), std::move(setupPayload), executor);
+  }
+  void resumeSocket(
+      std::shared_ptr<FrameTransport> frameTransport,
+      ResumeIdentificationToken,
+      ResumePosition,
+      Executor& executor) {
+    //      onSetup_(std::move(frameTransport), std::move(setupPayload));
+  }
+
+ private:
+  OnSetupNewSocket onSetup_;
+};
+
+RSocketServer::RSocketServer(
+    std::unique_ptr<ConnectionAcceptor> connectionAcceptor)
+    : lazyAcceptor(std::move(connectionAcceptor)) {}
+
+void RSocketServer::start(OnAccept onAccept) {
+  if (!acceptor_) {
+    LOG(INFO) << "RSocketServer => initialize connection acceptor on start";
+    acceptor_ = std::make_unique<RSocketConnection>([
+      this,
+      onAccept = std::move(onAccept)
+    ](std::shared_ptr<FrameTransport> frameTransport,
+      ConnectionSetupPayload setupPayload,
+      Executor & executor_) {
+      LOG(INFO) << "RSocketServer => received new setup payload";
+
+      std::shared_ptr<RequestHandler> requestHandler;
+      try {
+        requestHandler = onAccept(
+            std::make_unique<ConnectionSetupRequest>(std::move(setupPayload)));
+      } catch (RSocketError& e) {
+        // TODO emit ERROR ... but how do I do that here?
+        frameTransport->close(
+            folly::exception_wrapper{std::current_exception(), e});
+        return;
+      }
+      LOG(INFO) << "RSocketServer => received request handler";
+
+      auto rs = StandardReactiveSocket::disconnectedServer(
+          // we know this callback is on a specific EventBase
+          executor_,
+          std::move(requestHandler),
+          Stats::noop());
+
+      rs->clientConnect(std::move(frameTransport));
+
+      // register callback for removal when the socket closes
+      rs->onClosed([ this, rs = rs.get() ](const folly::exception_wrapper& ex) {
+        removeSocket(*rs);
+        LOG(INFO) << "RSocketServer => removed closed connection";
+      });
+
+      // store this ReactiveSocket
+      addSocket(std::move(rs));
+    });
+  } else {
+    throw std::runtime_error("RSocketServer.start already called.");
+  }
+  lazyAcceptor->start([ this, onAccept = std::move(onAccept) ](
+      std::unique_ptr<DuplexConnection> duplexConnection, Executor & executor) {
+    LOG(INFO) << "RSocketServer => received new connection";
+
+    LOG(INFO) << "RSocketServer => going to accept duplex connection";
+    // the callbacks above are wired up, now accept the connection
+    acceptor_->acceptConnection(std::move(duplexConnection), executor);
+  });
+}
+
+void RSocketServer::startAndPark(OnAccept onAccept) {
+  start(std::forward<OnAccept>(onAccept));
+  // now block this thread
+  std::unique_lock<std::mutex> lk(m);
+  // if shutdown gets implemented this would then be released by it
+  cv.wait(lk, [] { return false; });
+}
+
+void RSocketServer::removeSocket(ReactiveSocket& socket) {
+  LOG(INFO) << "RSocketServer => remove socket from vector";
+  reactiveSockets_.erase(std::remove_if(
+      reactiveSockets_.begin(),
+      reactiveSockets_.end(),
+      [&socket](std::unique_ptr<ReactiveSocket>& vecSocket) {
+        return vecSocket.get() == &socket;
+      }));
+}
+void RSocketServer::addSocket(std::unique_ptr<ReactiveSocket> socket) {
+  LOG(INFO) << "RSocketServer => add socket to vector";
+  reactiveSockets_.push_back(std::move(socket));
+}
+}

--- a/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
@@ -18,7 +18,8 @@ std::unique_ptr<ConnectionAcceptor> TcpConnectionAcceptor::create(int port) {
 }
 
 void TcpConnectionAcceptor::start(
-    std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>
+    std::function<
+        void(std::unique_ptr<DuplexConnection>, EventBase&)>
         acceptor) {
   // TODO needs to blow up if called more than once
   LOG(INFO) << "ConnectionAcceptor => start";

--- a/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
@@ -1,0 +1,69 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <rsocket/transports/TcpConnectionAcceptor.h>
+#include "src/framed/FramedDuplexConnection.h"
+#include "src/tcp/TcpDuplexConnection.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace rsocket {
+
+TcpConnectionAcceptor::TcpConnectionAcceptor(int port) {
+  addr.setFromLocalPort(port);
+}
+
+std::unique_ptr<ConnectionAcceptor> TcpConnectionAcceptor::create(int port) {
+  return std::make_unique<TcpConnectionAcceptor>(port);
+}
+
+void TcpConnectionAcceptor::start(
+    std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>
+        acceptor) {
+  // TODO needs to blow up if called more than once
+  LOG(INFO) << "ConnectionAcceptor => start";
+  onAccept = std::move(acceptor);
+  // TODO need to support more than 1 thread
+  serverSocket = AsyncServerSocket::newSocket(&eventBase);
+  thread = std::thread([this]() { eventBase.loopForever(); });
+  thread.detach();
+  eventBase.runInEventBaseThread([this]() {
+    LOG(INFO) << "ConnectionAcceptor => start in loop";
+    serverSocket->setReusePortEnabled(true);
+    serverSocket->bind(addr);
+    serverSocket->addAcceptCallback(this, &eventBase);
+    serverSocket->listen(10);
+    serverSocket->startAccepting();
+
+    for (auto i : serverSocket->getAddresses()) {
+      LOG(INFO) << "ConnectionAcceptor => listening on => " << i.describe();
+    }
+  });
+
+  LOG(INFO) << "ConnectionAcceptor => leave start";
+}
+
+void TcpConnectionAcceptor::connectionAccepted(
+    int fd,
+    const SocketAddress& clientAddr) noexcept {
+  LOG(INFO) << "ConnectionAcceptor => accept connection " << fd;
+  auto socket = folly::AsyncSocket::UniquePtr(new AsyncSocket(&eventBase, fd));
+
+  std::unique_ptr<DuplexConnection> connection =
+      std::make_unique<TcpDuplexConnection>(
+          std::move(socket), inlineExecutor());
+  std::unique_ptr<DuplexConnection> framedConnection =
+      std::make_unique<FramedDuplexConnection>(
+          std::move(connection), inlineExecutor());
+
+  onAccept(std::move(framedConnection), eventBase);
+}
+
+void TcpConnectionAcceptor::acceptError(const std::exception& ex) noexcept {
+  LOG(INFO) << "ConnectionAcceptor => error => " << ex.what();
+}
+
+TcpConnectionAcceptor::~TcpConnectionAcceptor() {
+  LOG(INFO) << "ConnectionAcceptor => destroy";
+}
+}

--- a/experimental/rsocket-src/transports/TcpConnectionFactory.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionFactory.cpp
@@ -36,7 +36,6 @@ class FramedDuplexConnectionOnThread : public DuplexConnection {
  private:
   std::unique_ptr<FramedDuplexConnection> fd_;
   std::unique_ptr<ScopedEventBaseThread> eventBaseThread_;
-  EventBase* eventBase_{eventBaseThread_->getEventBase()};
 };
 
 // create new ScopedEventBaseThread

--- a/experimental/rsocket-src/transports/TcpConnectionFactory.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionFactory.cpp
@@ -1,0 +1,82 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <rsocket/transports/TcpConnectionFactory.h>
+#include "src/framed/FramedDuplexConnection.h"
+#include "src/tcp/TcpDuplexConnection.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace rsocket {
+
+class TcpConnectionInstance : public AsyncSocket::ConnectCallback {
+ public:
+  TcpConnectionInstance(OnConnect onConnect, SocketAddress& addr)
+      : addr_(addr), onConnect_(onConnect) {}
+
+  void connect() {
+    // now start the connection asynchronously
+    eventBase_->runInEventBaseThreadAndWait([this]() {
+      LOG(INFO) << "ConnectionFactory => starting socket";
+      socket_.reset(new folly::AsyncSocket(eventBase_));
+
+      LOG(INFO) << "ConnectionFactory => attempting connection to "
+                << addr_.describe() << std::endl;
+
+      socket_->connect(this, addr_);
+
+      LOG(INFO) << "ConnectionFactory  => DONE connect";
+    });
+  }
+
+ private:
+  SocketAddress& addr_;
+  folly::AsyncSocket::UniquePtr socket_;
+  OnConnect onConnect_;
+  ScopedEventBaseThread eventBaseThread_;
+  EventBase* eventBase_{eventBaseThread_.getEventBase()};
+
+  void connectSuccess() noexcept {
+    LOG(INFO) << "ConnectionFactory => socketCallback => Success";
+
+    std::unique_ptr<DuplexConnection> connection =
+        std::make_unique<TcpDuplexConnection>(
+            std::move(socket_), inlineExecutor(), Stats::noop());
+    std::unique_ptr<DuplexConnection> framedConnection =
+        std::make_unique<FramedDuplexConnection>(
+            std::move(connection), inlineExecutor());
+
+    // callback with the connection now that we have it
+    onConnect_(std::move(framedConnection), *eventBase_);
+  }
+
+  void connectErr(const AsyncSocketException& ex) noexcept {
+    LOG(INFO) << "ConnectionFactory => socketCallback => ERROR => " << ex.what()
+              << " " << ex.getType() << std::endl;
+  }
+};
+
+TcpConnectionFactory::TcpConnectionFactory(std::string host, int port)
+    : addr(host, port, true) {}
+
+void TcpConnectionFactory::connect(OnConnect oc) {
+  auto c = std::make_unique<TcpConnectionInstance>(std::move(oc), addr);
+  c->connect();
+  connections_.push_back(std::move(c));
+}
+
+std::unique_ptr<ConnectionFactory> TcpConnectionFactory::create(
+    std::string host,
+    int port) {
+  LOG(INFO) << "ConnectionFactory creation => host: " << host
+            << " port: " << port;
+  return std::make_unique<TcpConnectionFactory>(host, port);
+}
+
+TcpConnectionFactory::~TcpConnectionFactory() {
+  LOG(INFO) << "ConnectionFactory => destroy";
+}
+}

--- a/experimental/rsocket/ConnectionAcceptor.h
+++ b/experimental/rsocket/ConnectionAcceptor.h
@@ -1,0 +1,33 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/io/async/EventBase.h>
+#include "src/DuplexConnection.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace rsocket {
+
+/**
+ * Common interface for a server that accepts connections and turns them into
+ * DuplexConnection.
+ *
+ * Built-in implementations can be found in rsocket/transports/, such as
+ * rsocket/transports/TcpServerConnectionAcceptor.h
+ */
+class ConnectionAcceptor {
+ public:
+  ConnectionAcceptor() = default;
+  virtual ~ConnectionAcceptor() = default;
+  ConnectionAcceptor(const ConnectionAcceptor&) = delete; // copy
+  ConnectionAcceptor(ConnectionAcceptor&&) = delete; // move
+  ConnectionAcceptor& operator=(const ConnectionAcceptor&) = delete; // copy
+  ConnectionAcceptor& operator=(ConnectionAcceptor&&) = delete; // move
+
+  virtual void start(
+      std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>
+          onAccept) = 0;
+};
+}

--- a/experimental/rsocket/ConnectionAcceptor.h
+++ b/experimental/rsocket/ConnectionAcceptor.h
@@ -14,8 +14,10 @@ namespace rsocket {
  * Common interface for a server that accepts connections and turns them into
  * DuplexConnection.
  *
+ * This is primarily used with RSocket::createServer(ConnectionAcceptor)
+ *
  * Built-in implementations can be found in rsocket/transports/, such as
- * rsocket/transports/TcpServerConnectionAcceptor.h
+ * rsocket/transports/TcpConnectionAcceptor.h
  */
 class ConnectionAcceptor {
  public:
@@ -26,8 +28,17 @@ class ConnectionAcceptor {
   ConnectionAcceptor& operator=(const ConnectionAcceptor&) = delete; // copy
   ConnectionAcceptor& operator=(ConnectionAcceptor&&) = delete; // move
 
+  /**
+   * Allocate/start required resources (threads, sockets, etc) and begin
+   * listening for new connections.
+   *
+   * This can only be called once.
+   *
+   *@param onAccept
+   */
   virtual void start(
       std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>
           onAccept) = 0;
+  // TODO need to add numThreads option (either overload or arg with default=1)
 };
 }

--- a/experimental/rsocket/ConnectionFactory.h
+++ b/experimental/rsocket/ConnectionFactory.h
@@ -1,0 +1,30 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "src/DuplexConnection.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace folly {
+class EventBase;
+}
+
+namespace rsocket {
+
+using OnConnect =
+    std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>;
+
+class ConnectionFactory {
+ public:
+  ConnectionFactory() = default;
+  virtual ~ConnectionFactory() = default;
+  ConnectionFactory(const ConnectionFactory&) = delete; // copy
+  ConnectionFactory(ConnectionFactory&&) = delete; // move
+  ConnectionFactory& operator=(const ConnectionFactory&) = delete; // copy
+  ConnectionFactory& operator=(ConnectionFactory&&) = delete; // move
+
+  virtual void connect(OnConnect onConnect) = 0;
+};
+}

--- a/experimental/rsocket/ConnectionFactory.h
+++ b/experimental/rsocket/ConnectionFactory.h
@@ -16,6 +16,15 @@ namespace rsocket {
 using OnConnect =
     std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>;
 
+/**
+ * Common interface for a client to create connections and turn them into
+ * DuplexConnections.
+ *
+ * This is primarily used with RSocket::createClient(ConnectionFactory)
+ *
+ * Built-in implementations can be found in rsocket/transports/, such as
+ * rsocket/transports/TcpConnectionFactory.h
+ */
 class ConnectionFactory {
  public:
   ConnectionFactory() = default;
@@ -25,6 +34,12 @@ class ConnectionFactory {
   ConnectionFactory& operator=(const ConnectionFactory&) = delete; // copy
   ConnectionFactory& operator=(ConnectionFactory&&) = delete; // move
 
+  /**
+   * Connect to server defined by constructor of the implementing class.
+   *
+   * Everytime this is called a new connection is made.
+   * @param onConnect
+   */
   virtual void connect(OnConnect onConnect) = 0;
 };
 }

--- a/experimental/rsocket/ConnectionResumeRequest.h
+++ b/experimental/rsocket/ConnectionResumeRequest.h
@@ -1,0 +1,27 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "src/StandardReactiveSocket.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+/**
+ * Represents a new connection RESUME request from a client.
+ */
+class ConnectionResumeRequest {
+ public:
+  ConnectionResumeRequest() = default;
+  virtual ~ConnectionResumeRequest() = default;
+  ConnectionResumeRequest(const ConnectionResumeRequest&) = delete; // copy
+  ConnectionResumeRequest(ConnectionResumeRequest&&) = delete; // move
+  ConnectionResumeRequest& operator=(const ConnectionResumeRequest&) =
+      delete; // copy
+  ConnectionResumeRequest& operator=(ConnectionResumeRequest&&) =
+      delete; // move
+
+ private:
+};
+}

--- a/experimental/rsocket/ConnectionResumeRequest.h
+++ b/experimental/rsocket/ConnectionResumeRequest.h
@@ -10,6 +10,8 @@ namespace rsocket {
 
 /**
  * Represents a new connection RESUME request from a client.
+ *
+ * Is passed to the RSocketServer resume callback for acceptance or rejection.
  */
 class ConnectionResumeRequest {
  public:
@@ -21,6 +23,8 @@ class ConnectionResumeRequest {
       delete; // copy
   ConnectionResumeRequest& operator=(ConnectionResumeRequest&&) =
       delete; // move
+
+  // TODO still just a placeholder, not implemented yet
 
  private:
 };

--- a/experimental/rsocket/ConnectionSetupRequest.h
+++ b/experimental/rsocket/ConnectionSetupRequest.h
@@ -1,0 +1,34 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "src/StandardReactiveSocket.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+/**
+ * Represents a new connection SETUP request from a client.
+ */
+class ConnectionSetupRequest {
+ public:
+  ConnectionSetupRequest(ConnectionSetupPayload setupPayload);
+  virtual ~ConnectionSetupRequest() = default;
+  ConnectionSetupRequest(const ConnectionSetupRequest&) = delete; // copy
+  ConnectionSetupRequest(ConnectionSetupRequest&&) = delete; // move
+  ConnectionSetupRequest& operator=(const ConnectionSetupRequest&) =
+      delete; // copy
+  ConnectionSetupRequest& operator=(ConnectionSetupRequest&&) = delete; // move
+
+  std::string& getMetadataMimeType();
+  std::string& getDataMimeType();
+  Payload& getPayload();
+  bool clientRequestsResumability();
+  ResumeIdentificationToken& getResumeIdentificationToken();
+  bool willHonorLease();
+
+ private:
+  ConnectionSetupPayload setupPayload_;
+};
+}

--- a/experimental/rsocket/ConnectionSetupRequest.h
+++ b/experimental/rsocket/ConnectionSetupRequest.h
@@ -10,6 +10,11 @@ namespace rsocket {
 
 /**
  * Represents a new connection SETUP request from a client.
+ *
+ * Is passed to the RSocketServer setup callback for acceptance or rejection.
+ *
+ * This provides access to the SETUP Data/Metadata, MimeTypes, and other such information
+ * to allow conditional connection handling.
  */
 class ConnectionSetupRequest {
  public:

--- a/experimental/rsocket/RSocket.h
+++ b/experimental/rsocket/RSocket.h
@@ -19,7 +19,10 @@ class RSocket {
    * @return RSocketClient which can then make RSocket connections.
    */
   static std::unique_ptr<RSocketClient> createClient(
-          std::unique_ptr<ConnectionFactory>);
+      std::unique_ptr<ConnectionFactory>);
+
+  // TODO duplex client that takes a requestHandler
+  // TODO ConnectionSetupPayload arguments such as MimeTypes, Keepalive, etc
 
   /**
    * Create an RSocketServer that will accept connections.

--- a/experimental/rsocket/RSocket.h
+++ b/experimental/rsocket/RSocket.h
@@ -1,0 +1,42 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "rsocket/RSocketClient.h"
+#include "rsocket/RSocketServer.h"
+
+namespace rsocket {
+
+/**
+ * Main entry to creating RSocket clients and servers.
+ */
+class RSocket {
+ public:
+  /**
+   * Create an RSocketClient that can be used to open RSocket connections.
+   * @param connectionFactory factory of DuplexConnections on the desired
+   * transport, such as TcpClientConnectionFactory
+   * @return RSocketClient which can then make RSocket connections.
+   */
+  static std::unique_ptr<RSocketClient> createClient(
+          std::unique_ptr<ConnectionFactory>);
+
+  /**
+   * Create an RSocketServer that will accept connections.
+   * @param connectionAcceptor acceptor of DuplexConnections on the desired
+   * transport, such as TcpServerConnectionAcceptor
+   * @return RSocketServer which can then accept RSocket connections.
+   */
+  static std::unique_ptr<RSocketServer> createServer(
+      std::unique_ptr<ConnectionAcceptor> ca);
+
+  // TODO createResumeServer
+
+  RSocket() = delete;
+  virtual ~RSocket() = delete;
+  RSocket(const RSocket&) = delete; // copy
+  RSocket(RSocket&&) = delete; // move
+  RSocket& operator=(const RSocket&) = delete; // copy
+  RSocket& operator=(RSocket&&) = delete; // move
+};
+}

--- a/experimental/rsocket/RSocketClient.h
+++ b/experimental/rsocket/RSocketClient.h
@@ -9,11 +9,13 @@
 
 using namespace ::reactivesocket;
 
-/**
- * Simplified API for client/server
- */
 namespace rsocket {
 
+/**
+ * API for connecting to an RSocket server. Returned from RSocket::createClient.
+ *
+ * This connects using a transport from the provided ConnectionFactory.
+ */
 class RSocketClient {
  public:
   RSocketClient(std::unique_ptr<ConnectionFactory>);
@@ -31,25 +33,21 @@ class RSocketClient {
    * Connect asynchronously and return a Future which will deliver the RSocket
    *
    * Each time this is called:
-   * - a new thread and EventBase is created
-   * - a new connection is created
+   * - a new connection is created using a ConnectionFactory
    * - a new StandardReactiveSocket is created
+   *
+   * The returned RSocketRequester is retained by the RSocketClient instance
+   * so that it lives for the life of RSocketClient, as opposed to the scope
+   * of the Future (such as when used with Future.then(...)).
+   *
+   * To destruct a single RSocketRequester sooner than the RSocketClient
+   * call RSocketRequester.close().
    */
   Future<std::shared_ptr<RSocketRequester>> connect();
 
-  /*
-   * Connect asynchronously and return a Future which will deliver the RSocket
-   *
-   * Each time this is called:
-   * - a new StandardReactiveSocket is created using the provided EventBase
-   */
-  // TODO implement overload that allows injecting an EventBase
-  //  Future<std::shared_ptr<StandardReactiveSocket>> connect(Executor&);
-
   // TODO implement version supporting fast start (send SETUP and requests
   // without waiting for transport to connect and ack)
-  //  std::shared_ptr<StandardReactiveSocket> fastConnect();
-  //  std::shared_ptr<StandardReactiveSocket> fastConnect(Executor&);
+  //  std::shared_ptr<RSocketRequester> fastConnect();
 
  private:
   std::unique_ptr<ConnectionFactory> lazyConnection;

--- a/experimental/rsocket/RSocketClient.h
+++ b/experimental/rsocket/RSocketClient.h
@@ -4,6 +4,7 @@
 
 #include <folly/futures/Future.h>
 #include "rsocket/ConnectionFactory.h"
+#include "rsocket/RSocketRequester.h"
 #include "src/StandardReactiveSocket.h"
 
 using namespace ::reactivesocket;
@@ -32,12 +33,26 @@ class RSocketClient {
    * Each time this is called:
    * - a new thread and EventBase is created
    * - a new connection is created
-   * - a new client is created
+   * - a new StandardReactiveSocket is created
    */
-  Future<std::shared_ptr<StandardReactiveSocket>> connect();
+  Future<std::shared_ptr<RSocketRequester>> connect();
+
+  /*
+   * Connect asynchronously and return a Future which will deliver the RSocket
+   *
+   * Each time this is called:
+   * - a new StandardReactiveSocket is created using the provided EventBase
+   */
+  // TODO implement overload that allows injecting an EventBase
+  //  Future<std::shared_ptr<StandardReactiveSocket>> connect(Executor&);
+
+  // TODO implement version supporting fast start (send SETUP and requests
+  // without waiting for transport to connect and ack)
+  //  std::shared_ptr<StandardReactiveSocket> fastConnect();
+  //  std::shared_ptr<StandardReactiveSocket> fastConnect(Executor&);
 
  private:
   std::unique_ptr<ConnectionFactory> lazyConnection;
-  std::shared_ptr<StandardReactiveSocket> rs;
+  std::vector<std::shared_ptr<RSocketRequester>> rsockets_;
 };
 }

--- a/experimental/rsocket/RSocketClient.h
+++ b/experimental/rsocket/RSocketClient.h
@@ -1,0 +1,43 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/futures/Future.h>
+#include "rsocket/ConnectionFactory.h"
+#include "src/StandardReactiveSocket.h"
+
+using namespace ::reactivesocket;
+
+/**
+ * Simplified API for client/server
+ */
+namespace rsocket {
+
+class RSocketClient {
+ public:
+  RSocketClient(std::unique_ptr<ConnectionFactory>);
+  ~RSocketClient();
+  RSocketClient(const RSocketClient&) = delete; // copy
+  RSocketClient(RSocketClient&&) = delete; // move
+  RSocketClient& operator=(const RSocketClient&) = delete; // copy
+  RSocketClient& operator=(RSocketClient&&) = delete; // move
+
+  // TODO ConnectionSetupPayload
+  // TODO keepalive timer
+  // TODO duplex with RequestHandler
+
+  /*
+   * Connect asynchronously and return a Future which will deliver the RSocket
+   *
+   * Each time this is called:
+   * - a new thread and EventBase is created
+   * - a new connection is created
+   * - a new client is created
+   */
+  Future<std::shared_ptr<StandardReactiveSocket>> connect();
+
+ private:
+  std::unique_ptr<ConnectionFactory> lazyConnection;
+  std::shared_ptr<StandardReactiveSocket> rs;
+};
+}

--- a/experimental/rsocket/RSocketErrors.h
+++ b/experimental/rsocket/RSocketErrors.h
@@ -5,11 +5,11 @@
 #include <string>
 
 namespace rsocket {
+
 /*
  * Error Codes from
  * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#error-codes
  */
-
 class RSocketError : public std::runtime_error {
  public:
   explicit RSocketError(const std::string& s)

--- a/experimental/rsocket/RSocketErrors.h
+++ b/experimental/rsocket/RSocketErrors.h
@@ -1,0 +1,133 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+
+namespace rsocket {
+/*
+ * Error Codes from
+ * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#error-codes
+ */
+
+class RSocketError : public std::runtime_error {
+ public:
+  explicit RSocketError(const std::string& s)
+      : std::runtime_error(std::move(s)) {}
+  explicit RSocketError(const char* s) : std::runtime_error(std::move(s)) {}
+  /**
+   * Get the error code for inclusion in an RSocket ERROR frame as per
+   * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#error-codes
+   * @return
+   */
+  virtual int getErrorCode() = 0;
+  /**
+   * Get the string name of the error as per
+   * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#error-codes
+   * @return
+   */
+  virtual const std::string getErrorString() = 0;
+};
+
+/**
+ * Error Code: INVALID_SETUP 0x00000001
+ */
+class InvalidSetupError : public RSocketError {
+ public:
+  explicit InvalidSetupError(const std::string& s) : RSocketError(s) {}
+  explicit InvalidSetupError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000001;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("INVALID_SETUP");
+  }
+};
+
+/**
+ * Error Code: UNSUPPORTED_SETUP 0x00000002
+ */
+class UnsupportedSetupError : public RSocketError {
+ public:
+  explicit UnsupportedSetupError(const std::string& s) : RSocketError(s) {}
+  explicit UnsupportedSetupError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000002;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("UNSUPPORTED_SETUP");
+  }
+};
+
+/**
+ * Error Code: REJECTED_SETUP 0x00000003
+ */
+class RejectedSetupError : public RSocketError {
+ public:
+  explicit RejectedSetupError(const std::string& s) : RSocketError(s) {}
+  explicit RejectedSetupError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000003;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("REJECTED_SETUP");
+  }
+};
+
+/**
+ * Error Code: REJECTED_RESUME 0x00000004
+ */
+class RejectedResumeError : public RSocketError {
+ public:
+  explicit RejectedResumeError(const std::string& s) : RSocketError(s) {}
+  explicit RejectedResumeError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000004;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("REJECTED_RESUME");
+  }
+};
+
+/**
+ * Error Code: CONNECTION_ERROR 0x00000101
+ */
+class ConnectionError : public RSocketError {
+ public:
+  explicit ConnectionError(const std::string& s) : RSocketError(s) {}
+  explicit ConnectionError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000101;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("CONNECTION_ERROR");
+  }
+};
+
+/**
+* Error Code: CONNECTION_CLOSE 0x00000102
+*/
+class ConnectionCloseError : public RSocketError {
+ public:
+  explicit ConnectionCloseError(const std::string& s) : RSocketError(s) {}
+  explicit ConnectionCloseError(const char* s) : RSocketError(s) {}
+
+  int getErrorCode() override {
+    return 0x00000102;
+  }
+
+  const std::string getErrorString() override {
+    return std::string("CONNECTION_CLOSE");
+  }
+};
+}

--- a/experimental/rsocket/RSocketRequester.h
+++ b/experimental/rsocket/RSocketRequester.h
@@ -10,6 +10,13 @@ using namespace ::reactivesocket;
 using namespace folly;
 
 namespace rsocket {
+
+/**
+ * Request APIs to submit requests on an RSocket connection.
+ *
+ * This is most commonly used by an RSocketClient, but due to the symmetric
+ * nature of RSocket, this can be used from server->client as well.
+ */
 class RSocketRequester {
  public:
   static std::shared_ptr<RSocketRequester> create(
@@ -24,20 +31,65 @@ class RSocketRequester {
 
   // TODO why is everything in here a shared_ptr and not just unique_ptr?
 
-  std::shared_ptr<Subscriber<Payload>> requestChannel(
-      std::shared_ptr<Subscriber<Payload>> responseSink);
-
+  /**
+   * Send a single request and get a response stream.
+   *
+   * Interaction model details can be found at
+   * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#request-stream
+   *
+   * @param payload
+   * @param responseSink
+   */
   void requestStream(
       Payload payload,
       std::shared_ptr<Subscriber<Payload>> responseSink);
 
+  /**
+    * Start a channel (streams in both directions).
+    *
+    * Interaction model details can be found at
+    * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#request-channel
+    *
+    * @param responseSink
+    * @return
+    */
+  std::shared_ptr<Subscriber<Payload>> requestChannel(
+      std::shared_ptr<Subscriber<Payload>> responseSink);
+
+  /**
+   * Send a single request and get a single response.
+   *
+   * Interaction model details can be found at
+   * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#stream-sequences-request-response
+   *
+   * @param payload
+   * @param responseSink
+   */
   void requestResponse(
       Payload payload,
       std::shared_ptr<Subscriber<Payload>> responseSink);
 
-  void requestFireAndForget(Payload request);
+  /**
+   * Send a single Payload with no response.
+   *
+   * Interaction model details can be found at
+   * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#request-fire-n-forget
+   *
+   * @param payload
+   */
+  void requestFireAndForget(Payload payload);
 
+  /**
+   * Send metadata without response.
+   *
+   * @param metadata
+   */
   void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
+
+  // TODO implement
+  //  void close();
+
+  // TODO implement versions that return Future/Publisher/Flowable
 
  private:
   RSocketRequester(

--- a/experimental/rsocket/RSocketRequester.h
+++ b/experimental/rsocket/RSocketRequester.h
@@ -1,0 +1,49 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/io/async/EventBase.h>
+#include "src/ReactiveStreamsCompat.h"
+#include "src/StandardReactiveSocket.h"
+
+using namespace ::reactivesocket;
+using namespace folly;
+
+namespace rsocket {
+class RSocketRequester {
+ public:
+  static std::shared_ptr<RSocketRequester> create(
+      std::unique_ptr<StandardReactiveSocket> srs,
+      EventBase& executor);
+
+  ~RSocketRequester();
+  RSocketRequester(const RSocketRequester&) = delete; // copy
+  RSocketRequester(RSocketRequester&&) = delete; // move
+  RSocketRequester& operator=(const RSocketRequester&) = delete; // copy
+  RSocketRequester& operator=(RSocketRequester&&) = delete; // move
+
+  // TODO why is everything in here a shared_ptr and not just unique_ptr?
+
+  std::shared_ptr<Subscriber<Payload>> requestChannel(
+      std::shared_ptr<Subscriber<Payload>> responseSink);
+
+  void requestStream(
+      Payload payload,
+      std::shared_ptr<Subscriber<Payload>> responseSink);
+
+  void requestResponse(
+      Payload payload,
+      std::shared_ptr<Subscriber<Payload>> responseSink);
+
+  void requestFireAndForget(Payload request);
+
+  void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
+
+ private:
+  RSocketRequester(
+      std::unique_ptr<StandardReactiveSocket> srs,
+      EventBase& eventBase);
+  std::shared_ptr<StandardReactiveSocket> standardReactiveSocket_;
+  EventBase& eventBase_;
+};
+}

--- a/experimental/rsocket/RSocketServer.h
+++ b/experimental/rsocket/RSocketServer.h
@@ -1,0 +1,71 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include "rsocket/ConnectionAcceptor.h"
+#include "rsocket/ConnectionResumeRequest.h"
+#include "rsocket/ConnectionSetupRequest.h"
+#include "src/RequestHandler.h"
+#include "src/ServerConnectionAcceptor.h"
+#include "src/StandardReactiveSocket.h"
+
+using namespace ::reactivesocket;
+
+namespace rsocket {
+
+using OnSetupNewSocket = std::function<void(
+    std::shared_ptr<FrameTransport> frameTransport,
+    ConnectionSetupPayload setupPayload,
+    folly::Executor&)>;
+
+using OnAccept = std::function<std::shared_ptr<RequestHandler>(
+    std::unique_ptr<ConnectionSetupRequest>)>;
+/**
+ * API for starting an RSocket server. Returned from RSocket::createServer.
+ */
+class RSocketServer {
+  // TODO resumability
+  // TODO concurrency (number of threads)
+
+ public:
+  RSocketServer(std::unique_ptr<ConnectionAcceptor>);
+  ~RSocketServer() = default;
+  RSocketServer(const RSocketServer&) = delete; // copy
+  RSocketServer(RSocketServer&&) = delete; // move
+  RSocketServer& operator=(const RSocketServer&) = delete; // copy
+  RSocketServer& operator=(RSocketServer&&) = delete; // move
+
+  /**
+   * Start the ConnectionAcceptor and begin handling connection.
+   *
+   * This method is asynchronous.
+   */
+  void start(OnAccept);
+
+  /**
+   * Start the ConnectionAcceptor and begin handling connection.
+   *
+   * This method will block the calling thread.
+   */
+  void startAndPark(OnAccept);
+
+  //  void start(
+  //      std::function<std::shared_ptr<RequestHandler>(
+  //          std::unique_ptr<ConnectionSetupRequest>)>,
+  //      // TODO what should a ResumeRequest return?
+  //      std::function<std::shared_ptr<RequestHandler>(
+  //          std::unique_ptr<ConnectionResumeRequest>)>);
+
+ private:
+  std::unique_ptr<ConnectionAcceptor> lazyAcceptor;
+  std::unique_ptr<reactivesocket::ServerConnectionAcceptor> acceptor_;
+  std::vector<std::unique_ptr<ReactiveSocket>> reactiveSockets_;
+  std::mutex m;
+  std::condition_variable cv;
+
+  void removeSocket(ReactiveSocket& socket);
+  void addSocket(std::unique_ptr<ReactiveSocket> socket);
+};
+}

--- a/experimental/rsocket/RSocketServer.h
+++ b/experimental/rsocket/RSocketServer.h
@@ -24,6 +24,9 @@ using OnAccept = std::function<std::shared_ptr<RequestHandler>(
     std::unique_ptr<ConnectionSetupRequest>)>;
 /**
  * API for starting an RSocket server. Returned from RSocket::createServer.
+ *
+ * This listens for connections using a transport from the provided
+ * ConnectionAcceptor.
  */
 class RSocketServer {
   // TODO resumability
@@ -38,19 +41,20 @@ class RSocketServer {
   RSocketServer& operator=(RSocketServer&&) = delete; // move
 
   /**
-   * Start the ConnectionAcceptor and begin handling connection.
+   * Start the ConnectionAcceptor and begin handling connections.
    *
    * This method is asynchronous.
    */
   void start(OnAccept);
 
   /**
-   * Start the ConnectionAcceptor and begin handling connection.
+   * Start the ConnectionAcceptor and begin handling connections.
    *
    * This method will block the calling thread.
    */
   void startAndPark(OnAccept);
 
+  // TODO version supporting RESUME
   //  void start(
   //      std::function<std::shared_ptr<RequestHandler>(
   //          std::unique_ptr<ConnectionSetupRequest>)>,

--- a/experimental/rsocket/transports/TcpConnectionAcceptor.h
+++ b/experimental/rsocket/transports/TcpConnectionAcceptor.h
@@ -10,6 +10,15 @@ using namespace ::folly;
 
 namespace rsocket {
 
+/**
+ * TCP implementation of ConnectionAcceptor for use with RSocket::createServer
+ *
+ * Creation of this does nothing. The 'start' method kicks off work.
+ *
+ * When started it will create a Thread, EventBase, and AsyncServerSocket.
+ *
+ * Destruction will shut down the thread(s) and socket.
+ */
 class TcpConnectionAcceptor : public ConnectionAcceptor,
                               public AsyncServerSocket::AcceptCallback {
  public:
@@ -26,6 +35,8 @@ class TcpConnectionAcceptor : public ConnectionAcceptor,
   /**
    * Create an EventBase, Thread, and AsyncServerSocket. Bind to the given port
    * and start accepting TCP connections.
+   *
+   * This can only be called once.
    *
    * @param onAccept
    */

--- a/experimental/rsocket/transports/TcpConnectionAcceptor.h
+++ b/experimental/rsocket/transports/TcpConnectionAcceptor.h
@@ -1,0 +1,50 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/io/async/AsyncServerSocket.h>
+#include "rsocket/ConnectionAcceptor.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace rsocket {
+
+class TcpConnectionAcceptor : public ConnectionAcceptor,
+                              public AsyncServerSocket::AcceptCallback {
+ public:
+  static std::unique_ptr<ConnectionAcceptor> create(int port);
+
+  TcpConnectionAcceptor(int port);
+  virtual ~TcpConnectionAcceptor();
+  TcpConnectionAcceptor(const TcpConnectionAcceptor&) = delete; // copy
+  TcpConnectionAcceptor(TcpConnectionAcceptor&&) = delete; // move
+  TcpConnectionAcceptor& operator=(const TcpConnectionAcceptor&) =
+      delete; // copy
+  TcpConnectionAcceptor& operator=(TcpConnectionAcceptor&&) = delete; // move
+
+  /**
+   * Create an EventBase, Thread, and AsyncServerSocket. Bind to the given port
+   * and start accepting TCP connections.
+   *
+   * @param onAccept
+   */
+  void start(std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)>
+                 onAccept) override;
+
+ private:
+  // TODO this is single-threaded right now
+  // TODO need to tell it how many threads to run on
+  EventBase eventBase;
+  std::thread thread;
+  folly::SocketAddress addr;
+  std::function<void(std::unique_ptr<DuplexConnection>, EventBase&)> onAccept;
+  std::shared_ptr<AsyncServerSocket> serverSocket;
+
+  virtual void connectionAccepted(
+      int fd,
+      const SocketAddress& clientAddr) noexcept override;
+
+  virtual void acceptError(const std::exception& ex) noexcept override;
+};
+}

--- a/experimental/rsocket/transports/TcpConnectionFactory.h
+++ b/experimental/rsocket/transports/TcpConnectionFactory.h
@@ -1,0 +1,35 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/io/async/AsyncSocket.h>
+#include "rsocket/ConnectionFactory.h"
+#include "src/DuplexConnection.h"
+
+using namespace ::reactivesocket;
+using namespace ::folly;
+
+namespace rsocket {
+
+class TcpConnectionFactory : public ConnectionFactory {
+ public:
+  TcpConnectionFactory(std::string host, int port);
+  virtual ~TcpConnectionFactory();
+  TcpConnectionFactory(const TcpConnectionFactory&) = delete; // copy
+  TcpConnectionFactory(TcpConnectionFactory&&) = delete; // move
+  TcpConnectionFactory& operator=(const TcpConnectionFactory&) = delete; // copy
+  TcpConnectionFactory& operator=(TcpConnectionFactory&&) = delete; // move
+
+  static std::unique_ptr<ConnectionFactory> create(std::string host, int port);
+
+  /**
+   * Connect to server on a new EventBase & Thread.
+   * @param onConnect
+   */
+  void connect(OnConnect onConnect) override;
+
+ private:
+  folly::SocketAddress addr;
+  std::vector<std::unique_ptr<AsyncSocket::ConnectCallback>> connections_;
+};
+}

--- a/experimental/rsocket/transports/TcpConnectionFactory.h
+++ b/experimental/rsocket/transports/TcpConnectionFactory.h
@@ -13,14 +13,14 @@ namespace rsocket {
 
 class TcpConnectionFactory : public ConnectionFactory {
  public:
-  TcpConnectionFactory(std::string host, int port);
+  TcpConnectionFactory(std::string host, uint16_t port);
   virtual ~TcpConnectionFactory();
   TcpConnectionFactory(const TcpConnectionFactory&) = delete; // copy
   TcpConnectionFactory(TcpConnectionFactory&&) = delete; // move
   TcpConnectionFactory& operator=(const TcpConnectionFactory&) = delete; // copy
   TcpConnectionFactory& operator=(TcpConnectionFactory&&) = delete; // move
 
-  static std::unique_ptr<ConnectionFactory> create(std::string host, int port);
+  static std::unique_ptr<ConnectionFactory> create(std::string host, uint16_t port);
 
   /**
    * Connect to server on a new EventBase & Thread.
@@ -29,7 +29,6 @@ class TcpConnectionFactory : public ConnectionFactory {
   void connect(OnConnect onConnect) override;
 
  private:
-  folly::SocketAddress addr;
-  std::vector<std::unique_ptr<AsyncSocket::ConnectCallback>> connections_;
+  folly::SocketAddress addr_;
 };
 }

--- a/experimental/rsocket/transports/TcpConnectionFactory.h
+++ b/experimental/rsocket/transports/TcpConnectionFactory.h
@@ -11,19 +11,35 @@ using namespace ::folly;
 
 namespace rsocket {
 
+/**
+* TCP implementation of ConnectionAcceptor for use with RSocket::createServer
+*
+* Creation of this does nothing. The 'start' method kicks off work.
+*
+* When started it will create a Thread, EventBase, and AsyncSocket.
+*/
 class TcpConnectionFactory : public ConnectionFactory {
  public:
   TcpConnectionFactory(std::string host, uint16_t port);
+  // TODO create variant that passes in Thread/EventBase to use
   virtual ~TcpConnectionFactory();
   TcpConnectionFactory(const TcpConnectionFactory&) = delete; // copy
   TcpConnectionFactory(TcpConnectionFactory&&) = delete; // move
   TcpConnectionFactory& operator=(const TcpConnectionFactory&) = delete; // copy
   TcpConnectionFactory& operator=(TcpConnectionFactory&&) = delete; // move
 
-  static std::unique_ptr<ConnectionFactory> create(std::string host, uint16_t port);
+  static std::unique_ptr<ConnectionFactory> create(
+      std::string host,
+      uint16_t port);
 
   /**
-   * Connect to server on a new EventBase & Thread.
+   * Connect to server defined in constructor.
+   *
+   * Each time this is called a new AsyncSocket is created and connected.
+   *
+   * With the default constructor this creates a new EventBase, Thread, and
+   * AsyncSocket each time connect(...) is called.
+   *
    * @param onConnect
    */
   void connect(OnConnect onConnect) override;


### PR DESCRIPTION
Continuation of exploration started in https://github.com/ReactiveSocket/reactivesocket-cpp/pull/310 after rebasing.

Server currently looking like this:

```cpp
  // RSocket server accepting on TCP
  auto rs = RSocket::createServer(TcpConnectionAcceptor::create(FLAGS_port));
  // global request handler
  auto requestHandler = std::make_shared<ServerRequestHandler>();
  // start accepting connections
  rs->start([requestHandler](auto connectionRequest) {
    if (!connectionRequest->isResumptionAttempt()) {
      return requestHandler;
    } else {
      throw std::runtime_error("Unable to handle these SETUP params");
    }
  });
```

This now supports a global request handler, and conditional handling of SETUP and RESUME to then error or return a different request handler (not all implemented yet, but flow is in place).

These changes required touching the actual production code in a few places.

Client looking like:

```cpp
  ScopedEventBaseThread eventBaseThread;
  auto rsf = RSocket::createClientFactory(
      TcpConnectionFactory::create(FLAGS_host, FLAGS_port));
  rsf->connect(eventBaseThread)
      .then([](std::shared_ptr<StandardReactiveSocket> rs) {
        rs->requestStream(
            Payload("args-here"), std::make_shared<ExampleSubscriber>(5, 6));
      });
```