### PR TITLE
Fluent API for Flowable and Subscriber/Subscription

### DIFF
--- a/experimental/vjn/.gitignore
+++ b/experimental/vjn/.gitignore
@@ -1,0 +1,15 @@
+# CMake
+CMakeCache.txt
+CMakeFiles/
+CMakeLists-local.txt
+CMakeLists.txt.user
+cmake_install.cmake
+
+# CMake Build
+/build
+
+# Miscellaneous
+*~
+.#*
+.DS_Store
+core

--- a/experimental/vjn/CMakeLists.txt
+++ b/experimental/vjn/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5)
+
+include (cmake/Downloads.cmake)
+
+# To debug the project, set the build type.
+set(CMAKE_BUILD_TYPE Debug)
+
+# Prefer static versions of boost everywhere.
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_RUNTIME ON)
+set(Boost_USE_MULTITHREADED ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+
+add_subdirectory(yarpl)

--- a/experimental/vjn/cmake/Downloads.cmake
+++ b/experimental/vjn/cmake/Downloads.cmake
@@ -1,0 +1,38 @@
+include (cmake/download/DownloadProject.cmake)
+
+download_project(PROJ   benchmark
+    GIT_REPOSITORY      git@github.com:google/benchmark.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)
+add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
+
+download_project(PROJ   double-conversion
+    GIT_REPOSITORY      git@github.com:google/double-conversion.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)
+add_subdirectory(
+  ${double-conversion_SOURCE_DIR} ${double-conversion_BINARY_DIR})
+
+set(WITH_GFLAGS OFF CACHE BOOL "Disable in child .cmake.")
+download_project(PROJ   gflags
+    GIT_REPOSITORY      git@github.com:gflags/gflags.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)
+add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+
+download_project(PROJ   glog
+    GIT_REPOSITORY      git@github.com:google/glog.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)
+add_subdirectory(${glog_SOURCE_DIR} ${glog_BINARY_DIR})
+
+download_project(PROJ   googletest
+    GIT_REPOSITORY      git@github.com:google/googletest.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)
+add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+
+download_project(PROJ   sparsehash
+    GIT_REPOSITORY      git@github.com:sparsehash/sparsehash.git
+    GIT_TAG             master
+    UPDATE_DISCONNECTED 1)

--- a/experimental/vjn/cmake/download/DownloadProject.CMakeLists.cmake.in
+++ b/experimental/vjn/cmake/download/DownloadProject.CMakeLists.cmake.in
@@ -1,0 +1,17 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(${DL_ARGS_PROJ}-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(${DL_ARGS_PROJ}-download
+                    ${DL_ARGS_UNPARSED_ARGUMENTS}
+                    SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
+                    BINARY_DIR          "${DL_ARGS_BINARY_DIR}"
+                    CONFIGURE_COMMAND   ""
+                    BUILD_COMMAND       ""
+                    INSTALL_COMMAND     ""
+                    TEST_COMMAND        ""
+)

--- a/experimental/vjn/cmake/download/DownloadProject.cmake
+++ b/experimental/vjn/cmake/download/DownloadProject.cmake
@@ -1,0 +1,178 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
+# MODULE:   DownloadProject
+#
+# PROVIDES:
+#   download_project( PROJ projectName
+#                    [PREFIX prefixDir]
+#                    [DOWNLOAD_DIR downloadDir]
+#                    [SOURCE_DIR srcDir]
+#                    [BINARY_DIR binDir]
+#                    [QUIET]
+#                    ...
+#   )
+#
+#       Provides the ability to download and unpack a tarball, zip file, git repository,
+#       etc. at configure time (i.e. when the cmake command is run). How the downloaded
+#       and unpacked contents are used is up to the caller, but the motivating case is
+#       to download source code which can then be included directly in the build with
+#       add_subdirectory() after the call to download_project(). Source and build
+#       directories are set up with this in mind.
+#
+#       The PROJ argument is required. The projectName value will be used to construct
+#       the following variables upon exit (obviously replace projectName with its actual
+#       value):
+#
+#           projectName_SOURCE_DIR
+#           projectName_BINARY_DIR
+#
+#       The SOURCE_DIR and BINARY_DIR arguments are optional and would not typically
+#       need to be provided. They can be specified if you want the downloaded source
+#       and build directories to be located in a specific place. The contents of
+#       projectName_SOURCE_DIR and projectName_BINARY_DIR will be populated with the
+#       locations used whether you provide SOURCE_DIR/BINARY_DIR or not.
+#
+#       The DOWNLOAD_DIR argument does not normally need to be set. It controls the
+#       location of the temporary CMake build used to perform the download.
+#
+#       The PREFIX argument can be provided to change the base location of the default
+#       values of DOWNLOAD_DIR, SOURCE_DIR and BINARY_DIR. If all of those three arguments
+#       are provided, then PREFIX will have no effect. The default value for PREFIX is
+#       CMAKE_BINARY_DIR.
+#
+#       The QUIET option can be given if you do not want to show the output associated
+#       with downloading the specified project.
+#
+#       In addition to the above, any other options are passed through unmodified to
+#       ExternalProject_Add() to perform the actual download, patch and update steps.
+#       The following ExternalProject_Add() options are explicitly prohibited (they
+#       are reserved for use by the download_project() command):
+#
+#           CONFIGURE_COMMAND
+#           BUILD_COMMAND
+#           INSTALL_COMMAND
+#           TEST_COMMAND
+#
+#       Only those ExternalProject_Add() arguments which relate to downloading, patching
+#       and updating of the project sources are intended to be used. Also note that at
+#       least one set of download-related arguments are required.
+#
+#       If using CMake 3.2 or later, the UPDATE_DISCONNECTED option can be used to
+#       prevent a check at the remote end for changes every time CMake is run
+#       after the first successful download. See the documentation of the ExternalProject
+#       module for more information. It is likely you will want to use this option if it
+#       is available to you. Note, however, that the ExternalProject implementation contains
+#       bugs which result in incorrect handling of the UPDATE_DISCONNECTED option when
+#       using the URL download method or when specifying a SOURCE_DIR with no download
+#       method. Fixes for these have been created, the last of which is scheduled for
+#       inclusion in CMake 3.8.0. Details can be found here:
+#
+#           https://gitlab.kitware.com/cmake/cmake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c
+#           https://gitlab.kitware.com/cmake/cmake/issues/16428
+#
+#       If you experience build errors related to the update step, consider avoiding
+#       the use of UPDATE_DISCONNECTED.
+#
+# EXAMPLE USAGE:
+#
+#   include(DownloadProject)
+#   download_project(PROJ                googletest
+#                    GIT_REPOSITORY      https://github.com/google/googletest.git
+#                    GIT_TAG             master
+#                    UPDATE_DISCONNECTED 1
+#                    QUIET
+#   )
+#
+#   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+#
+#========================================================================================
+
+
+set(_DownloadProjectDir "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeParseArguments)
+
+function(download_project)
+
+    set(options QUIET)
+    set(oneValueArgs
+        PROJ
+        PREFIX
+        DOWNLOAD_DIR
+        SOURCE_DIR
+        BINARY_DIR
+        # Prevent the following from being passed through
+        CONFIGURE_COMMAND
+        BUILD_COMMAND
+        INSTALL_COMMAND
+        TEST_COMMAND
+    )
+    set(multiValueArgs "")
+
+    cmake_parse_arguments(DL_ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Hide output if requested
+    if (DL_ARGS_QUIET)
+        set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+        unset(OUTPUT_QUIET)
+        message(STATUS "Downloading/updating ${DL_ARGS_PROJ}")
+    endif()
+
+    # Set up where we will put our temporary CMakeLists.txt file and also
+    # the base point below which the default source and binary dirs will be
+    if (NOT DL_ARGS_PREFIX)
+        set(DL_ARGS_PREFIX "${CMAKE_BINARY_DIR}")
+    endif()
+    if (NOT DL_ARGS_DOWNLOAD_DIR)
+        set(DL_ARGS_DOWNLOAD_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-download")
+    endif()
+
+    # Ensure the caller can know where to find the source and build directories
+    if (NOT DL_ARGS_SOURCE_DIR)
+        set(DL_ARGS_SOURCE_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-src")
+    endif()
+    if (NOT DL_ARGS_BINARY_DIR)
+        set(DL_ARGS_BINARY_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-build")
+    endif()
+    set(${DL_ARGS_PROJ}_SOURCE_DIR "${DL_ARGS_SOURCE_DIR}" PARENT_SCOPE)
+    set(${DL_ARGS_PROJ}_BINARY_DIR "${DL_ARGS_BINARY_DIR}" PARENT_SCOPE)
+
+    # The way that CLion manages multiple configurations, it causes a copy of
+    # the CMakeCache.txt to be copied across due to it not expecting there to
+    # be a project within a project.  This causes the hard-coded paths in the
+    # cache to be copied and builds to fail.  To mitigate this, we simply
+    # remove the cache if it exists before we configure the new project.  It
+    # is safe to do so because it will be re-generated.  Since this is only
+    # executed at the configure step, it should not cause additional builds or
+    # downloads.
+    file(REMOVE "${DL_ARGS_DOWNLOAD_DIR}/CMakeCache.txt")
+
+    # Create and build a separate CMake project to carry out the download.
+    # If we've already previously done these steps, they will not cause
+    # anything to be updated, so extra rebuilds of the project won't occur.
+    # Make sure to pass through CMAKE_MAKE_PROGRAM in case the main project
+    # has this set to something not findable on the PATH.
+    configure_file("${_DownloadProjectDir}/DownloadProject.CMakeLists.cmake.in"
+                   "${DL_ARGS_DOWNLOAD_DIR}/CMakeLists.txt")
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+                        -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+                        .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "CMake step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "Build step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+
+endfunction()

--- a/experimental/vjn/cmake/download/LICENSE
+++ b/experimental/vjn/cmake/download/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Crascit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/experimental/vjn/cmake/download/README
+++ b/experimental/vjn/cmake/download/README
@@ -1,0 +1,1 @@
+From: https://github.com/Crascit/DownloadProject.

--- a/experimental/vjn/yarpl/CMakeLists.txt
+++ b/experimental/vjn/yarpl/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(yarpl)
+file(GLOB_RECURSE SOURCES src/*.cc include/*.h )
+add_library(${PROJECT_NAME} ${SOURCES})
+find_package(Boost REQUIRED COMPONENTS filesystem regex system)
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} glog gflags)
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC "${PROJECT_SOURCE_DIR}/include")
+
+project(yarpl-main)
+file(GLOB_RECURSE MAIN_SOURCES main/*.cc main/*.h)
+add_executable(${PROJECT_NAME} ${MAIN_SOURCES})
+target_link_libraries(${PROJECT_NAME} yarpl)
+
+project(yarpl-test)
+file(GLOB_RECURSE TEST_SOURCES test/*.cc test/*.h)
+add_executable(${PROJECT_NAME} ${TEST_SOURCES})
+target_link_libraries(${PROJECT_NAME} yarpl gtest gmock_main)
+
+project(yarpl-benchmark)
+file(GLOB_RECURSE BENCHMARK_SOURCES benchmark/*.cc benchmark/*.h)
+add_executable(${PROJECT_NAME} ${BENCHMARK_SOURCES})
+target_link_libraries(${PROJECT_NAME} yarpl benchmark)

--- a/experimental/vjn/yarpl/benchmark/main.cc
+++ b/experimental/vjn/yarpl/benchmark/main.cc
@@ -1,0 +1,3 @@
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN()

--- a/experimental/vjn/yarpl/include/reactivestreams/publisher.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/publisher.h
@@ -4,12 +4,12 @@
 
 namespace reactivestreams {
 
-template<typename T>
+template <typename T>
 class Subscriber;
 
-template<typename T>
+template <typename T>
 class Publisher {
-public:
+ public:
   virtual ~Publisher() = default;
   virtual void subscribe(std::unique_ptr<Subscriber<T>> subscriber) = 0;
 };

--- a/experimental/vjn/yarpl/include/reactivestreams/publisher.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/publisher.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+namespace reactivestreams {
+
+template<typename T>
+class Subscriber;
+
+template<typename T>
+class Publisher {
+public:
+  virtual ~Publisher() = default;
+  virtual void subscribe(std::unique_ptr<Subscriber<T>> subscriber) = 0;
+};
+
+}  // reactivestreams

--- a/experimental/vjn/yarpl/include/reactivestreams/subscriber.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/subscriber.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <exception>
+#include <memory>
+
+#include "type_traits.h"
+
+namespace reactivestreams {
+
+template<typename T>
+class Subscription;
+
+template<typename T>
+class Subscriber {
+public:
+  virtual ~Subscriber() = default;
+
+  virtual void on_next(const T& value) {}
+  virtual void on_next(T&& value) { on_next(value); }
+  virtual void on_error(const std::exception& error) { throw error; }
+  virtual void on_complete() {}
+  virtual void on_subscribe(Subscription<T>* subscription) {}
+
+  template<
+      typename Next,
+      typename = typename std::enable_if<
+          std::is_callable<Next(const T&), void>::value
+          >::type>
+  static std::unique_ptr<Subscriber<T>> create(Next&& next) {
+    return std::unique_ptr<Subscriber<T>>(
+        new Derived1<Next>(std::forward<Next>(next)));
+  }
+
+  template<
+      typename Next,
+      typename Error,
+      typename = typename std::enable_if<
+          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Error(const std::exception&), void>::value
+          >::type>
+  static std::unique_ptr<Subscriber<T>> create(Next&& next, Error&& error) {
+    return std::unique_ptr<Subscriber<T>>(
+        new Derived2<Next, Error>(
+            std::forward<Next>(next),
+            std::forward<Error>(error)));
+  }
+
+  template<
+      typename Next,
+      typename Error,
+      typename Complete,
+      typename = typename std::enable_if<
+          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Error(const std::exception&), void>::value &&
+          std::is_callable<Complete(), void>::value
+          >::type>
+  static std::unique_ptr<Subscriber<T>> create(
+      Next&& next, Error&& error, Complete&& complete) {
+    return std::unique_ptr<Subscriber<T>>(
+        new Derived3<Next, Error, Complete>(
+            std::forward<Next>(next),
+            std::forward<Error>(error),
+            std::forward<Complete>(complete)));
+  }
+
+private:
+  template<typename Next>
+  class Derived1 : public Subscriber {
+  public:
+    Derived1(Next&& next) : next_(std::forward<Next>(next)) {}
+
+    virtual void on_next(const T& value) {
+      next_(value);
+    }
+
+  private:
+    Next next_;
+  };
+
+  template<typename Next, typename Error>
+  class Derived2 : public Derived1<Next> {
+  public:
+    Derived2(Next&& next, Error&& error)
+      : Derived1<Next>(std::forward<Next>(next)),
+        error_(std::forward<Error>(error)) {}
+
+    virtual void on_error(const std::exception &error) {
+      error_(error);
+    }
+
+  private:
+    Error error_;
+  };
+
+  template<typename Next, typename Error, typename Complete>
+  class Derived3 : public Derived2<Next, Error> {
+  public:
+    Derived3(Next&& next, Error&& error, Complete&& complete)
+      : Derived2<Next, Error>(
+          std::forward<Next>(next), std::forward<Error>(error)),
+        complete_(std::forward<Complete>(complete)) {}
+
+    virtual void on_complete() {
+      complete_();
+    }
+
+  private:
+    Complete complete_;
+  };
+};
+
+}  // reactivestreams

--- a/experimental/vjn/yarpl/include/reactivestreams/subscriber.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/subscriber.h
@@ -17,7 +17,7 @@ class Subscriber {
 
   virtual void on_next(const T&) {}
   virtual void on_next(T&& value) { on_next(value); }
-  virtual void on_error(const std::exception& error) { throw error; }
+  virtual void on_error(const std::exception_ptr error) { throw error; }
   virtual void on_complete() {}
   virtual void on_subscribe(Subscription<T>*) {}
 
@@ -33,7 +33,7 @@ class Subscriber {
       typename Next, typename Error,
       typename = typename std::enable_if<
           std::is_callable<Next(const T&), void>::value &&
-          std::is_callable<Error(const std::exception&), void>::value>::type>
+          std::is_callable<Error(const std::exception_ptr), void>::value>::type>
   static std::unique_ptr<Subscriber<T>> create(Next&& next, Error&& error) {
     return std::unique_ptr<Subscriber<T>>(new Derived2<Next, Error>(
         std::forward<Next>(next), std::forward<Error>(error)));
@@ -42,7 +42,7 @@ class Subscriber {
   template <typename Next, typename Error, typename Complete,
             typename = typename std::enable_if<
                 std::is_callable<Next(const T&), void>::value &&
-                std::is_callable<Error(const std::exception&), void>::value &&
+                std::is_callable<Error(const std::exception_ptr), void>::value &&
                 std::is_callable<Complete(), void>::value>::type>
   static std::unique_ptr<Subscriber<T>> create(Next&& next, Error&& error,
                                                Complete&& complete) {
@@ -70,7 +70,7 @@ class Subscriber {
         : Derived1<Next>(std::forward<Next>(next)),
           error_(std::forward<Error>(error)) {}
 
-    virtual void on_error(const std::exception& error) { error_(error); }
+    virtual void on_error(const std::exception_ptr error) { error_(error); }
 
    private:
     Error error_;

--- a/experimental/vjn/yarpl/include/reactivestreams/subscription.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/subscription.h
@@ -1,27 +1,28 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
+#include "subscriber.h"
+
 namespace reactivestreams {
 
-template<typename T>
+template <typename T>
 class Subscription {
-public:
+ public:
   virtual ~Subscription() = default;
   virtual void request(long n) = 0;
   virtual void cancel() = 0;
 };
 
-template<typename T, typename Next>
+template <typename T, typename Next>
 class DeletingSubscription : public Subscription<T> {
-public:
-  DeletingSubscription(
-      std::shared_ptr<Next> function,
-      std::unique_ptr<Subscriber<T>> subscriber)
-        : function_(function),
-          subscriber_(std::move(subscriber)) {}
+ public:
+  DeletingSubscription(std::shared_ptr<Next> function,
+                       std::unique_ptr<Subscriber<T>> subscriber)
+      : function_(function), subscriber_(std::move(subscriber)) {}
 
   void start() {
     subscriber_->on_subscribe(this);
@@ -36,10 +37,10 @@ public:
     delete this;
   }
 
-  void request(long n) {}
+  void request(long) {}
   void cancel() {}
 
-private:
+ private:
   std::shared_ptr<Next> function_;
   std::unique_ptr<Subscriber<T>> subscriber_;
 };

--- a/experimental/vjn/yarpl/include/reactivestreams/subscription.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/subscription.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <atomic>
+#include <type_traits>
+#include <utility>
+
+namespace reactivestreams {
+
+template<typename T>
+class Subscription {
+public:
+  virtual ~Subscription() = default;
+  virtual void request(long n) = 0;
+  virtual void cancel() = 0;
+};
+
+template<typename T, typename Next>
+class DeletingSubscription : public Subscription<T> {
+public:
+  DeletingSubscription(
+      std::shared_ptr<Next> function,
+      std::unique_ptr<Subscriber<T>> subscriber)
+        : function_(function),
+          subscriber_(std::move(subscriber)) {}
+
+  void start() {
+    subscriber_->on_subscribe(this);
+
+    try {
+      (*function_)(*subscriber_);
+      subscriber_->on_complete();
+    } catch (std::exception& error) {
+      subscriber_->on_error(error);
+    }
+
+    delete this;
+  }
+
+  void request(long n) {}
+  void cancel() {}
+
+private:
+  std::shared_ptr<Next> function_;
+  std::unique_ptr<Subscriber<T>> subscriber_;
+};
+
+}  // reactivestreams

--- a/experimental/vjn/yarpl/include/reactivestreams/subscription.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/subscription.h
@@ -30,8 +30,8 @@ class DeletingSubscription : public Subscription<T> {
     try {
       (*function_)(*subscriber_);
       subscriber_->on_complete();
-    } catch (std::exception& error) {
-      subscriber_->on_error(error);
+    } catch (...) {
+      subscriber_->on_error(std::current_exception());
     }
 
     delete this;

--- a/experimental/vjn/yarpl/include/reactivestreams/type_traits.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/type_traits.h
@@ -8,18 +8,19 @@ namespace std {
 
 namespace implementation {
 
-template<typename C, typename R, typename Enable = void>
+template <typename C, typename R, typename Enable = void>
 struct is_callable : std::false_type {};
 
-template<typename F, typename... Args, typename R>
-struct is_callable<F(Args...), R, std::enable_if_t<
-    std::is_same<R, std::result_of_t<F(Args...)>>::value>> : std::true_type {};
+template <typename F, typename... Args, typename R>
+struct is_callable<
+    F(Args...), R,
+    std::enable_if_t<std::is_same<R, std::result_of_t<F(Args...)>>::value>>
+    : std::true_type {};
 
 }  // implementation
 
-template<typename Call, typename Return>
+template <typename Call, typename Return>
 struct is_callable : implementation::is_callable<Call, Return> {};
 
 }  // std
 #endif  // __cplusplus
-

--- a/experimental/vjn/yarpl/include/reactivestreams/type_traits.h
+++ b/experimental/vjn/yarpl/include/reactivestreams/type_traits.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <type_traits>
+
+#if __cplusplus < 201500
+
+namespace std {
+
+namespace implementation {
+
+template<typename C, typename R, typename Enable = void>
+struct is_callable : std::false_type {};
+
+template<typename F, typename... Args, typename R>
+struct is_callable<F(Args...), R, std::enable_if_t<
+    std::is_same<R, std::result_of_t<F(Args...)>>::value>> : std::true_type {};
+
+}  // implementation
+
+template<typename Call, typename Return>
+struct is_callable : implementation::is_callable<Call, Return> {};
+
+}  // std
+#endif  // __cplusplus
+

--- a/experimental/vjn/yarpl/include/yarpl/flowable.h
+++ b/experimental/vjn/yarpl/include/yarpl/flowable.h
@@ -22,16 +22,12 @@ public:
   template<typename F, typename = typename std::enable_if<
       std::is_callable<F(Subscriber&), void>::value>::type>
   static std::shared_ptr<Flowable> create(F&& function) {
-    return std::shared_ptr<Flowable>(
-        new Derived<F>(std::forward<F>(function)));
+    return std::make_shared<Derived<F>>(std::forward<F>(function));
   }
 
   template<typename F, typename = typename std::enable_if<
       std::is_callable<F(T), typename std::result_of<F(T)>::type>::value>::type>
-  auto map(F&& function) {
-    return std::shared_ptr<Flowable<typename std::result_of<F(T)>::type>>(
-        new Mapper<F>(std::forward<F>(function), this->shared_from_this()));
-  }
+  auto map(F&& function);
 
   virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
       Scheduler& scheduler) = 0;
@@ -69,58 +65,19 @@ private:
   private:
     const std::shared_ptr<Function> function_;
   };
-
-  template<typename Transform>
-  class Mapper : public Flowable, public Subscriber {
-  public:
-    Mapper(Transform&& transform, std::shared_ptr<Flowable<T>> upstream)
-        : forwarder_(std::unique_ptr<Forwarder>(
-            new Forwarder(std::forward<Transform>(transform)))),
-          upstream_(upstream) {}
-
-    void subscribe(std::unique_ptr<Subscriber> subscriber) override {
-      // TODO(vjn): check that subscriber_.get() == nullptr?
-      forwarder_->set_subscriber(std::move(subscriber));
-      upstream_->subscribe(std::move(forwarder_));
-    }
-
-    virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
-        Scheduler& scheduler) override {
-    }
-  private:
-    class Forwarder : public Subscriber {
-    public:
-      Forwarder(Transform&& transform)
-          : transform_(std::forward<Transform>(transform)) {}
-
-      void set_subscriber(std::unique_ptr<Subscriber> subscriber) {
-        subscriber_ = std::move(subscriber);
-      }
-
-      virtual void on_next(const T& value) override {
-        subscriber_->on_next(transform_(value));
-      }
-
-      virtual void on_error(const std::exception& error) override {
-        subscriber_->on_error(error);
-      }
-
-      virtual void on_complete() override {
-        subscriber_->on_complete();
-      }
-
-      virtual void on_subscribe(Subscription* subscription) override {
-        subscriber_->on_subscribe(subscription);
-      }
-
-    private:
-      Transform transform_;
-      std::unique_ptr<Subscriber> subscriber_;
-    };
-
-    std::unique_ptr<Forwarder> forwarder_;
-    const std::shared_ptr<Flowable<T>> upstream_;
-  };
 };
+
+}  // yarpl
+
+#include "yarpl/operators/map.h"
+
+namespace yarpl {
+
+template<typename T>
+template<typename F, typename Default>
+auto Flowable<T>::map(F&& function) {
+  return std::make_shared<operators::Mapper<T, F>>(
+      std::forward<F>(function), this->shared_from_this());
+}
 
 }  // yarpl

--- a/experimental/vjn/yarpl/include/yarpl/flowable.h
+++ b/experimental/vjn/yarpl/include/yarpl/flowable.h
@@ -12,57 +12,59 @@
 
 namespace yarpl {
 
-template<typename T>
+template <typename T>
 class Flowable : public reactivestreams::Publisher<T>,
-    public std::enable_shared_from_this<Flowable<T>> {
+                 public std::enable_shared_from_this<Flowable<T>> {
   using Subscriber = reactivestreams::Subscriber<T>;
   using Subscription = reactivestreams::Subscription<T>;
 
-public:
-  template<typename F, typename = typename std::enable_if<
-      std::is_callable<F(Subscriber&), void>::value>::type>
+ public:
+  template <typename F,
+            typename = typename std::enable_if<
+                std::is_callable<F(Subscriber&), void>::value>::type>
   static std::shared_ptr<Flowable> create(F&& function) {
     return std::make_shared<Derived<F>>(std::forward<F>(function));
   }
 
-  template<typename F, typename = typename std::enable_if<
-      std::is_callable<F(T), typename std::result_of<F(T)>::type>::value>::type>
+  template <typename F,
+            typename = typename std::enable_if<std::is_callable<
+                F(T), typename std::result_of<F(T)>::type>::value>::type>
   auto map(F&& function);
 
   virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
-      Scheduler& scheduler) = 0;
+                            Scheduler& scheduler) = 0;
 
-protected:
+ protected:
   Flowable() = default;
 
-private:
+ private:
   Flowable(Flowable&&) = delete;
   Flowable(const Flowable&) = delete;
   Flowable& operator=(Flowable&&) = delete;
-  Flowable& operator=(const Flowable &) = delete;
+  Flowable& operator=(const Flowable&) = delete;
 
-  template<typename Function>
+  template <typename Function>
   class Derived : public Flowable {
-  public:
+   public:
     Derived(Function&& function)
-        : function_(std::make_shared<Function>(
-            std::forward<Function>(function))) {}
+        : function_(
+              std::make_shared<Function>(std::forward<Function>(function))) {}
 
     void subscribe(std::unique_ptr<Subscriber> subscriber) override {
       (new reactivestreams::DeletingSubscription<T, Function>(
-          function_, std::move(subscriber)))->start();
+           function_, std::move(subscriber)))
+          ->start();
     }
 
     virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
-        Scheduler& scheduler) override {
-      auto subscription = new reactivestreams::DeletingSubscription<
-          T, Function>(function_, std::move(subscriber));
-      scheduler.schedule([subscription] {
-        subscription->start();
-      });
+                              Scheduler& scheduler) override {
+      auto subscription =
+          new reactivestreams::DeletingSubscription<T, Function>(
+              function_, std::move(subscriber));
+      scheduler.schedule([subscription] { subscription->start(); });
     }
 
-  private:
+   private:
     const std::shared_ptr<Function> function_;
   };
 };
@@ -73,11 +75,11 @@ private:
 
 namespace yarpl {
 
-template<typename T>
-template<typename F, typename Default>
+template <typename T>
+template <typename F, typename Default>
 auto Flowable<T>::map(F&& function) {
-  return std::make_shared<operators::Mapper<T, F>>(
-      std::forward<F>(function), this->shared_from_this());
+  return std::make_shared<operators::Mapper<T, F>>(std::forward<F>(function),
+                                                   this->shared_from_this());
 }
 
 }  // yarpl

--- a/experimental/vjn/yarpl/include/yarpl/flowable.h
+++ b/experimental/vjn/yarpl/include/yarpl/flowable.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <reactivestreams/publisher.h>
+#include <reactivestreams/subscription.h>
+#include <reactivestreams/type_traits.h>
+
+#include "yarpl/scheduler.h"
+
+namespace yarpl {
+
+template<typename T>
+class Flowable : public reactivestreams::Publisher<T>,
+    public std::enable_shared_from_this<Flowable<T>> {
+  using Subscriber = reactivestreams::Subscriber<T>;
+  using Subscription = reactivestreams::Subscription<T>;
+
+public:
+  template<typename F, typename = typename std::enable_if<
+      std::is_callable<F(Subscriber&), void>::value>::type>
+  static std::shared_ptr<Flowable> create(F&& function) {
+    return std::shared_ptr<Flowable>(
+        new Derived<F>(std::forward<F>(function)));
+  }
+
+  template<typename F, typename = typename std::enable_if<
+      std::is_callable<F(T), typename std::result_of<F(T)>::type>::value>::type>
+  auto map(F&& function) {
+    return std::shared_ptr<Flowable<typename std::result_of<F(T)>::type>>(
+        new Mapper<F>(std::forward<F>(function), this->shared_from_this()));
+  }
+
+  virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
+      Scheduler& scheduler) = 0;
+
+protected:
+  Flowable() = default;
+
+private:
+  Flowable(Flowable&&) = delete;
+  Flowable(const Flowable&) = delete;
+  Flowable& operator=(Flowable&&) = delete;
+  Flowable& operator=(const Flowable &) = delete;
+
+  template<typename Function>
+  class Derived : public Flowable {
+  public:
+    Derived(Function&& function)
+        : function_(std::make_shared<Function>(
+            std::forward<Function>(function))) {}
+
+    void subscribe(std::unique_ptr<Subscriber> subscriber) override {
+      (new reactivestreams::DeletingSubscription<T, Function>(
+          function_, std::move(subscriber)))->start();
+    }
+
+    virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
+        Scheduler& scheduler) override {
+      auto subscription = new reactivestreams::DeletingSubscription<
+          T, Function>(function_, std::move(subscriber));
+      scheduler.schedule([subscription] {
+        subscription->start();
+      });
+    }
+
+  private:
+    const std::shared_ptr<Function> function_;
+  };
+
+  template<typename Transform>
+  class Mapper : public Flowable, public Subscriber {
+  public:
+    Mapper(Transform&& transform, std::shared_ptr<Flowable<T>> upstream)
+        : forwarder_(std::unique_ptr<Forwarder>(
+            new Forwarder(std::forward<Transform>(transform)))),
+          upstream_(upstream) {}
+
+    void subscribe(std::unique_ptr<Subscriber> subscriber) override {
+      // TODO(vjn): check that subscriber_.get() == nullptr?
+      forwarder_->set_subscriber(std::move(subscriber));
+      upstream_->subscribe(std::move(forwarder_));
+    }
+
+    virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
+        Scheduler& scheduler) override {
+    }
+  private:
+    class Forwarder : public Subscriber {
+    public:
+      Forwarder(Transform&& transform)
+          : transform_(std::forward<Transform>(transform)) {}
+
+      void set_subscriber(std::unique_ptr<Subscriber> subscriber) {
+        subscriber_ = std::move(subscriber);
+      }
+
+      virtual void on_next(const T& value) override {
+        subscriber_->on_next(transform_(value));
+      }
+
+      virtual void on_error(const std::exception& error) override {
+        subscriber_->on_error(error);
+      }
+
+      virtual void on_complete() override {
+        subscriber_->on_complete();
+      }
+
+      virtual void on_subscribe(Subscription* subscription) override {
+        subscriber_->on_subscribe(subscription);
+      }
+
+    private:
+      Transform transform_;
+      std::unique_ptr<Subscriber> subscriber_;
+    };
+
+    std::unique_ptr<Forwarder> forwarder_;
+    const std::shared_ptr<Flowable<T>> upstream_;
+  };
+};
+
+}  // yarpl

--- a/experimental/vjn/yarpl/include/yarpl/operators/map.h
+++ b/experimental/vjn/yarpl/include/yarpl/operators/map.h
@@ -46,7 +46,7 @@ class Mapper : public Flowable<T>, public ::reactivestreams::Subscriber<T> {
       subscriber_->on_next(transform_(value));
     }
 
-    virtual void on_error(const std::exception& error) override {
+    virtual void on_error(const std::exception_ptr error) override {
       subscriber_->on_error(error);
     }
 

--- a/experimental/vjn/yarpl/include/yarpl/operators/map.h
+++ b/experimental/vjn/yarpl/include/yarpl/operators/map.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <yarpl/flowable.h>
+#include <reactivestreams/subscriber.h>
+
+namespace yarpl { namespace operators {
+
+using ::reactivestreams::Subscriber;
+
+template<typename T, typename Transform>
+class Mapper : public Flowable<T>, public ::reactivestreams::Subscriber<T> {
+  using Flowable = ::yarpl::Flowable<T>;
+  using Subscriber = ::reactivestreams::Subscriber<T>;
+  using Subscription = ::reactivestreams::Subscription<T>;
+public:
+  Mapper(Transform&& transform, std::shared_ptr<Flowable> upstream)
+      : forwarder_(std::unique_ptr<Forwarder>(
+          new Forwarder(std::forward<Transform>(transform)))),
+        upstream_(upstream) {}
+
+  void subscribe(std::unique_ptr<Subscriber> subscriber) override {
+    // TODO(vjn): check that subscriber_.get() == nullptr?
+    forwarder_->set_subscriber(std::move(subscriber));
+    upstream_->subscribe(std::move(forwarder_));
+  }
+
+  virtual void subscribe_on(std::unique_ptr<Subscriber> subscriber,
+      Scheduler& scheduler) override {
+  }
+private:
+  class Forwarder : public Subscriber {
+  public:
+    Forwarder(Transform&& transform)
+        : transform_(std::forward<Transform>(transform)) {}
+
+    void set_subscriber(std::unique_ptr<Subscriber> subscriber) {
+      subscriber_ = std::move(subscriber);
+    }
+
+    virtual void on_next(const T& value) override {
+      subscriber_->on_next(transform_(value));
+    }
+
+    virtual void on_error(const std::exception& error) override {
+      subscriber_->on_error(error);
+    }
+
+    virtual void on_complete() override {
+      subscriber_->on_complete();
+    }
+
+    virtual void on_subscribe(Subscription* subscription) override {
+      subscriber_->on_subscribe(subscription);
+    }
+
+  private:
+    Transform transform_;
+    std::unique_ptr<Subscriber> subscriber_;
+  };
+
+  std::unique_ptr<Forwarder> forwarder_;
+  const std::shared_ptr<Flowable> upstream_;
+};
+
+}}  // yarpl::operators

--- a/experimental/vjn/yarpl/include/yarpl/scheduler.h
+++ b/experimental/vjn/yarpl/include/yarpl/scheduler.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <functional>
 #include <reactivestreams/type_traits.h>
+#include <functional>
 
 namespace yarpl {
 
 class Scheduler {
-public:
+ public:
+  virtual ~Scheduler() = default;
   virtual void schedule(std::function<void()>&& action) = 0;
 };
 

--- a/experimental/vjn/yarpl/include/yarpl/scheduler.h
+++ b/experimental/vjn/yarpl/include/yarpl/scheduler.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <functional>
+#include <reactivestreams/type_traits.h>
+
+namespace yarpl {
+
+class Scheduler {
+public:
+  virtual void schedule(std::function<void()>&& action) = 0;
+};
+
+}  // yarpl

--- a/experimental/vjn/yarpl/main/main.cc
+++ b/experimental/vjn/yarpl/main/main.cc
@@ -16,8 +16,14 @@ auto make_subscriber(int state) {
       [state](int i) mutable {
         std::cout << "  state: " << ++state << ", i = " << i << std::endl;
       },
-      [](const std::exception& error) {
-        std::cout << "  exception: " << error.what() << std::endl;
+      [](const std::exception_ptr eptr) {
+        try {
+          std::rethrow_exception(eptr);
+        } catch (const std::exception& exception) {
+          std::cerr << "  exception: " << exception.what() << std::endl;
+        } catch (...) {
+          std::cerr << "  !unknown exception!" << std::endl;
+        }
       },
       []() { std::cout << "  complete." << std::endl; });
 }

--- a/experimental/vjn/yarpl/main/main.cc
+++ b/experimental/vjn/yarpl/main/main.cc
@@ -1,0 +1,77 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <reactivestreams/subscriber.h>
+#include <yarpl/flowable.h>
+#include <yarpl/scheduler.h>
+
+namespace {
+
+using reactivestreams::Subscriber;
+
+auto make_subscriber(int state) {
+  return Subscriber<int>::create(
+      [state](int i) mutable {
+        std::cout << "  state: " << ++state << ", i = " << i << std::endl;
+      },
+      [](const std::exception& error) {
+        std::cout << "  exception: " << error.what() << std::endl;
+      },
+      []() {
+        std::cout << "  complete." << std::endl;
+      });
+}
+
+class Scheduler : public yarpl::Scheduler {
+public:
+  virtual void schedule(std::function<void()>&& action) {
+    std::thread(action).detach();
+  }
+};
+
+}  // namespace
+
+
+int main(int argc, char* argv[]) {
+  using yarpl::Flowable;
+
+  std::cout << "@ do nothing." << std::endl;
+  Flowable<int>::create([=](Subscriber<int>& subscriber) {
+  })->subscribe(make_subscriber(1000));
+
+  std::cout << "@ throw an error." << std::endl;
+  Flowable<int>::create([=](Subscriber<int>& subscriber) {
+    throw std::runtime_error("Don't do that.");
+  })->subscribe(make_subscriber(1000));
+
+  std::cout << "@ multiple next calls." << std::endl;
+  Flowable<int>::create([=](Subscriber<int>& subscriber) {
+    for (int i = 0; i < 3; ++i)
+      subscriber.on_next(100+i);
+  })->subscribe(make_subscriber(500));
+
+  std::cout << "@ table of squares of squares." << std::endl;
+  Flowable<int>::create([=](Subscriber<int>& subscriber) {
+    for (int i = 0; i < 5; ++i)
+      subscriber.on_next(i);
+  })->map([](int x) -> int { return x*x; })
+      ->map([](int x) -> int { return x*x; })
+      ->subscribe(make_subscriber(600));
+
+  auto scheduler = Scheduler();
+
+  auto background = Flowable<int>::create([=](Subscriber<int>& subscriber) {
+    for (int i = 0; i < 5; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      subscriber.on_next(100+i);
+    }
+  });
+
+  background->subscribe_on(make_subscriber(500), scheduler);
+  std::cout << "@ asynchronous, background flowable started." << std::endl;
+
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  return 0;
+}

--- a/experimental/vjn/yarpl/test/test.cc
+++ b/experimental/vjn/yarpl/test/test.cc
@@ -1,5 +1,3 @@
 #include <gtest/gtest.h>
 
-TEST(yarpl, yarpl_simple) {
-  EXPECT_FALSE(false);
-}
+TEST(yarpl, yarpl_simple) { EXPECT_FALSE(false); }

--- a/experimental/vjn/yarpl/test/test.cc
+++ b/experimental/vjn/yarpl/test/test.cc
@@ -1,0 +1,5 @@
+#include <gtest/gtest.h>
+
+TEST(yarpl, yarpl_simple) {
+  EXPECT_FALSE(false);
+}


### PR DESCRIPTION
Main goal is to specify user functionality as function objects (lambdas), and move/copy them into the flowable/subscriber. This is an example, and is far from complete: particularly, there is one operator example, map, but its code needs to be factored properly and used in writing several more.