### PR TITLE
RSocket TcpConnectionFactory Threading

### DIFF
--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -8,20 +8,20 @@
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
 
-using namespace reactivesocket;
 /**
  * Subscriber that logs all events.
  * Request 5 items to begin with, then 3 more after each receipt of 3.
  */
 namespace rsocket_example {
-class ExampleSubscriber : public Subscriber<Payload> {
+class ExampleSubscriber
+    : public reactivesocket::Subscriber<reactivesocket::Payload> {
  public:
   ~ExampleSubscriber();
   ExampleSubscriber(int initialRequest, int numToTake);
 
-  void onSubscribe(
-      std::shared_ptr<Subscription> subscription) noexcept override;
-  void onNext(Payload element) noexcept override;
+  void onSubscribe(std::shared_ptr<reactivesocket::Subscription>
+                       subscription) noexcept override;
+  void onNext(reactivesocket::Payload element) noexcept override;
   void onComplete() noexcept override;
   void onError(folly::exception_wrapper ex) noexcept override;
 
@@ -33,7 +33,7 @@ class ExampleSubscriber : public Subscriber<Payload> {
   int numToTake_;
   int requested_;
   int received_;
-  std::shared_ptr<Subscription> subscription_;
+  std::shared_ptr<reactivesocket::Subscription> subscription_;
   bool terminated_{false};
   std::mutex m_;
   std::condition_variable terminalEventCV_;

--- a/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <rsocket/transports/TcpConnectionAcceptor.h>
+#include "rsocket/transports/TcpConnectionAcceptor.h"
 #include "src/framed/FramedDuplexConnection.h"
 #include "src/tcp/TcpDuplexConnection.h"
 

--- a/experimental/rsocket/transports/TcpConnectionFactory.h
+++ b/experimental/rsocket/transports/TcpConnectionFactory.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
 #include "rsocket/ConnectionFactory.h"
 #include "src/DuplexConnection.h"
 
@@ -13,12 +14,13 @@ namespace rsocket {
 *
 * Creation of this does nothing. The 'start' method kicks off work.
 *
-* When started it will create a Thread, EventBase, and AsyncSocket.
+* When started it will create a Thread and EventBase upon which
+* all AsyncSocket connections will be made.
 */
 class TcpConnectionFactory : public ConnectionFactory {
  public:
   TcpConnectionFactory(std::string host, uint16_t port);
-  // TODO create variant that passes in Thread/EventBase to use
+  // TODO create variant that passes in EventBase to use
   virtual ~TcpConnectionFactory();
   TcpConnectionFactory(const TcpConnectionFactory&) = delete; // copy
   TcpConnectionFactory(TcpConnectionFactory&&) = delete; // move
@@ -32,8 +34,6 @@ class TcpConnectionFactory : public ConnectionFactory {
   /**
    * Connect to server defined in constructor.
    *
-   * Each time this is called a new AsyncSocket is created and connected.
-   *
    * This creates a new AsyncSocket each time connect(...) is called.
    *
    * @param onConnect
@@ -42,5 +42,6 @@ class TcpConnectionFactory : public ConnectionFactory {
 
  private:
   folly::SocketAddress addr_;
+  std::unique_ptr<folly::ScopedEventBaseThread> eventBaseThread_;
 };
 }


### PR DESCRIPTION
Use a single thread/eventBase for an entire TcpConnectionFactory.

Also fixes the shutdown issue so destruction is now clean:

```
I0310 18:39:16.841248 3910693824 RSocketClient.cpp:53] RSocketClient => destroy
I0310 18:39:16.841277 127508480 RSocketRequester.cpp:15] RSocketRequester => destroy on EventBase
I0310 18:39:16.841287 127508480 RSocketRequester.cpp:31] RSocketRequester => destroy
I0310 18:39:16.841421 127508480 RSocketRequester.cpp:15] RSocketRequester => destroy on EventBase
I0310 18:39:16.841437 127508480 RSocketRequester.cpp:31] RSocketRequester => destroy
I0310 18:39:16.841505 3910693824 TcpConnectionFactory.cpp:97] ConnectionFactory => destroy

Process finished with exit code 0
```