### PR TITLE
Flowable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 
 ### CMake ###
 CMakeCache.txt
-CMakeFiles
+CMakeFiles/
+CMakeLists.txt.user
 CMakeScripts
 Makefile
 cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ endif()
 
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${META_CXX_STD}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-func-template")
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
@@ -202,6 +203,7 @@ add_library(
 target_link_libraries(
   ReactiveSocket
   ${FOLLY_LIBRARIES}
+  ${GFLAGS_LIBRARY}
   ${GLOG_LIBRARY})
 
 add_dependencies(ReactiveSocket ReactiveStreams)
@@ -374,7 +376,7 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
-# add_subdirectory(experimental/yarpl)
+add_subdirectory(experimental/yarpl)
 
 ########################################
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
-add_subdirectory(experimental/yarpl)
+# add_subdirectory(experimental/yarpl)
 
 ########################################
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ target_link_libraries(
 
 add_dependencies(tcpresumeserver gmock)
 
-# add_subdirectory(experimental/yarpl)
+add_subdirectory(experimental/yarpl)
 
 ########################################
 # Examples

--- a/experimental/yarpl/CMakeLists.txt
+++ b/experimental/yarpl/CMakeLists.txt
@@ -15,9 +15,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables -Wpadded")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
 
 # Configuration for Debug build mode.

--- a/experimental/yarpl/CMakeLists.txt
+++ b/experimental/yarpl/CMakeLists.txt
@@ -11,7 +11,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -momit-leaf-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
 
 # Configuration for Debug build mode.
 #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
@@ -46,6 +49,8 @@ add_library(
         include/yarpl/Flowable_Subscriber.h
         include/yarpl/Flowable_SubscriptionSync.h
         include/yarpl/Flowable_TestSubscriber.h
+        # hack-y extraction of test code
+        include/yarpl/Tuple.h
         # Flowable sources
         src/yarpl/flowable/sources/Flowable_RangeSubscription.h
         src/yarpl/flowable/sources/Flowable_RangeSubscription.cpp
@@ -64,6 +69,16 @@ add_library(
         src/yarpl/ThreadScheduler.h
         # move this out at some point
         include/reactivestreams/ReactiveStreams.h
+        # hack-y extraction of test code
+        src/yarpl/Tuple.cpp
+        # The "v" version of Flowable.
+        include/yarpl/v/Flowable.h
+        include/yarpl/v/Flowables.h
+        include/yarpl/v/FlowableV.h
+        include/yarpl/v/Operator.h
+        include/yarpl/v/Subscriber.h
+        include/yarpl/v/Subscribers.h
+        include/yarpl/v/Subscription.h
 )
 
 target_include_directories(
@@ -85,6 +100,8 @@ add_executable(
         examples/FlowableBExamples.h
         examples/FlowableCExamples.cpp
         examples/FlowableCExamples.h
+        examples/FlowableVExamples.cpp
+        examples/FlowableVExamples.h
 )
 
 target_link_libraries(

--- a/experimental/yarpl/CMakeLists.txt
+++ b/experimental/yarpl/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required (VERSION 3.4)
+
+# To debug the project, set the build type.
+set(CMAKE_BUILD_TYPE Debug)
+
 project (yarpl)
 
 # CMake Config
@@ -76,6 +80,7 @@ add_library(
         include/yarpl/v/Flowables.h
         include/yarpl/v/FlowableV.h
         include/yarpl/v/Operator.h
+        include/yarpl/v/Refcounted.h
         include/yarpl/v/Subscriber.h
         include/yarpl/v/Subscribers.h
         include/yarpl/v/Subscription.h

--- a/experimental/yarpl/examples/FlowableVExamples.cpp
+++ b/experimental/yarpl/examples/FlowableVExamples.cpp
@@ -19,7 +19,7 @@ template<typename T>
 auto printer() {
   return Subscribers::create<T>([](T value) {
     std::cout << "  next: " << value << std::endl;
-  }, 2);
+  }, 2 /* low [optional] batch size for demo */);
 }
 
 }  // namespace

--- a/experimental/yarpl/examples/FlowableVExamples.cpp
+++ b/experimental/yarpl/examples/FlowableVExamples.cpp
@@ -25,6 +25,9 @@ auto printer() {
 }  // namespace
 
 void FlowableVExamples::run() {
+  std::cout << "create a flowable" << std::endl;
+  Flowables::range(2, 2);
+
   std::cout << "just: single value" << std::endl;
   Flowables::just<long>(23)
       ->subscribe(printer<long>());
@@ -52,36 +55,12 @@ void FlowableVExamples::run() {
       ->map([](int64_t v) { return std::to_string(v); })
       ->map([](std::string v) { return "-> " + v + " <-"; })
       ->subscribe(printer<std::string>());
+
+  std::cout << "take example: 3 out of 10 items" << std::endl;
+  Flowables::range(1, 11)
+      ->take(3)
+      ->subscribe(printer<int64_t>());
 }
-
-//std::unique_ptr<FlowableV<long>> getC() {
-//  return FlowablesV::range(1, 10);
-//}
-
-//void FlowableVExamples::run() {
-//  FlowableV<long>::create([](auto subscriber) {
-//    auto subscription = new yarpl::flowable::sources::RangeSubscription(
-//        1, 10, std::move(subscriber));
-//    subscription->start();
-//  })->subscribe(Subscribers::create<long>([](auto t) {
-//    std::cout << "Value received: " << t << std::endl;
-//  }));
-
-//  FlowablesC::range(1, 5)->subscribe(Subscribers::create<long>(
-//      [](auto t) { std::cout << "Value received: " << t << std::endl; }));
-
-//  getC()
-//      ->map([](auto i) { return "mapped value => " + std::to_string(i); })
-//      ->subscribe(Subscribers::create<std::string>(
-//          [](auto t) { std::cout << "from getC => " << t << std::endl; }));
-
-//  FlowablesC::range(1, 5)
-//      ->map([](auto i) { return "mapped value => " + std::to_string(i); })
-//      ->subscribe(Subscribers::create<std::string>(
-//          [](auto t) { std::cout << "Value received: " << t << std::endl; }));
-
-//  FlowablesC::range(1, 5)->take(2)->subscribe(Subscribers::create<long>(
-//      [](auto t) { std::cout << "Value received: " << t << std::endl; }));
 
 //  ThreadScheduler scheduler;
 

--- a/experimental/yarpl/examples/FlowableVExamples.cpp
+++ b/experimental/yarpl/examples/FlowableVExamples.cpp
@@ -1,0 +1,102 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "FlowableVExamples.h"
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "yarpl/ThreadScheduler.h"
+
+#include "yarpl/v/Flowables.h"
+#include "yarpl/v/Subscribers.h"
+
+using namespace yarpl;
+
+namespace {
+
+template<typename T>
+auto printer() {
+  return Subscribers::create<T>([](T value) {
+    std::cout << "  next: " << value << std::endl;
+  }, 2);
+}
+
+}  // namespace
+
+void FlowableVExamples::run() {
+  std::cout << "just: single value" << std::endl;
+  Flowables::just<long>(23)
+      ->subscribe(printer<long>());
+
+  std::cout << "just: multiple values." << std::endl;
+  Flowables::just<long>({1, 4, 7, 11})
+      ->subscribe(printer<long>());
+
+  std::cout << "just: string values." << std::endl;
+  Flowables::just<std::string>({"the", "quick", "brown", "fox"})
+      ->subscribe(printer<std::string>());
+
+  std::cout << "range operator." << std::endl;
+  Flowables::range(1, 4)->subscribe(printer<int64_t>());
+
+  std::cout << "map example: squares" << std::endl;
+  Flowables::range(1, 4)
+      ->map([](int64_t v) { return v*v; })
+      ->subscribe(printer<int64_t>());
+
+  std::cout << "map example: convert to string" << std::endl;
+  Flowables::range(1, 4)
+      ->map([](int64_t v) { return v*v; })
+      ->map([](int64_t v) { return v*v; })
+      ->map([](int64_t v) { return std::to_string(v); })
+      ->map([](std::string v) { return "-> " + v + " <-"; })
+      ->subscribe(printer<std::string>());
+}
+
+//std::unique_ptr<FlowableV<long>> getC() {
+//  return FlowablesV::range(1, 10);
+//}
+
+//void FlowableVExamples::run() {
+//  FlowableV<long>::create([](auto subscriber) {
+//    auto subscription = new yarpl::flowable::sources::RangeSubscription(
+//        1, 10, std::move(subscriber));
+//    subscription->start();
+//  })->subscribe(Subscribers::create<long>([](auto t) {
+//    std::cout << "Value received: " << t << std::endl;
+//  }));
+
+//  FlowablesC::range(1, 5)->subscribe(Subscribers::create<long>(
+//      [](auto t) { std::cout << "Value received: " << t << std::endl; }));
+
+//  getC()
+//      ->map([](auto i) { return "mapped value => " + std::to_string(i); })
+//      ->subscribe(Subscribers::create<std::string>(
+//          [](auto t) { std::cout << "from getC => " << t << std::endl; }));
+
+//  FlowablesC::range(1, 5)
+//      ->map([](auto i) { return "mapped value => " + std::to_string(i); })
+//      ->subscribe(Subscribers::create<std::string>(
+//          [](auto t) { std::cout << "Value received: " << t << std::endl; }));
+
+//  FlowablesC::range(1, 5)->take(2)->subscribe(Subscribers::create<long>(
+//      [](auto t) { std::cout << "Value received: " << t << std::endl; }));
+
+//  ThreadScheduler scheduler;
+
+//  FlowablesC::range(1, 10)
+//      ->subscribeOn(scheduler)
+//      ->map([](auto i) {
+//        std::this_thread::sleep_for(std::chrono::milliseconds(400));
+//        return "mapped->" + std::to_string(i);
+//      })
+//      ->take(2)
+//      ->subscribe(Subscribers::create<std::string>([](auto t) {
+//        std::cout << "Value received after scheduling: " << t << std::endl;
+//      }));
+
+//  // wait to see above async example
+//  /* sleep override */
+//  std::this_thread::sleep_for(std::chrono::milliseconds(1300));
+//}

--- a/experimental/yarpl/examples/FlowableVExamples.h
+++ b/experimental/yarpl/examples/FlowableVExamples.h
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+class FlowableVExamples {
+ public:
+  static void run();
+};

--- a/experimental/yarpl/examples/yarpl-playground.cpp
+++ b/experimental/yarpl/examples/yarpl-playground.cpp
@@ -5,11 +5,14 @@
 #include "FlowableBExamples.h"
 #include "FlowableCExamples.h"
 #include "FlowableExamples.h"
+#include "FlowableVExamples.h"
 #include "ObservableExamples.h"
 
 int main() {
-  std::cout << "*** Run ObservableExamples ***" << std::endl;
-  ObservableExamples::run();
+  std::cout << "*** Run yarpl::flowable::v examples ***" << std::endl;
+  FlowableVExamples::run();
+  //  std::cout << "*** Run ObservableExamples ***" << std::endl;
+  //  ObservableExamples::run();
   //  std::cout << "*** Run FlowableExamples ***" << std::endl;
   //  FlowableExamples::run();
   //  std::cout << "*** Run FlowableExamplesA ***" << std::endl;

--- a/experimental/yarpl/include/reactivestreams/ReactiveStreams.h
+++ b/experimental/yarpl/include/reactivestreams/ReactiveStreams.h
@@ -11,6 +11,12 @@ namespace reactivestreams_yarpl {
 /**
  * Emitted from Publisher.subscribe to Subscriber.onSubscribe.
  * Implementations of this SHOULD own the Subscriber lifecycle.
+ *
+ * Rules:
+ * - No subscription methods will be invoked after onError or
+ *   onComplete has been called on the subscriber.
+ * - No more than one invocation of subscription's methods at
+ *   any time: same method, or different ones.
  */
 class Subscription {
  public:

--- a/experimental/yarpl/include/yarpl/v/Flowable.h
+++ b/experimental/yarpl/include/yarpl/v/Flowable.h
@@ -1,0 +1,227 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+#include "reactivestreams/ReactiveStreams.h"
+#include "yarpl/utils/type_traits.h"
+
+#include "Subscriber.h"
+
+namespace yarpl {
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+
+template<typename T>
+class Flowable : public boost::intrusive_ref_counter<Flowable<T>> {
+public:
+  using Handle = boost::intrusive_ptr<Flowable<T>>;
+  using Subscriber = Subscriber<T>;
+
+  virtual ~Flowable() = default;
+  virtual void subscribe(std::unique_ptr<Subscriber>) = 0;
+
+  template<typename Function>
+  auto map(Function&& function);
+
+  /**
+   * Create a flowable from an emitter.
+   *
+   * \param emitter function that is invoked to emit values to a subscriber.
+   * The emitter's signature is:
+   * \code{.cpp}
+   *     std::tuple<int64_t, bool> emitter(Subscriber&, int64_t requested);
+   * \endcode
+   *
+   * The emitter can invoke up to \b requested calls to `onNext()`, and can
+   * optionally make a final call to `onComplete()` or `onError()`; returns
+   * the actual number of `onNext()` calls; and whether the subscription is
+   * finished (completed/in error).
+   *
+   * \return a handle to a flowable that will use the emitter.
+   */
+  template<typename Emitter, typename = typename std::enable_if<
+      std::is_callable<Emitter(Subscriber&, int64_t),
+                       std::tuple<int64_t, bool>>::value>::type>
+  static Handle create(Emitter&& emitter) {
+    return Handle(new Wrapper<Emitter>(std::forward<Emitter>(emitter)));
+  }
+
+private:
+  virtual std::tuple<int64_t, bool> emit(Subscriber&, int64_t) = 0;
+
+  template<typename Emitter>
+  class Wrapper : public Flowable {
+  public:
+    Wrapper(Emitter&& emitter)
+      : emitter_(std::forward<Emitter>(emitter)) {}
+
+    virtual void subscribe(std::unique_ptr<Subscriber> subscriber) {
+      new SynchronousSubscription(this, std::move(subscriber));
+    }
+
+    virtual std::tuple<int64_t, bool> emit(
+        Subscriber& subscriber, int64_t requested) {
+      return emitter_(subscriber, requested);
+    }
+
+  private:
+    Emitter emitter_;
+  };
+
+  /**
+   * Manager for a flowable subscription.
+   *
+   * This is synchronous: the emit calls are triggered within the context
+   * of a request(n) call.
+   */
+  class SynchronousSubscription : public Subscription, public Subscriber {
+  public:
+    SynchronousSubscription(
+        Flowable::Handle handle, std::unique_ptr<Subscriber> subscriber)
+      : flowable_(handle), subscriber_(std::move(subscriber)) {
+      subscriber_->onSubscribe(Handle(this));
+    }
+
+    virtual void request(int64_t delta) override {
+      static auto max = std::numeric_limits<int64_t>::max();
+      if (delta <= 0) {
+        auto message = "request(n): " + std::to_string(delta) + " <= 0";
+        throw std::logic_error(message);
+      }
+
+      while (true) {
+        auto current = requested_.load(std::memory_order_relaxed);
+        auto total = current + delta;
+        if (total < current) {
+          // overflow; cap at max (turn flow control off).
+          total = max;
+        }
+
+        if (requested_.compare_exchange_strong(current, total))
+          break;
+      }
+
+      process();
+    }
+
+    virtual void cancel() override {
+      static auto min = std::numeric_limits<int64_t>::min();
+      auto previous = requested_.exchange(min, std::memory_order_relaxed);
+      if (previous != min) {
+        // we're first to mark the cancellation.  Cancel the upstream.
+      }
+
+      // Note: process() will finalize: releasing our reference on this.
+      process();
+    }
+
+    // Subscriber methods.
+    virtual void onSubscribe(Subscription::Handle) override {
+      // Not actually expected to be called.
+    }
+
+    virtual void onNext(const T& value) override {
+      subscriber_->onNext(value);
+    }
+
+    virtual void onComplete() override {
+      static auto min = std::numeric_limits<int64_t>::min();
+      subscriber_->onComplete();
+      requested_.store(min, std::memory_order_relaxed);
+      // We should already be in process(); nothing more to do.
+      //
+      // Note: we're not invoking the Subscriber superclass' method:
+      // we're following the Subscription's protocol instead.
+    }
+
+    virtual void onError(const std::exception_ptr error) override {
+      static auto min = std::numeric_limits<int64_t>::min();
+      subscriber_->onError(error);
+      requested_.store(min, std::memory_order_relaxed);
+      // We should already be in process(); nothing more to do.
+      //
+      // Note: we're not invoking the Subscriber superclass' method:
+      // we're following the Subscription's protocol instead.
+    }
+
+  private:
+    // Processing loop.  Note: this can delete `this` upon completion,
+    // error, or cancellation; thus, no fields should be accessed once
+    // this method returns.
+    void process() {
+      static auto min = std::numeric_limits<int64_t>::min();
+      static auto max = std::numeric_limits<int64_t>::max();
+
+      std::unique_lock<std::mutex> lock(processing_, std::defer_lock);
+      if (!lock.try_lock()) {
+        return;
+      }
+
+      while (true) {
+        auto current = requested_.load(std::memory_order_relaxed);
+        if (current == min) {
+          // Subscription was canceled, completed, or had an error.
+          return release();
+        }
+
+        // If no more items can be emitted now, wait for a request(n).
+        if (current <= 0) return;
+
+        int64_t emitted;
+        bool done;
+
+        std::tie(emitted, done) = flowable_->emit(
+              *this /* implicit conversion to subscriber */, current);
+
+        while (true) {
+          auto current = requested_.load(std::memory_order_relaxed);
+          if (current == min || (current == max && !done))
+            break;
+
+          auto updated = done ? min : current - emitted;
+          if (requested_.compare_exchange_strong(current, updated))
+            break;
+        }
+      }
+    }
+
+    // The number of items that can be sent downstream.  Each request(n)
+    // adds n; each onNext consumes 1.  If this is MAX, flow-control is
+    // disabled: items sent downstream don't consume any longer.  A MIN
+    // value represents cancellation.  Other -ve values aren't permitted.
+    std::atomic_int_fast64_t requested_{0};
+
+    // We don't want to recursively invoke process(); one loop should do.
+    std::mutex processing_;
+
+    Flowable::Handle flowable_;
+    std::unique_ptr<Subscriber> subscriber_;
+  };
+};
+
+#pragma clang diagnostic pop
+
+}  // yarpl
+
+#include "Operator.h"
+
+namespace yarpl {
+
+template<typename T>
+template<typename Function>
+auto Flowable<T>::map(Function&& function) {
+  using D = typename std::result_of<Function(T)>::type;
+  return typename Flowable<D>::Handle(new MapOperator<T, D, Function>(
+      Flowable<T>::Handle(this), std::forward<Function>(function)));
+}
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Flowable.h
+++ b/experimental/yarpl/include/yarpl/v/Flowable.h
@@ -59,11 +59,12 @@ private:
   template<typename Emitter>
   class Wrapper : public Flowable {
   public:
-    Wrapper(Emitter&& emitter)
+    explicit Wrapper(Emitter&& emitter)
       : emitter_(std::forward<Emitter>(emitter)) {}
 
     virtual void subscribe(Reference<Subscriber> subscriber) {
-      new SynchronousSubscription(this, std::move(subscriber));
+      new SynchronousSubscription(
+            Reference<Flowable>(this), std::move(subscriber));
     }
 
     virtual std::tuple<int64_t, bool> emit(

--- a/experimental/yarpl/include/yarpl/v/FlowableV.h
+++ b/experimental/yarpl/include/yarpl/v/FlowableV.h
@@ -1,0 +1,71 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+//  /**
+//   * Lift an operator into F<T> and return F<R>
+//   * @tparam R
+//   * @tparam F
+//   * @param onSubscribeLift
+//   * @return
+//   */
+//  template <
+//      typename R,
+//      typename F,
+//      typename = typename std::enable_if<std::is_callable<
+//          F(std::unique_ptr<reactivestreams_yarpl::Subscriber<R>>),
+//        std::unique_ptr<reactivestreams_yarpl::Subscriber<T>>>::value>::type>
+//  std::unique_ptr<FlowableV<R>> lift(F&& onSubscribeLift) {
+//    return FlowableV<R>::create(
+//        [ this, onSub = std::move(onSubscribeLift) ](auto sOfR) mutable {
+//          this->subscribe(std::move(onSub(std::move(sOfR))));
+//        });
+//  }
+
+//  /**
+//   * Map F<T> -> F<R>
+//   *
+//   * @tparam F
+//   * @param function
+//   * @return
+//   */
+//  template <
+//      typename F,
+//      typename = typename std::enable_if<
+//         std::is_callable<F(T), typename std::result_of<F(T)>::type>::value>::
+//          type>
+//  std::unique_ptr<FlowableV<typename std::result_of<F(T)>::type>> map(
+//      F&& function);
+
+//  /**
+//   * Take n items from F<T> then cancel.
+//   * @param toTake
+//   * @return
+//   */
+//  std::unique_ptr<FlowableV<T>> take(int64_t toTake) {
+//    return lift<T>(yarpl::operators::FlowableTakeOperator<T>(toTake));
+//  }
+
+//  /**
+//   * SubscribeOn the given Scheduler
+//   * @param scheduler
+//   * @return
+//   */
+//  std::unique_ptr<FlowableV<T>> subscribeOn(yarpl::Scheduler& scheduler) {
+// return lift<T>(yarpl::operators::FlowableSubscribeOnOperator<T>(scheduler));
+//  }
+
+// protected:
+//  FlowableV() = default;
+
+
+//template <typename T>
+//template <typename F, typename Default>
+//std::unique_ptr<FlowableV<typename std::result_of<F(T)>::type>>
+//FlowableV<T>::map(F&& function) {
+//  return lift<typename std::result_of<F(T)>::type>(
+//      yarpl::operators::
+//          FlowableMapOperator<T, typename std::result_of<F(T)>::type, F>(
+//              std::forward<F>(function)));
+//}
+

--- a/experimental/yarpl/include/yarpl/v/Flowables.h
+++ b/experimental/yarpl/include/yarpl/v/Flowables.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <limits>
+
+#include "Flowable.h"
+
+namespace yarpl {
+
+class Flowables {
+public:
+  static Flowable<int64_t>::Handle range(int64_t start, int64_t end) {
+    auto lambda = [start, end, i = start](
+        Subscriber<int64_t>& subscriber, int64_t requested) mutable {
+      int64_t emitted = 0;
+      bool done = false;
+
+      while (i < end && emitted < requested) {
+        subscriber.onNext(i++);
+        ++emitted;
+      }
+
+      if (i >= end) {
+        subscriber.onComplete();
+        done = true;
+      }
+
+      return std::make_tuple(requested, done);
+    };
+
+    return Flowable<int64_t>::create(std::move(lambda));
+  }
+
+  template<typename T>
+  static typename Flowable<T>::Handle just(const T& value) {
+    auto lambda = [value](Subscriber<T>& subscriber, int64_t) {
+      // # requested should be > 0.  Ignoring the actual parameter.
+      subscriber.onNext(value);
+      subscriber.onComplete();
+      return std::make_tuple(static_cast<int64_t>(1), true);
+    };
+
+    return Flowable<T>::create(std::move(lambda));
+  }
+
+  template<typename T>
+  static typename Flowable<T>::Handle just(std::initializer_list<T> list) {
+    auto lambda = [list, it = list.begin()](
+        Subscriber<T>& subscriber, int64_t requested) mutable {
+      int64_t emitted = 0;
+      bool done = false;
+
+      while (it != list.end() && emitted < requested) {
+        subscriber.onNext(*it++);
+        ++emitted;
+      }
+
+      if (it == list.end()) {
+        subscriber.onComplete();
+        done = true;
+      }
+
+      return std::make_tuple(static_cast<int64_t>(emitted), done);
+    };
+
+    return Flowable<T>::create(std::move(lambda));
+  }
+
+private:
+  Flowables() = delete;
+};
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Flowables.h
+++ b/experimental/yarpl/include/yarpl/v/Flowables.h
@@ -8,7 +8,7 @@ namespace yarpl {
 
 class Flowables {
 public:
-  static Flowable<int64_t>::Handle range(int64_t start, int64_t end) {
+  static Reference<Flowable<int64_t>> range(int64_t start, int64_t end) {
     auto lambda = [start, end, i = start](
         Subscriber<int64_t>& subscriber, int64_t requested) mutable {
       int64_t emitted = 0;
@@ -31,7 +31,7 @@ public:
   }
 
   template<typename T>
-  static typename Flowable<T>::Handle just(const T& value) {
+  static Reference<Flowable<T>> just(const T& value) {
     auto lambda = [value](Subscriber<T>& subscriber, int64_t) {
       // # requested should be > 0.  Ignoring the actual parameter.
       subscriber.onNext(value);
@@ -43,7 +43,7 @@ public:
   }
 
   template<typename T>
-  static typename Flowable<T>::Handle just(std::initializer_list<T> list) {
+  static Reference<Flowable<T>> just(std::initializer_list<T> list) {
     auto lambda = [list, it = list.begin()](
         Subscriber<T>& subscriber, int64_t requested) mutable {
       int64_t emitted = 0;

--- a/experimental/yarpl/include/yarpl/v/Operator.h
+++ b/experimental/yarpl/include/yarpl/v/Operator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <utility>
 
 #include "Flowable.h"
@@ -12,40 +11,45 @@ namespace yarpl {
 /**
  * Base (helper) class for operators.  Operators are templated on two types:
  * D and U.
+ *
  */
 template<typename U, typename D>
 class Operator : public Flowable<D> {
 public:
-  Operator(typename Flowable<U>::Handle upstream) : upstream_(upstream) {}
+  Operator(Reference<Flowable<U>> upstream) : upstream_(upstream) {}
 
-  virtual void subscribe(std::unique_ptr<Subscriber<D>> subscriber) override {
-    upstream_->subscribe(std::make_unique<Subscription>(
-        typename Flowable<D>::Handle(this), std::move(subscriber)));
+  virtual void subscribe(Reference<Subscriber<D>> subscriber) override {
+    upstream_->subscribe(Reference<Subscription>(new Subscription(
+        Reference<Flowable<D>>(this), std::move(subscriber))));
   }
 
 protected:
   class Subscription : public ::yarpl::Subscription, public Subscriber<U> {
   public:
-    Subscription(typename Flowable<D>::Handle flowable,
-                 std::unique_ptr<Subscriber<D>> subscriber)
-      : flowable_(flowable), subscriber_(std::move(subscriber)) {
+    Subscription(
+        Reference<Flowable<D>> flowable, Reference<Subscriber<D>> subscriber)
+      : flowable_(flowable), subscriber_(subscriber) {
     }
 
-    virtual void onSubscribe(::yarpl::Subscription::Handle subscription)
+    ~Subscription() {
+      subscriber_.reset();
+    }
+
+    virtual void onSubscribe(Reference<::yarpl::Subscription> subscription)
         override {
       upstream_ = subscription;
-      subscriber_->onSubscribe(::yarpl::Subscription::Handle(this));
+      subscriber_->onSubscribe(Reference<::yarpl::Subscription>(this));
     }
 
     virtual void onComplete() override {
       subscriber_->onComplete();
+      upstream_.reset();
+      release();
     }
 
     virtual void onError(const std::exception_ptr error) override {
       subscriber_->onError(error);
-    }
-
-    virtual void onNext(const U&) override {
+      upstream_.reset();
     }
 
     virtual void  request(int64_t delta) override {
@@ -57,12 +61,12 @@ protected:
     }
 
   protected:
-    typename Flowable<D>::Handle flowable_;
-    std::unique_ptr<Subscriber<D>> subscriber_;
-    ::yarpl::Subscription::Handle upstream_;
+    Reference<Flowable<D>> flowable_;
+    Reference<Subscriber<D>> subscriber_;
+    Reference<::yarpl::Subscription> upstream_;
   };
 
-  typename Flowable<U>::Handle upstream_;
+  Reference<Flowable<U>> upstream_;
 
 private:
   // TODO(vjn): fix: this shouldn't be needed.
@@ -75,20 +79,19 @@ template<typename U, typename D, typename F, typename = typename
          std::enable_if<std::is_callable<F(U), D>::value>::type>
 class MapOperator : public Operator<U, D> {
 public:
-  MapOperator(typename Flowable<U>::Handle upstream, F&& function)
+  MapOperator(Reference<Flowable<U>> upstream, F&& function)
     : Operator<U, D>(upstream), function_(std::forward<F>(function)) {}
 
-  virtual void subscribe(std::unique_ptr<Subscriber<D>> subscriber) override {
-    Operator<U, D>::upstream_->subscribe(
-        std::make_unique<Subscription>(
-            typename Flowable<D>::Handle(this), std::move(subscriber)));
+  virtual void subscribe(Reference<Subscriber<D>> subscriber) override {
+    Operator<U, D>::upstream_->subscribe(Reference<Subscription>(
+        new Subscription(Reference<Flowable<D>>(this), std::move(subscriber))));
   }
 
-protected:
+private:
   class Subscription : public Operator<U, D>::Subscription {
   public:
-    Subscription(typename Flowable<D>::Handle handle,
-                 std::unique_ptr<Subscriber<D>> subscriber)
+    Subscription(Reference<Flowable<D>> handle,
+                 Reference<Subscriber<D>> subscriber)
       : Operator<U, D>::Subscription(handle, std::move(subscriber)) {}
 
     virtual void onNext(const U& value) override {
@@ -98,8 +101,46 @@ protected:
     }
   };
 
-private:
   F function_;
+};
+
+template<typename T>
+class TakeOperator : public Operator<T, T> {
+public:
+  TakeOperator(Reference<Flowable<T>> upstream, int64_t limit)
+    : Operator<T, T>(upstream), limit_(limit) {}
+
+  virtual void subscribe(Reference<Subscriber<T>> subscriber) override {
+    Operator<T, T>::upstream_->subscribe(
+        Reference<Subscription>(new Subscription(
+            Reference<Flowable<T>>(this), limit_, std::move(subscriber))));
+  }
+
+private:
+  class Subscription : public Operator<T, T>::Subscription {
+  public:
+    Subscription(Reference<Flowable<T>> handle, int64_t limit,
+                 Reference<Subscriber<T>> subscriber)
+      : Operator<T, T>::Subscription(handle, std::move(subscriber)),
+        limit_(limit) {}
+
+    virtual void onNext(const T& value) {
+      if (processed_++ < limit_) {
+        Operator<T, T>::Subscription::subscriber_->onNext(value);
+        if (processed_ == limit_) {
+          Operator<T, T>::Subscription::cancel();
+          Operator<T, T>::Subscription::onComplete();
+        }
+      }
+    }
+
+  private:
+    int64_t requested_{0};
+    int64_t processed_{0};
+    const int64_t limit_;
+  };
+
+  const int64_t limit_;
 };
 
 }  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Operator.h
+++ b/experimental/yarpl/include/yarpl/v/Operator.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <iostream>
+#include <utility>
+
+#include "Flowable.h"
+#include "Subscriber.h"
+#include "Subscription.h"
+
+namespace yarpl {
+
+/**
+ * Base (helper) class for operators.  Operators are templated on two types:
+ * D and U.
+ */
+template<typename U, typename D>
+class Operator : public Flowable<D> {
+public:
+  Operator(typename Flowable<U>::Handle upstream) : upstream_(upstream) {}
+
+  virtual void subscribe(std::unique_ptr<Subscriber<D>> subscriber) override {
+    upstream_->subscribe(std::make_unique<Subscription>(
+        typename Flowable<D>::Handle(this), std::move(subscriber)));
+  }
+
+protected:
+  class Subscription : public ::yarpl::Subscription, public Subscriber<U> {
+  public:
+    Subscription(typename Flowable<D>::Handle flowable,
+                 std::unique_ptr<Subscriber<D>> subscriber)
+      : flowable_(flowable), subscriber_(std::move(subscriber)) {
+    }
+
+    virtual void onSubscribe(::yarpl::Subscription::Handle subscription)
+        override {
+      upstream_ = subscription;
+      subscriber_->onSubscribe(::yarpl::Subscription::Handle(this));
+    }
+
+    virtual void onComplete() override {
+      subscriber_->onComplete();
+    }
+
+    virtual void onError(const std::exception_ptr error) override {
+      subscriber_->onError(error);
+    }
+
+    virtual void onNext(const U&) override {
+    }
+
+    virtual void  request(int64_t delta) override {
+      upstream_->request(delta);
+    }
+
+    virtual void cancel() override {
+      upstream_->cancel();
+    }
+
+  protected:
+    typename Flowable<D>::Handle flowable_;
+    std::unique_ptr<Subscriber<D>> subscriber_;
+    ::yarpl::Subscription::Handle upstream_;
+  };
+
+  typename Flowable<U>::Handle upstream_;
+
+private:
+  // TODO(vjn): fix: this shouldn't be needed.
+  virtual std::tuple<int64_t, bool> emit(Subscriber<D>&, int64_t) override {
+    return std::make_tuple(0, false);
+  }
+};
+
+template<typename U, typename D, typename F, typename = typename
+         std::enable_if<std::is_callable<F(U), D>::value>::type>
+class MapOperator : public Operator<U, D> {
+public:
+  MapOperator(typename Flowable<U>::Handle upstream, F&& function)
+    : Operator<U, D>(upstream), function_(std::forward<F>(function)) {}
+
+  virtual void subscribe(std::unique_ptr<Subscriber<D>> subscriber) override {
+    Operator<U, D>::upstream_->subscribe(
+        std::make_unique<Subscription>(
+            typename Flowable<D>::Handle(this), std::move(subscriber)));
+  }
+
+protected:
+  class Subscription : public Operator<U, D>::Subscription {
+  public:
+    Subscription(typename Flowable<D>::Handle handle,
+                 std::unique_ptr<Subscriber<D>> subscriber)
+      : Operator<U, D>::Subscription(handle, std::move(subscriber)) {}
+
+    virtual void onNext(const U& value) override {
+      MapOperator& map = *static_cast<MapOperator*>(
+            Operator<U, D>::Subscription::flowable_.get());
+      Operator<U, D>::Subscription::subscriber_->onNext(map.function_(value));
+    }
+  };
+
+private:
+  F function_;
+};
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Operator.h
+++ b/experimental/yarpl/include/yarpl/v/Operator.h
@@ -16,7 +16,8 @@ namespace yarpl {
 template<typename U, typename D>
 class Operator : public Flowable<D> {
 public:
-  Operator(Reference<Flowable<U>> upstream) : upstream_(std::move(upstream)) {}
+  explicit Operator(Reference<Flowable<U>> upstream)
+    : upstream_(std::move(upstream)) {}
 
   virtual void subscribe(Reference<Subscriber<D>> subscriber) override {
     upstream_->subscribe(Reference<Subscription>(new Subscription(

--- a/experimental/yarpl/include/yarpl/v/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/v/Refcounted.h
@@ -5,9 +5,6 @@
 
 namespace yarpl {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wweak-vtables"
-
 class Refcounted {
 public:
   virtual ~Refcounted() = default;
@@ -29,8 +26,6 @@ private:
 
   mutable std::atomic_int refcount_{0};
 };
-
-#pragma clang diagnostic pop
 
 template<typename T, typename = typename std::enable_if<
     std::is_base_of<Refcounted, T>::value>::type>

--- a/experimental/yarpl/include/yarpl/v/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/v/Refcounted.h
@@ -33,7 +33,7 @@ class Reference {
 public:
   Reference() : pointer_(nullptr) {}
 
-  Reference(T* pointer) : pointer_(pointer) {
+  explicit Reference(T* pointer) : pointer_(pointer) {
     if (pointer_) pointer_->incRef();
   }
 

--- a/experimental/yarpl/include/yarpl/v/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/v/Refcounted.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <atomic>
+#include <type_traits>
+
+namespace yarpl {
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+
+class Refcounted {
+public:
+  virtual ~Refcounted() = default;
+
+private:
+  template<typename T, typename>
+  friend class Reference;
+
+  void incRef() {
+    refcount_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void decRef() {
+    if (refcount_.fetch_sub(1, std::memory_order_relaxed) == 1) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      delete this;
+    }
+  }
+
+  mutable std::atomic_int refcount_{0};
+};
+
+#pragma clang diagnostic pop
+
+template<typename T, typename = typename std::enable_if<
+    std::is_base_of<Refcounted, T>::value>::type>
+class Reference {
+public:
+  Reference() : pointer_(nullptr) {}
+
+  Reference(T* pointer) : pointer_(pointer) {
+    if (pointer_) pointer_->incRef();
+  }
+
+  ~Reference() {
+    if (pointer_) pointer_->decRef();
+  }
+
+  template<typename U, typename>
+  friend class Reference;
+
+  template<typename U>
+  Reference(Reference<U>&& other) : pointer_(other.pointer_) {
+    other.pointer_ = nullptr;
+  }
+
+  template<typename U>
+  Reference& operator=(Reference<U>&& other) {
+    Reference(static_cast<Reference<U>&&>(other)).swap(*this);
+    return *this;
+  }
+
+  Reference& operator=(Reference&& other) {
+    Reference(static_cast<Reference&&>(other)).swap(*this);
+    return *this;
+  }
+
+  Reference& operator=(const Reference& other) {
+    Reference(other.pointer_).swap(*this);
+    return *this;
+  }
+
+  Reference(const Reference& other) : pointer_(other.pointer_) {
+    if (pointer_) pointer_->incRef();
+  }
+
+  T* get() const {
+    return pointer_;
+  }
+
+  T& operator*() const {
+    return *pointer_;
+  }
+
+  T* operator->() const {
+    return pointer_;
+  }
+
+  void reset() {
+    Reference().swap(*this);
+  }
+
+private:
+  void swap(Reference& other) {
+    T* temp = pointer_;
+    pointer_ = other.pointer_;
+    other.pointer_ = temp;
+  }
+
+  T* pointer_;
+};
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Subscriber.h
+++ b/experimental/yarpl/include/yarpl/v/Subscriber.h
@@ -1,19 +1,22 @@
 #pragma once
 
 #include "reactivestreams/ReactiveStreams.h"
+
+#include "Refcounted.h"
 #include "Subscription.h"
 
 namespace yarpl {
 
 template<typename T>
-class Subscriber : public reactivestreams_yarpl::Subscriber<T> {
+class Subscriber : public reactivestreams_yarpl::Subscriber<T>,
+    public virtual Refcounted {
 protected:
   static const auto max = std::numeric_limits<int64_t>::max();
 
 public:
   // Note: if any of the following methods is overridden in a subclass,
   // the new methods SHOULD ensure that these are invoked as well.
-  virtual void onSubscribe(Subscription::Handle subscription) {
+  virtual void onSubscribe(Reference<Subscription> subscription) {
     subscription_ = subscription;
   }
 
@@ -38,7 +41,7 @@ protected:
 private:
   // "Our" reference to the subscription, to ensure that it is retained
   // while calls to its methods are in-flight.
-  Subscription::Handle subscription_;
+  Reference<Subscription> subscription_{nullptr};
 
   // Note: we've overridden the signature of onSubscribe with yarpl's
   // Subscriber.  Keep this definition, making it private, to keep the

--- a/experimental/yarpl/include/yarpl/v/Subscriber.h
+++ b/experimental/yarpl/include/yarpl/v/Subscriber.h
@@ -10,9 +10,6 @@ namespace yarpl {
 template<typename T>
 class Subscriber : public reactivestreams_yarpl::Subscriber<T>,
     public virtual Refcounted {
-protected:
-  static const auto max = std::numeric_limits<int64_t>::max();
-
 public:
   // Note: if any of the following methods is overridden in a subclass,
   // the new methods SHOULD ensure that these are invoked as well.

--- a/experimental/yarpl/include/yarpl/v/Subscriber.h
+++ b/experimental/yarpl/include/yarpl/v/Subscriber.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "reactivestreams/ReactiveStreams.h"
+#include "Subscription.h"
+
+namespace yarpl {
+
+template<typename T>
+class Subscriber : public reactivestreams_yarpl::Subscriber<T> {
+protected:
+  static const auto max = std::numeric_limits<int64_t>::max();
+
+public:
+  // Note: if any of the following methods is overridden in a subclass,
+  // the new methods SHOULD ensure that these are invoked as well.
+  virtual void onSubscribe(Subscription::Handle subscription) {
+    subscription_ = subscription;
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  virtual void onComplete() {
+    subscription_.reset();
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  virtual void onError(const std::exception_ptr) {
+    subscription_.reset();
+  }
+
+  virtual void onNext(const T&) {}
+  virtual void onNext(T&& value) { onNext(value); }
+
+protected:
+  Subscription* subscription() {
+    return subscription_.operator->();
+  }
+
+private:
+  // "Our" reference to the subscription, to ensure that it is retained
+  // while calls to its methods are in-flight.
+  Subscription::Handle subscription_;
+
+  // Note: we've overridden the signature of onSubscribe with yarpl's
+  // Subscriber.  Keep this definition, making it private, to keep the
+  // compiler from issuing a warning about the override.
+  virtual void onSubscribe(reactivestreams_yarpl::Subscription*) {}
+};
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Subscribers.h
+++ b/experimental/yarpl/include/yarpl/v/Subscribers.h
@@ -17,7 +17,7 @@ public:
       Derived(N&& next, int64_t batch)
         : next_(std::forward<N>(next)), batch_(batch), pending_(0) {}
 
-      virtual void onSubscribe(Subscription::Handle subscription) override {
+      virtual void onSubscribe(Reference<Subscription> subscription) override {
         Subscriber<T>::onSubscribe(subscription);
         pending_ += batch_;
         subscription->request(batch_);
@@ -38,7 +38,7 @@ public:
       int64_t pending_;
     };
 
-    return std::make_unique<Derived>(std::forward<N>(next), batch);
+    return Reference<Derived>(new Derived(std::forward<N>(next), batch));
   }
 
 private:

--- a/experimental/yarpl/include/yarpl/v/Subscribers.h
+++ b/experimental/yarpl/include/yarpl/v/Subscribers.h
@@ -7,11 +7,9 @@
 namespace yarpl {
 
 class Subscribers {
-  static const auto max = std::numeric_limits<int64_t>::max();
-
 public:
   template<typename T, typename N>
-  static auto create(N&& next, int64_t batch = max) {
+  static auto create(N&& next, int64_t batch = Flowable<T>::NO_FLOW_CONTROL) {
     class Derived : public Subscriber<T> {
     public:
       Derived(N&& next, int64_t batch)

--- a/experimental/yarpl/include/yarpl/v/Subscription.h
+++ b/experimental/yarpl/include/yarpl/v/Subscription.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+#include "reactivestreams/ReactiveStreams.h"
+
+namespace yarpl {
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+
+class Subscription : public reactivestreams_yarpl::Subscription,
+    public boost::intrusive_ref_counter<Subscription> {
+public:
+  using Handle = boost::intrusive_ptr<Subscription>;
+  virtual ~Subscription() = default;
+
+  virtual void request(int64_t n) = 0;
+  virtual void cancel() = 0;
+
+protected:
+  Subscription() : reference_(this) {}
+
+  // Drop the reference we're holding on the subscription (handle).
+  void release() {
+    reference_.reset();
+  }
+
+private:
+  // We expect to be heap-allocated; until this subscription finishes
+  // (is canceled; completes; error's out), hold a reference so we are
+  // not deallocated (by the subscriber).
+  Handle reference_{this};
+};
+
+#pragma clang diagnostic pop
+
+}  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Subscription.h
+++ b/experimental/yarpl/include/yarpl/v/Subscription.h
@@ -5,22 +5,19 @@
 
 namespace yarpl {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wweak-vtables"
-
 class Subscription : public reactivestreams_yarpl::Subscription,
     public virtual Refcounted {
 public:
   virtual void request(int64_t n) = 0;
   virtual void cancel() = 0;
 
+protected:
+  Subscription() : reference_(this) {}
+
   // Drop the reference we're holding on the subscription (handle).
   void release() {
     reference_.reset();
   }
-
-protected:
-  Subscription() : reference_(this) {}
 
 private:
   // We expect to be heap-allocated; until this subscription finishes
@@ -28,7 +25,5 @@ private:
   // not deallocated (by the subscriber).
   Reference<Refcounted> reference_;
 };
-
-#pragma clang diagnostic pop
 
 }  // yarpl

--- a/experimental/yarpl/include/yarpl/v/Subscription.h
+++ b/experimental/yarpl/include/yarpl/v/Subscription.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <boost/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
-
 #include "reactivestreams/ReactiveStreams.h"
+#include "Refcounted.h"
 
 namespace yarpl {
 
@@ -11,27 +9,24 @@ namespace yarpl {
 #pragma clang diagnostic ignored "-Wweak-vtables"
 
 class Subscription : public reactivestreams_yarpl::Subscription,
-    public boost::intrusive_ref_counter<Subscription> {
+    public virtual Refcounted {
 public:
-  using Handle = boost::intrusive_ptr<Subscription>;
-  virtual ~Subscription() = default;
-
   virtual void request(int64_t n) = 0;
   virtual void cancel() = 0;
-
-protected:
-  Subscription() : reference_(this) {}
 
   // Drop the reference we're holding on the subscription (handle).
   void release() {
     reference_.reset();
   }
 
+protected:
+  Subscription() : reference_(this) {}
+
 private:
   // We expect to be heap-allocated; until this subscription finishes
   // (is canceled; completes; error's out), hold a reference so we are
   // not deallocated (by the subscriber).
-  Handle reference_{this};
+  Reference<Refcounted> reference_;
 };
 
 #pragma clang diagnostic pop

--- a/experimental/yarpl/src/yarpl/ThreadScheduler.cpp
+++ b/experimental/yarpl/src/yarpl/ThreadScheduler.cpp
@@ -33,6 +33,7 @@ class ThreadWorker : public Worker {
   ThreadWorker() {
     std::cout << "Create ThreadWorker" << std::endl;
   }
+
   ~ThreadWorker() {
     std::cout << "DESTROYING ThreadWorker!" << std::endl;
   }


### PR DESCRIPTION
Another attempt at Flowable: the main improvement is proper lifetime management of the Flowable, Subscriber and Subscription objects. To do this, we have an intrusive reference count.

(boost::intrusive_ptr<> isn't being used since on Clang, the wrong method is found by ADL when we have both a refcount base, and an intrusive_ptr field of a different type.)