### PR TITLE
fix open source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT REACTIVE_STREAMS_GIT_URL)
   set(REACTIVE_STREAMS_GIT_URL "https://github.com/ReactiveSocket/reactive-streams-cpp.git" CACHE STRING "Location of the ReactiveStreams C++ git repo" FORCE)
 endif(NOT REACTIVE_STREAMS_GIT_URL)
 
-option(BUILD_BENCHMARKS "Build benchmarks" ON)
+option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 
 enable_testing()
 
@@ -73,7 +73,6 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${META_CXX_STD}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-func-template")
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
 if("${BUILD_TYPE_LOWER}" MATCHES "debug")

--- a/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
+++ b/experimental/rsocket-src/transports/TcpConnectionAcceptor.cpp
@@ -56,7 +56,7 @@ class TcpConnectionAcceptor::SocketCallback
 ////////////////////////////////////////////////////////////////////////////////
 
 TcpConnectionAcceptor::TcpConnectionAcceptor(Options options)
-    : options_{std::move(options)} {}
+    : options_(std::move(options)) {}
 
 TcpConnectionAcceptor::~TcpConnectionAcceptor() {
   LOG(INFO) << "Shutting down TCP listener";


### PR DESCRIPTION
Fixing the following errors:

- broken benchmarks build. https://travis-ci.org/ReactiveSocket/reactivesocket-cpp/jobs/222877635
- unrecognized option undefined-func-template
- fix initialization error in TcpConnectionAcceptor constructor