### PR TITLE
Flowable delegating everything to onSubscribeFunc

### DIFF
--- a/experimental/yarpl/examples/FlowableVExamples.cpp
+++ b/experimental/yarpl/examples/FlowableVExamples.cpp
@@ -29,6 +29,31 @@ std::string getThreadId() {
   return oss.str();
 }
 
+void fromPublisherExample() {
+  auto onSubscribe = [](Reference<Subscriber<int>> subscriber) {
+    class Subscription : public ::yarpl::Subscription {
+    public:
+      virtual void request(int64_t delta) override {
+        // TODO
+      }
+
+      virtual void cancel() override {
+        // TODO
+      }
+    };
+
+    Reference<::yarpl::Subscription> subscription(new Subscription);
+    subscriber->onSubscribe(subscription);
+    subscriber->onNext(1234);
+    subscriber->onNext(5678);
+    subscriber->onNext(1234);
+    subscriber->onComplete();
+  };
+
+  Flowables::fromPublisher<int>(std::move(onSubscribe))
+      ->subscribe(printer<int>());
+}
+
 } // namespace
 
 void FlowableVExamples::run() {
@@ -103,4 +128,7 @@ void FlowableVExamples::run() {
       ->subscribe(printer<std::string>());
   std::cout << "  waiting   on " << getThreadId() << std::endl;
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  std::cout << "fromPublisher - delegate to onSubscribe" << std::endl;
+  fromPublisherExample();
 }

--- a/experimental/yarpl/include/yarpl/v/Flowables.h
+++ b/experimental/yarpl/include/yarpl/v/Flowables.h
@@ -65,6 +65,16 @@ class Flowables {
     return Flowable<T>::create(std::move(lambda));
   }
 
+  template<typename T, typename OnSubscribe,
+           typename = typename std::enable_if<std::is_callable<
+      OnSubscribe(Reference<Subscriber<T>>),
+      void>::value>::type>
+  static Reference<Flowable<T>> fromPublisher(OnSubscribe&& function) {
+    return Reference<Flowable<T>>(
+        new FromPublisherOperator<T, OnSubscribe>(
+            std::forward<OnSubscribe>(function)));
+  }
+
  private:
   Flowables() = delete;
 };

--- a/experimental/yarpl/include/yarpl/v/Operator.h
+++ b/experimental/yarpl/include/yarpl/v/Operator.h
@@ -242,4 +242,17 @@ private:
   std::unique_ptr<Worker> worker_;
 };
 
+template<typename T, typename OnSubscribe>
+class FromPublisherOperator : public Flowable<T> {
+public:
+  FromPublisherOperator(OnSubscribe&& function)
+    : function_(function) {}
+
+  void subscribe(Reference<Subscriber<T>> subscriber) {
+    function_(std::move(subscriber));
+  }
+private:
+  OnSubscribe function_;
+};
+
 } // yarpl

--- a/experimental/yarpl/include/yarpl/v/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/v/Refcounted.h
@@ -26,7 +26,7 @@ public:
   virtual ~Refcounted() = default;
 #endif  /* NDEBUG */
 
- private:
+private:
   template <typename T, typename>
   friend class Reference;
 


### PR DESCRIPTION
Simpler version, with ::yarpl:: types, and just stashing away an onSubscribeFunc for use during later subscribe() calls.